### PR TITLE
Feat/bash tool agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,27 @@ viewModelScope.launch {
 
 Tool calls use a structured JSON envelope internally: `{"tool":"name","arguments":{...}}`. The parser also accepts the legacy `tool_name` field for robustness, but new prompts only emit the `tool` shape.
 
+For JVM or desktop hosts where `bash` is available, you can also opt into a shell-execution tool:
+
+```kotlin
+val edge = LLMEdge.create(context, viewModelScope)
+val bashTool =
+    BashToolFactory(
+        BashToolOptions(
+            allowRawShell = true, // raw `command` strings are disabled unless you opt in
+            defaultWorkingDirectory = context.filesDir.absolutePath,
+        ),
+    ).createBashTool()
+
+val agent = edge.text.toolAgent(
+    tools = listOf(bashTool),
+    systemPrompt = "Use shell commands only when necessary.",
+    policy = ToolPolicies.ALLOW_ALL, // required because run_bash_command is an action tool
+)
+```
+
+The bash tool accepts either `argv` for structured commands or `command` for raw shell strings. If `bash` is unavailable or the command fails, the tool returns a structured error result instead of claiming success.
+
 ### Speech Request Objects
 
 Speech APIs now support request-first calls in addition to the existing convenience overloads:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,6 +86,39 @@ Default batch sizes are currently `8` for blocking generation and `4` for stream
 If you are tuning on big.LITTLE devices, adjust `batchSize` together with `numThreads` and
 `generationThreads` rather than treating them in isolation.
 
+### Tool Calling
+
+Use `edge.text.toolAgent(...)` when the model should call app-defined tools instead of only returning text.
+Read-only tools run automatically. Action tools, including the bash tool below, still require an
+explicit policy approval.
+
+```kotlin
+val edge = LLMEdge.create(context, viewModelScope)
+val agent =
+    edge.text.toolAgent(
+        tools =
+            listOf(
+                BashToolFactory(
+                    BashToolOptions(
+                        allowRawShell = true,
+                        defaultWorkingDirectory = context.filesDir.absolutePath,
+                    ),
+                ).createBashTool(),
+            ),
+        systemPrompt = "Use shell commands only when they materially help answer the user.",
+        policy = ToolPolicies.ALLOW_ALL,
+    )
+```
+
+`run_bash_command` supports two argument shapes:
+
+- `argv`: a structured array such as `["echo", "hello"]`
+- `command`: a raw shell string such as `"pwd"`; this stays disabled unless `allowRawShell = true`
+
+The tool captures `stdout`, `stderr`, exit code, timeout state, truncation state, and the executed
+command details in the returned `ToolResult.data`. If `bash` is unavailable at runtime or process
+startup fails, the tool reports that as a structured tool error.
+
 ### Image Generation
 
 Handles model resolution and memory-safe loading through the `edge.image` client.

--- a/llmedge/src/main/java/io/aatricks/llmedge/tools/BashToolFactory.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/tools/BashToolFactory.kt
@@ -1,0 +1,262 @@
+package io.aatricks.llmedge.tools
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+data class BashToolOptions(
+    val shellExecutable: String = "bash",
+    val allowRawShell: Boolean = false,
+    val defaultWorkingDirectory: String? = null,
+    val environment: Map<String, String> = emptyMap(),
+    val timeoutMillis: Long = 30_000,
+    val maxOutputChars: Int = 8_000,
+)
+
+class BashToolFactory private constructor(
+    private val options: BashToolOptions,
+    private val executor: BashCommandExecutor,
+) {
+    @JvmOverloads
+    constructor(options: BashToolOptions = BashToolOptions()) : this(options, ProcessBuilderBashCommandExecutor())
+
+    fun createBashTool(): Tool =
+        Tool(
+            name = "run_bash_command",
+            description =
+                "Runs a shell command. Provide either argv as an array of command arguments or command as a raw shell string. " +
+                    "Raw shell strings require explicit factory opt-in.",
+            kind = ToolKind.ACTION,
+            schema =
+                ToolSchema(
+                    parameters =
+                        mapOf(
+                            "argv" to
+                                ToolParameter(
+                                    type = ToolParameterType.ARRAY,
+                                    description = "Structured command arguments, for example [\"echo\", \"hello\"]",
+                                    required = false,
+                                ),
+                            "command" to
+                                ToolParameter(
+                                    type = ToolParameterType.STRING,
+                                    description = "Raw shell command string executed via bash -lc.",
+                                    required = false,
+                                ),
+                            "workingDirectory" to
+                                ToolParameter(
+                                    type = ToolParameterType.STRING,
+                                    description = "Optional working directory override for this command.",
+                                    required = false,
+                                ),
+                        ),
+                ),
+            handler = ::runCommand,
+        )
+
+    private suspend fun runCommand(arguments: JsonObject): ToolResult {
+        val rawCommand = arguments["command"]?.jsonPrimitive?.contentOrNull
+        val argvElement = arguments["argv"]
+        val workingDirectory = arguments["workingDirectory"]?.jsonPrimitive?.contentOrNull ?: options.defaultWorkingDirectory
+
+        if ((rawCommand == null) == (argvElement == null)) {
+            return invalidArguments("Provide exactly one of 'argv' or 'command'.")
+        }
+
+        val argv =
+            if (argvElement != null) {
+                parseArgv(argvElement) ?: return invalidArguments("Argument 'argv' must be a non-empty array of strings.")
+            } else {
+                if (!options.allowRawShell) {
+                    return ToolResult.error(
+                        text = "Raw shell execution is disabled for this bash tool.",
+                        data = toolErrorData("raw_shell_disabled", "Raw shell execution is disabled for this bash tool."),
+                    )
+                }
+                val command = rawCommand?.takeUnless(String::isBlank)
+                    ?: return invalidArguments("Argument 'command' must be a non-empty string.")
+                listOf(options.shellExecutable, "-lc", command)
+            }
+
+        val resolvedWorkingDirectory = workingDirectory?.takeUnless(String::isBlank)
+
+        val request =
+            BashExecutionRequest(
+                argv = argv,
+                command = rawCommand,
+                workingDirectory = resolvedWorkingDirectory,
+                environment = options.environment,
+                timeoutMillis = options.timeoutMillis,
+                maxOutputChars = options.maxOutputChars,
+            )
+
+        val execution =
+            runCatching { executor.run(request) }
+                .getOrElse { error ->
+                    return ToolResult.error(
+                        text = "Failed to run command: ${error.message ?: "Unknown error."}",
+                        data =
+                            buildJsonObject {
+                                put("code", "execution_failed")
+                                put("message", error.message ?: "Unknown error.")
+                                put("argv", request.argv.toJsonArray())
+                                request.command?.let { put("command", it) }
+                                request.workingDirectory?.let { put("workingDirectory", it) }
+                            },
+                    )
+                }
+
+        val truncatedStdout = execution.stdout.limitTo(options.maxOutputChars)
+        val truncatedStderr = execution.stderr.limitTo(options.maxOutputChars)
+        val truncated = truncatedStdout != execution.stdout || truncatedStderr != execution.stderr
+        val data =
+            buildJsonObject {
+                execution.exitCode?.let { put("exitCode", it) }
+                put("stdout", truncatedStdout)
+                put("stderr", truncatedStderr)
+                put("timedOut", execution.timedOut)
+                put("truncated", truncated)
+                put("argv", request.argv.toJsonArray())
+                request.command?.let { put("command", it) }
+                request.workingDirectory?.let { put("workingDirectory", it) }
+            }
+
+        val text =
+            buildString {
+                if (execution.timedOut) {
+                    append("Command timed out after ${request.timeoutMillis} ms.")
+                } else {
+                    append("Command completed with exit code ${execution.exitCode ?: "unknown"}.")
+                }
+                if (truncatedStdout.isNotEmpty()) {
+                    append(" Stdout: ")
+                    append(truncatedStdout)
+                }
+                if (truncatedStderr.isNotEmpty()) {
+                    append(" Stderr: ")
+                    append(truncatedStderr)
+                }
+                if (truncated) {
+                    append(" Output was truncated.")
+                }
+            }
+
+        val isError = execution.timedOut || (execution.exitCode != null && execution.exitCode != 0)
+        return if (isError) ToolResult.error(text = text, data = data) else ToolResult.success(text = text, data = data)
+    }
+
+    private fun invalidArguments(message: String): ToolResult =
+        ToolResult.error(
+            text = message,
+            data = toolErrorData("invalid_arguments", message),
+        )
+
+    private fun parseArgv(element: JsonElement): List<String>? {
+        val array = element as? JsonArray ?: return null
+        if (array.isEmpty()) {
+            return null
+        }
+
+        val parts =
+            array.map { item ->
+                val primitive = item as? JsonPrimitive ?: return null
+                if (!primitive.isString) {
+                    return null
+                }
+                primitive.content
+            }
+
+        return parts.takeIf { it.firstOrNull()?.isNotBlank() == true }
+    }
+
+    internal companion object {
+        fun forTesting(
+            options: BashToolOptions = BashToolOptions(),
+            executor: BashCommandExecutor,
+        ): BashToolFactory = BashToolFactory(options, executor)
+    }
+}
+
+internal data class BashExecutionRequest(
+    val argv: List<String>,
+    val command: String? = null,
+    val workingDirectory: String? = null,
+    val environment: Map<String, String> = emptyMap(),
+    val timeoutMillis: Long,
+    val maxOutputChars: Int,
+)
+
+internal data class BashExecutionResult(
+    val exitCode: Int?,
+    val stdout: String,
+    val stderr: String,
+    val timedOut: Boolean = false,
+)
+
+internal fun interface BashCommandExecutor {
+    suspend fun run(request: BashExecutionRequest): BashExecutionResult
+}
+
+private class ProcessBuilderBashCommandExecutor : BashCommandExecutor {
+    override suspend fun run(request: BashExecutionRequest): BashExecutionResult =
+        withContext(Dispatchers.IO) {
+            val process =
+                ProcessBuilder(request.argv)
+                    .apply {
+                        request.workingDirectory?.let { directory(File(it)) }
+                        environment().putAll(request.environment)
+                    }.start()
+
+            supervisorScope {
+                val stdoutDeferred =
+                    async(Dispatchers.IO) {
+                        process.inputStream.bufferedReader().use { it.readText() }
+                    }
+                val stderrDeferred =
+                    async(Dispatchers.IO) {
+                        process.errorStream.bufferedReader().use { it.readText() }
+                    }
+
+                val finished = process.waitFor(request.timeoutMillis, TimeUnit.MILLISECONDS)
+                if (!finished) {
+                    process.destroy()
+                    if (process.isAlive) {
+                        process.destroyForcibly()
+                    }
+                    process.waitFor()
+                }
+
+                BashExecutionResult(
+                    exitCode = if (finished) process.exitValue() else null,
+                    stdout = stdoutDeferred.await(),
+                    stderr = stderrDeferred.await(),
+                    timedOut = !finished,
+                )
+            }
+        }
+}
+
+private fun List<String>.toJsonArray() =
+    buildJsonArray {
+        this@toJsonArray.forEach { add(JsonPrimitive(it)) }
+    }
+
+private fun String.limitTo(maxChars: Int): String =
+    when {
+        maxChars <= 0 -> ""
+        length <= maxChars -> this
+        else -> take(maxChars)
+    }

--- a/llmedge/src/test/java/io/aatricks/llmedge/tools/BashToolFactoryTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/tools/BashToolFactoryTest.kt
@@ -163,6 +163,30 @@ class BashToolFactoryTest {
     }
 
     @Test
+    fun `raw shell execution runs real bash process`() = runTest {
+        val workingDirectory = System.getProperty("java.io.tmpdir")
+        val tool =
+            BashToolFactory(
+                BashToolOptions(
+                    allowRawShell = true,
+                    defaultWorkingDirectory = workingDirectory,
+                ),
+            ).createBashTool()
+
+        val result =
+            tool.handler(
+                buildJsonObject {
+                    put("command", "pwd")
+                },
+            )
+
+        assertFalse(result.isError)
+        assertEquals(0, result.data["exitCode"]?.jsonPrimitive?.intOrNull)
+        assertEquals("${workingDirectory.trimEnd('/')}\n", result.data["stdout"]?.jsonPrimitive?.contentOrNull)
+        assertEquals("pwd", result.data["command"]?.jsonPrimitive?.contentOrNull)
+    }
+
+    @Test
     fun `timeouts are reported as errors`() = runTest {
         val tool =
             BashToolFactory.forTesting(

--- a/llmedge/src/test/java/io/aatricks/llmedge/tools/BashToolFactoryTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/tools/BashToolFactoryTest.kt
@@ -1,0 +1,244 @@
+package io.aatricks.llmedge.tools
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BashToolFactoryTest {
+    @Test
+    fun `bash tool requires exactly one of argv or command`() = runTest {
+        val tool = BashToolFactory().createBashTool()
+
+        val missing = tool.handler(buildJsonObject { })
+        val both =
+            tool.handler(
+                buildJsonObject {
+                    put("command", "pwd")
+                    put("argv", buildJsonArray { add(JsonPrimitive("pwd")) })
+                },
+            )
+
+        assertTrue(missing.isError)
+        assertTrue(missing.text.contains("exactly one"))
+        assertTrue(both.isError)
+        assertTrue(both.text.contains("exactly one"))
+    }
+
+    @Test
+    fun `structured argv execution succeeds and returns structured result`() = runTest {
+        val executor =
+            RecordingExecutor {
+                BashExecutionResult(
+                    exitCode = 0,
+                    stdout = "hello\n",
+                    stderr = "",
+                )
+            }
+        val tool =
+            BashToolFactory.forTesting(
+                options = BashToolOptions(defaultWorkingDirectory = "/repo"),
+                executor = executor,
+            ).createBashTool()
+
+        val result =
+            tool.handler(
+                buildJsonObject {
+                    put(
+                        "argv",
+                        buildJsonArray {
+                            add(JsonPrimitive("echo"))
+                            add(JsonPrimitive("hello"))
+                        },
+                    )
+                },
+            )
+
+        assertFalse(result.isError)
+        assertEquals(1, executor.requests.size)
+        assertEquals(listOf("echo", "hello"), executor.requests.single().argv)
+        assertNull(executor.requests.single().command)
+        assertEquals("/repo", executor.requests.single().workingDirectory)
+        assertEquals(0, result.data["exitCode"]?.jsonPrimitive?.intOrNull)
+        assertEquals("hello\n", result.data["stdout"]?.jsonPrimitive?.contentOrNull)
+        assertEquals("echo", result.data["argv"]?.jsonArray?.first()?.jsonPrimitive?.contentOrNull)
+        assertTrue(result.text.contains("exit code 0"))
+    }
+
+    @Test
+    fun `non zero exit is reported as an error`() = runTest {
+        val tool =
+            BashToolFactory.forTesting(
+                options = BashToolOptions(),
+                executor =
+                    RecordingExecutor {
+                        BashExecutionResult(
+                            exitCode = 2,
+                            stdout = "",
+                            stderr = "bad option",
+                        )
+                    },
+            ).createBashTool()
+
+        val result =
+            tool.handler(
+                buildJsonObject {
+                    put(
+                        "argv",
+                        buildJsonArray {
+                            add(JsonPrimitive("ls"))
+                            add(JsonPrimitive("--bad-option"))
+                        },
+                    )
+                },
+            )
+
+        assertTrue(result.isError)
+        assertEquals(2, result.data["exitCode"]?.jsonPrimitive?.intOrNull)
+        assertTrue(result.text.contains("exit code 2"))
+        assertTrue(result.text.contains("bad option"))
+    }
+
+    @Test
+    fun `raw shell execution is rejected by default`() = runTest {
+        val executor = RecordingExecutor { BashExecutionResult(exitCode = 0, stdout = "", stderr = "") }
+        val tool =
+            BashToolFactory.forTesting(
+                options = BashToolOptions(),
+                executor = executor,
+            ).createBashTool()
+
+        val result =
+            tool.handler(
+                buildJsonObject {
+                    put("command", "pwd")
+                },
+            )
+
+        assertTrue(result.isError)
+        assertTrue(result.text.contains("disabled"))
+        assertTrue(executor.requests.isEmpty())
+    }
+
+    @Test
+    fun `raw shell execution succeeds when enabled`() = runTest {
+        val executor =
+            RecordingExecutor {
+                BashExecutionResult(
+                    exitCode = 0,
+                    stdout = "/repo\n",
+                    stderr = "",
+                )
+            }
+        val tool =
+            BashToolFactory.forTesting(
+                options = BashToolOptions(allowRawShell = true, shellExecutable = "/bin/bash"),
+                executor = executor,
+            ).createBashTool()
+
+        val result =
+            tool.handler(
+                buildJsonObject {
+                    put("command", "pwd")
+                    put("workingDirectory", "/tmp/demo")
+                },
+            )
+
+        assertFalse(result.isError)
+        assertEquals(listOf("/bin/bash", "-lc", "pwd"), executor.requests.single().argv)
+        assertEquals("pwd", executor.requests.single().command)
+        assertEquals("/tmp/demo", executor.requests.single().workingDirectory)
+        assertEquals("pwd", result.data["command"]?.jsonPrimitive?.contentOrNull)
+    }
+
+    @Test
+    fun `timeouts are reported as errors`() = runTest {
+        val tool =
+            BashToolFactory.forTesting(
+                options = BashToolOptions(),
+                executor =
+                    RecordingExecutor {
+                        BashExecutionResult(
+                            exitCode = null,
+                            stdout = "",
+                            stderr = "timed out",
+                            timedOut = true,
+                        )
+                    },
+            ).createBashTool()
+
+        val result =
+            tool.handler(
+                buildJsonObject {
+                    put(
+                        "argv",
+                        buildJsonArray {
+                            add(JsonPrimitive("sleep"))
+                            add(JsonPrimitive("10"))
+                        },
+                    )
+                },
+            )
+
+        assertTrue(result.isError)
+        assertTrue(result.data["timedOut"]?.jsonPrimitive?.booleanOrNull == true)
+        assertTrue(result.text.contains("timed out"))
+    }
+
+    @Test
+    fun `output is truncated to configured limit`() = runTest {
+        val tool =
+            BashToolFactory.forTesting(
+                options = BashToolOptions(maxOutputChars = 4),
+                executor =
+                    RecordingExecutor {
+                        BashExecutionResult(
+                            exitCode = 0,
+                            stdout = "abcdefgh",
+                            stderr = "wxyz123",
+                        )
+                    },
+            ).createBashTool()
+
+        val result =
+            tool.handler(
+                buildJsonObject {
+                    put(
+                        "argv",
+                        buildJsonArray {
+                            add(JsonPrimitive("echo"))
+                            add(JsonPrimitive("abcdefgh"))
+                        },
+                    )
+                },
+            )
+
+        assertFalse(result.isError)
+        assertEquals("abcd", result.data["stdout"]?.jsonPrimitive?.contentOrNull)
+        assertEquals("wxyz", result.data["stderr"]?.jsonPrimitive?.contentOrNull)
+        assertTrue(result.data["truncated"]?.jsonPrimitive?.booleanOrNull == true)
+        assertTrue(result.text.contains("truncated"))
+    }
+
+    private class RecordingExecutor(
+        private val block: suspend (BashExecutionRequest) -> BashExecutionResult,
+    ) : BashCommandExecutor {
+        val requests = mutableListOf<BashExecutionRequest>()
+
+        override suspend fun run(request: BashExecutionRequest): BashExecutionResult {
+            requests += request
+            return block(request)
+        }
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/tools/ToolAgentTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/tools/ToolAgentTest.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -322,6 +324,45 @@ class ToolAgentTest {
             assertEquals(1, executor.requests.size)
             assertEquals(listOf("echo", "hello"), executor.requests.single().argv)
             assertTrue(result.trace.first().toolResult?.data?.toString()?.contains("hello") == true)
+        } finally {
+            edge.close()
+        }
+    }
+
+    @Test
+    fun `reply executes real bash command through tool agent`() = runTest {
+        val workingDirectory = ApplicationProvider.getApplicationContext<Context>().cacheDir.absolutePath
+        installBridge(
+            listOf("""{"tool":"run_bash_command","arguments":{"command":"pwd","workingDirectory":"$workingDirectory"}}"""),
+            listOf("The command returned the requested working directory."),
+        )
+        val edge = createEdge(this)
+        val agent =
+            edge.text.toolAgent(
+                model = localModel(edge),
+                options = TextModelOptions(temperature = 0.0f, useVulkan = false),
+                tools =
+                    listOf(
+                        BashToolFactory(
+                            BashToolOptions(allowRawShell = true),
+                        ).createBashTool(),
+                    ),
+                policy = ToolPolicies.ALLOW_ALL,
+            )
+
+        try {
+            val result = agent.reply("Run pwd in the cache dir", maxSteps = 2)
+
+            assertEquals("The command returned the requested working directory.", result.text)
+            assertTrue(result.trace.first().toolResult?.isError == false)
+            assertEquals(
+                "$workingDirectory\n",
+                result.trace.first().toolResult?.data?.get("stdout")?.jsonPrimitive?.contentOrNull,
+            )
+            assertEquals(
+                "pwd",
+                result.trace.first().toolResult?.data?.get("command")?.jsonPrimitive?.contentOrNull,
+            )
         } finally {
             edge.close()
         }

--- a/llmedge/src/test/java/io/aatricks/llmedge/tools/ToolAgentTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/tools/ToolAgentTest.kt
@@ -265,6 +265,69 @@ class ToolAgentTest {
     }
 
     @Test
+    fun `reply denies bash tool by default`() = runTest {
+        installBridge(
+            listOf("""{"tool":"run_bash_command","arguments":{"argv":["echo","hello"]}}"""),
+            listOf("I cannot run shell commands without approval."),
+        )
+        val edge = createEdge(this)
+        val executor = RecordingBashExecutor { BashExecutionResult(exitCode = 0, stdout = "hello\n", stderr = "") }
+        val agent =
+            edge.text.toolAgent(
+                model = localModel(edge),
+                options = TextModelOptions(temperature = 0.0f, useVulkan = false),
+                tools =
+                    listOf(
+                        BashToolFactory.forTesting(BashToolOptions(), executor).createBashTool(),
+                    ),
+            )
+
+        try {
+            val result = agent.reply("Run echo hello", maxSteps = 2)
+
+            assertTrue(result.trace.first().toolResult?.isError == true)
+            assertTrue(result.trace.first().toolDeniedReason?.contains("explicit approval") == true)
+            assertTrue(executor.requests.isEmpty())
+        } finally {
+            edge.close()
+        }
+    }
+
+    @Test
+    fun `reply executes bash tool with explicit policy`() = runTest {
+        installBridge(
+            listOf("""{"tool":"run_bash_command","arguments":{"argv":["echo","hello"]}}"""),
+            listOf("The command printed hello."),
+        )
+        val edge = createEdge(this)
+        val executor =
+            RecordingBashExecutor {
+                BashExecutionResult(exitCode = 0, stdout = "hello\n", stderr = "")
+            }
+        val agent =
+            edge.text.toolAgent(
+                model = localModel(edge),
+                options = TextModelOptions(temperature = 0.0f, useVulkan = false),
+                tools =
+                    listOf(
+                        BashToolFactory.forTesting(BashToolOptions(), executor).createBashTool(),
+                    ),
+                policy = ToolPolicies.ALLOW_ALL,
+            )
+
+        try {
+            val result = agent.reply("Run echo hello", maxSteps = 2)
+
+            assertEquals("The command printed hello.", result.text)
+            assertEquals(1, executor.requests.size)
+            assertEquals(listOf("echo", "hello"), executor.requests.single().argv)
+            assertTrue(result.trace.first().toolResult?.data?.toString()?.contains("hello") == true)
+        } finally {
+            edge.close()
+        }
+    }
+
+    @Test
     fun `reply reports unknown tool and continues`() = runTest {
         installBridge(
             listOf("""{"tool":"missing_tool","arguments":{}}"""),
@@ -534,6 +597,17 @@ class ToolAgentTest {
                 )
             },
         )
+
+    private class RecordingBashExecutor(
+        private val block: suspend (BashExecutionRequest) -> BashExecutionResult,
+    ) : BashCommandExecutor {
+        val requests = mutableListOf<BashExecutionRequest>()
+
+        override suspend fun run(request: BashExecutionRequest): BashExecutionResult {
+            requests += request
+            return block(request)
+        }
+    }
 
     private fun installBridge(
         vararg responses: List<String>,


### PR DESCRIPTION
This pull request adds support for a new bash shell execution tool, allowing the LLM agent to run shell commands in a controlled and structured way. It introduces the `BashToolFactory` and related classes, comprehensive tests for the new tool, and documentation updates to guide users on enabling and using the bash tool.

**New Bash Tool Implementation:**

* Added `BashToolFactory`, `BashToolOptions`, and supporting classes to provide a tool for running bash commands via structured `argv` or raw shell strings (with explicit opt-in). The tool handles command execution, timeouts, output truncation, error reporting, and structured results. (`llmedge/src/main/java/io/aatricks/llmedge/tools/BashToolFactory.kt`)

**Testing:**

* Added `BashToolFactoryTest` with extensive coverage for argument validation, successful and failed executions, raw shell handling, timeouts, and output truncation. (`llmedge/src/test/java/io/aatricks/llmedge/tools/BashToolFactoryTest.kt`)
* Minor import additions to support new tests. (`llmedge/src/test/java/io/aatricks/llmedge/tools/ToolAgentTest.kt`)

**Documentation:**

* Updated `README.md` and `docs/usage.md` with instructions and code examples for enabling and using the bash tool, including configuration options and result structure. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R256-R276) [[2]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R89-R121)

**Subproject Update:**

* Updated the `llmedge-examples` subproject reference to the latest commit.