### PR TITLE
Feat/low end models

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Acknowledgments to Shubham Panchal and upstream projects are listed in [`CREDITS
 
 - **LLM Inference**: Run GGUF models directly on Android using llama.cpp (JNI)
 - **Model Downloads**: Download and cache models from Hugging Face Hub
+- **Low-end Presets**: `ModelPresets` ready-to-use specs (Microsoft BitNet b1.58 2B4T, SmolVLM2-256M) tuned for low-end devices
+- **On-device Safetensors → GGUF**: Convert Hugging Face safetensors models on-device (Llama arch + GPT2-BPE tokenizer), with optional quantization (Q8_0 / Q4_K_M / IQ2_BN), via `ModelSpec.safetensors(...)`
 - **Optimized Inference**: Native KV cache reuse for compact chats, default batched blocking and streaming text generation, separate prompt vs generation thread tuning, and Kotlin-managed `ChatSession` replay for reasoning-heavy models
 - **Speech-to-Text (STT)**: Whisper.cpp integration with timestamp support, language detection, streaming transcription, and SRT generation
 - **Text-to-Speech (TTS)**: Bark.cpp integration with ARM optimizations
@@ -194,7 +196,8 @@ val caption = edge.vision.analyze(
 > BitNet's GGUF metadata carries an incorrect chat template, so llmedge supplies the canonical one via
 > `ModelHints.chatTemplate`. A template you pass through `TextModelOptions.chatTemplate` always overrides it.
 > Bonsai and other ternary models distributed only as PrismML `Q2_0` GGUFs are **not** loadable by this
-> runtime (it uses `IQ2_BN`); see the safetensors-conversion design for the conversion path.
+> runtime (it uses `IQ2_BN`); convert the safetensors instead — see
+> [Converting safetensors models](docs/usage.md#converting-safetensors-models).
 
 ### Reasoning Controls
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Log.d("llmedge", "Cached ${modelFile.name} at ${modelFile.parent}")
 ik_llama.cpp runtime — no need to hand-type repo/filenames:
 
 ```kotlin
-// Microsoft BitNet b1.58 2B4T — native 1-bit LLM (IQ2_BN_R4, ~988 MB).
+// Microsoft BitNet b1.58 2B4T — native 1-bit LLM (IQ2_BN, ~988 MB).
 // The correct chat template ships on the preset, so generation is well-formed out of the box.
 val reply = edge.text.generate(prompt = "Hi", model = ModelPresets.bitnet)
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,31 @@ Log.d("llmedge", "Cached ${modelFile.name} at ${modelFile.parent}")
 
 - Direct `HuggingFaceHub` downloads remain available for expert workflows, but most app code should stay on the facade/model-repository path.
 
+#### Built-in low-end presets
+
+`ModelPresets` exposes ready-to-use specs tuned for low-end devices, already supported by the bundled
+ik_llama.cpp runtime — no need to hand-type repo/filenames:
+
+```kotlin
+// Microsoft BitNet b1.58 2B4T — native 1-bit LLM (IQ2_BN_R4, ~988 MB).
+// The correct chat template ships on the preset, so generation is well-formed out of the box.
+val reply = edge.text.generate(prompt = "Hi", model = ModelPresets.bitnet)
+
+// SmolVLM2-256M — tiny vision model (~280 MB total: base + projector).
+val caption = edge.vision.analyze(
+    image = bitmap,
+    prompt = "Describe this image.",
+    model = ModelPresets.smolVlm2.model,
+    projector = ModelPresets.smolVlm2.projector,
+)
+```
+
+> [!NOTE]
+> BitNet's GGUF metadata carries an incorrect chat template, so llmedge supplies the canonical one via
+> `ModelHints.chatTemplate`. A template you pass through `TextModelOptions.chatTemplate` always overrides it.
+> Bonsai and other ternary models distributed only as PrismML `Q2_0` GGUFs are **not** loadable by this
+> runtime (it uses `IQ2_BN`); see the safetensors-conversion design for the conversion path.
+
 ### Reasoning Controls
 
 Reasoning-aware models can be controlled from the facade through `TextModelOptions`. The default configuration keeps thinking enabled (`ThinkingMode.DEFAULT`, reasoning budget `-1`). To disable thinking for a request or session, pass the options explicitly:

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ llmedge is a lightweight toolkit for running LLM inference, vision models, and m
 **Core Features:**
 
 - Native C++ inference via [llama.cpp](https://github.com/ggerganov/llama.cpp) (GGUF model support)
+- On-device safetensors → GGUF conversion (Llama arch + GPT2-BPE) with optional quantization, plus low-end `ModelPresets` (BitNet b1.58 2B4T, SmolVLM2-256M)
 - Kotlin API for Android with coroutines and Flow support
 - Automatic CPU feature detection (FP16, dotprod, SVE, i8mm)
 - Optional Android GPU acceleration with experimental OpenCL preferred first, Vulkan fallback second, and CPU fallback last

--- a/docs/superpowers/specs/2026-06-01-low-end-model-presets-design.md
+++ b/docs/superpowers/specs/2026-06-01-low-end-model-presets-design.md
@@ -11,7 +11,7 @@ bundled runtime (`ikawrakow/ik_llama.cpp`) already supports, plus an optional ap
 
 | Model | Type | Quant | Size | Verdict |
 |---|---|---|---|---|
-| **Microsoft BitNet b1.58 2B4T** | text LLM (1-bit) | `IQ2_BN_R4` | ~988 MB | ship |
+| **Microsoft BitNet b1.58 2B4T** | text LLM (1-bit) | `IQ2_BN` | ~988 MB | ship |
 | **SmolVLM2-256M-Video-Instruct** | vision (VLM) | `Q8_0` + mmproj | ~280 MB | ship |
 | **Bonsai** (ternary) | text LLM | n/a on this runtime | — | appendix only |
 
@@ -75,7 +75,7 @@ This keeps `ModelSpec` unchanged (it already carries `hints`) and makes BitNet c
 // internal DefaultModelCatalog additions
 val bitnetText = huggingFaceSpec(
     repoId = "tdh111/bitnet-b1.58-2B-4T-GGUF",
-    filename = "bitnet1582b4t-iq2_bn_r4.gguf",
+    filename = "bitnet1582b4t-iq2_bn.gguf", // plain IQ2_BN (portable); repo also has an _r4 CPU repack
     preferredQuantizations = emptyList(),
     artifactKind = ModelArtifactKind.GGUF_MODEL,
     capabilities = setOf(ModelCapability.TEXT),

--- a/docs/superpowers/specs/2026-06-01-low-end-model-presets-design.md
+++ b/docs/superpowers/specs/2026-06-01-low-end-model-presets-design.md
@@ -1,7 +1,7 @@
 # Low-end model presets for llmedge — design
 
 **Date:** 2026-06-01
-**Status:** Approved scope, pending spec review
+**Status:** Implemented + unit-tested (`ModelPresets.bitnet`, `ModelPresets.smolVlm2`)
 **Branch:** `feat/low-end-models`
 
 ## Summary

--- a/docs/superpowers/specs/2026-06-01-low-end-model-presets-design.md
+++ b/docs/superpowers/specs/2026-06-01-low-end-model-presets-design.md
@@ -1,0 +1,190 @@
+# Low-end model presets for llmedge — design
+
+**Date:** 2026-06-01
+**Status:** Approved scope, pending spec review
+**Branch:** `feat/low-end-models`
+
+## Summary
+
+Add ready-to-use model presets to llmedge for two low-end-device-friendly models that the
+bundled runtime (`ikawrakow/ik_llama.cpp`) already supports, plus an optional appendix for Bonsai:
+
+| Model | Type | Quant | Size | Verdict |
+|---|---|---|---|---|
+| **Microsoft BitNet b1.58 2B4T** | text LLM (1-bit) | `IQ2_BN_R4` | ~988 MB | ship |
+| **SmolVLM2-256M-Video-Instruct** | vision (VLM) | `Q8_0` + mmproj | ~280 MB | ship |
+| **Bonsai** (ternary) | text LLM | n/a on this runtime | — | appendix only |
+
+This is **Track A**. A separate spec (`…-safetensors-conversion-design.md`, Track B) covers the
+in-library safetensors→GGUF converter the user also requested; it is intentionally **out of scope here**
+so these presets can land without blocking on a much larger subsystem.
+
+## Context (verified)
+
+- The `llama.cpp` submodule is actually **`ikawrakow/ik_llama.cpp`** pinned at `78977c0c` (2026-04-24).
+  Its `ggml.h` defines `GGML_TYPE_IQ1_BN` / `IQ2_BN` / `IQ2_BN_R4` (ternary/BitNet), compiled into the
+  arm64 JNI targets via the IQK kernels. It does **not** define `Q2_0` / `TQ1_0` / `TQ2_0`.
+- The multimodal path uses `mtmd` + `clip` (LLaVA-style: base GGUF + mmproj GGUF). `clip` supports
+  ~20 vision architectures including `smolvlm`/`idefics3` — **not** any Microsoft-native VLM
+  (Florence-2, Phi-3/3.5-vision).
+- Models are declared as `ModelSpec` presets. `DefaultModelCatalog` (internal) holds the built-in
+  specs; `ModelRegistry` wires them as `config.models.*` defaults. The example app has no hardcoded
+  picker — apps select models by passing a `ModelSpec` or overriding `LLMEdgeConfig.models`.
+- **Chat template flow:** `LLMInference.loadModel(path, chatTemplate, …)`. When `chatTemplate` is empty,
+  native falls back to the GGUF's embedded template. The Kotlin side sets the template at the
+  **`TextClient` options** level (`options.chatTemplate`), **not** on `ModelSpec`. `ModelHints` currently
+  has only `{artifactKind, capabilities}` — no template field.
+
+## Problem this solves
+
+1. Users have to hand-type repo/filename for good low-end models. Presets make BitNet + SmolVLM2
+   first-class.
+2. **BitNet's embedded chat template is wrong** (per the GGUF uploader). A naive preset would load the
+   wrong template and produce garbled output — a silently-broken preset. The preset must carry and apply
+   the correct template itself.
+
+## Design
+
+### 1. `ModelHints` carries an optional chat template
+
+Add a field so a text preset is self-contained:
+
+```kotlin
+data class ModelHints(
+    val artifactKind: ModelArtifactKind = ModelArtifactKind.AUTO,
+    val capabilities: Set<ModelCapability> = emptySet(),
+    val chatTemplate: String? = null,   // NEW: applied at load when caller didn't override
+)
+```
+
+Wiring rule (text load path): the effective template is
+`callerOptions.chatTemplate ?: resolvedSpec.hints.chatTemplate` (then native's GGUF-embedded fallback).
+Caller override always wins; otherwise the preset's template is used. Exact thread-through point
+(`TextRuntimeSupport` / `TextRuntimeSession` where the resolved `ModelSpec` + options meet `loadModel`)
+is nailed in the plan. Include the spec's `hints.chatTemplate` in the runtime cache key (alongside the
+existing `chatTemplate` token) so two specs differing only by template don't collide.
+
+This keeps `ModelSpec` unchanged (it already carries `hints`) and makes BitNet correct out of the box.
+
+### 2. Catalog entries (internal) + a public presets surface
+
+`DefaultModelCatalog` is `internal`, so end users cannot reference its entries. Add the new specs there
+**and** expose a **public** presets object so apps can use them directly:
+
+```kotlin
+// internal DefaultModelCatalog additions
+val bitnetText = huggingFaceSpec(
+    repoId = "tdh111/bitnet-b1.58-2B-4T-GGUF",
+    filename = "bitnet1582b4t-iq2_bn_r4.gguf",
+    preferredQuantizations = emptyList(),
+    artifactKind = ModelArtifactKind.GGUF_MODEL,
+    capabilities = setOf(ModelCapability.TEXT),
+    chatTemplate = BitNetTemplate.CHAT,   // pinned, see Risks
+)
+
+val smolVlm2Model = huggingFaceSpec(
+    repoId = "ggml-org/SmolVLM2-256M-Video-Instruct-GGUF",
+    filename = "SmolVLM2-256M-Video-Instruct-Q8_0.gguf",
+    preferredQuantizations = emptyList(),
+    artifactKind = ModelArtifactKind.GGUF_MODEL,
+    capabilities = setOf(ModelCapability.TEXT, ModelCapability.VISION),
+)
+val smolVlm2Projector = huggingFaceSpec(
+    repoId = "ggml-org/SmolVLM2-256M-Video-Instruct-GGUF",
+    filename = "mmproj-SmolVLM2-256M-Video-Instruct-Q8_0.gguf",
+    preferredQuantizations = emptyList(),
+    artifactKind = ModelArtifactKind.PROJECTOR,
+    capabilities = setOf(ModelCapability.PROJECTOR),
+)
+```
+
+```kotlin
+// NEW public surface — io.aatricks.llmedge.model.ModelPresets
+object ModelPresets {
+    /** Microsoft BitNet b1.58 2B4T, 1-bit (IQ2_BN_R4). ~988 MB. Self-contained chat template. */
+    val bitnet: ModelSpec = DefaultModelCatalog.bitnetText
+    /** SmolVLM2-256M vision base + projector. ~280 MB total. */
+    val smolVlm2: VisionModels = VisionModels(
+        model = DefaultModelCatalog.smolVlm2Model,
+        projector = DefaultModelCatalog.smolVlm2Projector,
+    )
+}
+```
+
+`huggingFaceSpec(...)` gets a `chatTemplate` parameter passed into `ModelHints`.
+
+Defaults in `ModelRegistry` are **unchanged** (text stays SmolLM-135M, vision stays llava-phi-3) so we
+don't force large downloads on existing users. The new models are opt-in via `ModelPresets`.
+
+### 3. `BitNetTemplate` constant
+
+Add an internal `BitNetTemplate.CHAT` string holding the canonical BitNet b1.58 2B4T chat template
+(pinned from the Microsoft model card — see Risks). Used by the catalog entry.
+
+### 4. Docs
+
+- `docs/usage.md` — under "Downloading Models" / vision: show `ModelPresets.bitnet` and
+  `ModelPresets.smolVlm2` usage; note BitNet works without manually setting a template.
+- `README.md` — add the two models to the feature/model notes; flag BitNet ~988 MB.
+
+## Usage (target API)
+
+```kotlin
+val edge = LLMEdge.create(context, scope)
+
+// BitNet — template applied automatically from the preset
+val reply = edge.text.complete(prompt = "Hi", model = ModelPresets.bitnet)
+
+// SmolVLM2 vision
+val desc = edge.vision.analyze(
+    image = bitmap,
+    model = ModelPresets.smolVlm2.model,
+    projector = ModelPresets.smolVlm2.projector,
+)
+```
+
+## Data flow (existing plumbing, unchanged)
+
+- **Text:** `ModelPresets.bitnet` → `ModelRepository.prefetch` (HF download → cache) →
+  `TextClient.complete(model=…)` → effective template resolved (preset's `hints.chatTemplate`) →
+  `LLMInference.loadModel(gguf, template)`.
+- **Vision:** base+projector specs → `VisionClient.analyze` → `mtmd` projector (`clip` smolvlm arch) +
+  base model.
+
+No native/CMake/submodule changes — both quants and the smolvlm clip arch are already compiled in.
+
+## Risks & how the plan resolves them
+
+1. **BitNet template correctness (highest).** Wrong template = garbled output. The plan must pin the
+   canonical template from `microsoft/bitnet-b1.58-2B-4T` `tokenizer_config.json` (chat_template) and
+   verify a rendered sample matches the documented BitNet format
+   (`<|begin_of_text|>` … `System:`/`User:`/`Assistant:` … `<|eot_id|>`). Do not trust the GGUF's embedded one.
+2. **Exact HF filenames.** BitNet `bitnet1582b4t-iq2_bn_r4.gguf` verified on `tdh111/...`. Re-confirm the
+   SmolVLM2 base + `mmproj-` filenames on `ggml-org/SmolVLM2-256M-Video-Instruct-GGUF` at implementation
+   (use the `HFFileSelectionSupport` listing).
+3. **SmolVLM2 end-to-end** through the existing `VisionPipeline`/`mtmd` on the 256M build — confirm
+   projector init + an analyze call returns sane output (the `<__media__>` marker + clip smolvlm path).
+4. **Template threading cache-key collision** — include `hints.chatTemplate` in the runtime cache token.
+5. **Size** — BitNet 988 MB is the heavy one; document it. SmolVLM2 ~280 MB is fine.
+
+## Testing
+
+- **Unit:** catalog/registry/`ModelPresets` wiring; `ModelHints.chatTemplate` precedence
+  (caller override > preset > embedded); `BitNetTemplate.CHAT` non-empty + renders.
+- **Integration (`androidTest`, emulator/device):** download+load `ModelPresets.bitnet`, generate with
+  the auto-applied template; load SmolVLM2 base+projector and run one `analyze`. Gate behind the existing
+  network/model-download test conventions.
+
+## Out of scope (→ Track B spec)
+
+- In-library safetensors **direct loading / lossy loading / conversion**. Tracked separately as the
+  safetensors→GGUF converter (one converter, precision param: F16 = "direct", quantized = "lossy"),
+  v1 scoped to Llama/Mistral. Gated on confirming Bonsai's ternary weight storage.
+
+## Appendix: Bonsai (optional, not default)
+
+Bonsai has no GGUF loadable by this runtime (its only GGUF is `Q2_0`, exclusive to PrismML's fork; the
+0.5B is safetensors-only). The only path onto ik_llama is an **offline** convert
+(`convert_hf_to_gguf.py` → `llama-quantize --outtype iq2_bn`), then sideload the resulting GGUF or host it
+and reference via `ModelSpec.huggingFace(...)` / `ModelSpec.localFile(...)`. Documented as a recipe; not a
+built-in preset. (Becomes cleaner once Track B's converter exists.)

--- a/docs/superpowers/specs/2026-06-01-safetensors-conversion-design.md
+++ b/docs/superpowers/specs/2026-06-01-safetensors-conversion-design.md
@@ -1,0 +1,133 @@
+# Safetensors → GGUF conversion as a library option — design (Track B)
+
+**Date:** 2026-06-01
+**Status:** Design for approval
+**Branch:** `feat/low-end-models`
+**Depends on:** Track A presets spec (independent; can land before or after)
+
+## What the user asked
+
+> implement safetensors direct loading **or** lossy precision safetensors loading **or** conversion
+> as an option in the library
+
+These three collapse to **one converter with a precision parameter**:
+
+- **"direct loading"** = convert to **F16** GGUF (no precision loss) and load it — functionally
+  "load the safetensors as-is" from the caller's view, with a transparent, cached GGUF intermediate.
+- **"lossy loading"** = convert to a **quantized** GGUF (`Q8_0` / `Q4_K_M` / `IQ2_BN`).
+- **"conversion as an option"** = the converter itself, exposed through the library.
+
+We build **one** thing: a safetensors→GGUF pipeline with `precision ∈ {F16, Q8_0, Q4_K_M, …}`.
+
+## Why GGUF stays in the middle (no true "direct" runtime load)
+
+The LLM backend is `ik_llama.cpp` (GGML). Its model loader (`llama_model_load_from_file`) consumes
+**GGUF only**; there is no safetensors code path for LLMs, and the SD safetensors reader (`sd.cpp`) is a
+separate codebase with no tokenizer/llama-name-mapping logic. A real "load safetensors directly into the
+LLM runtime" means reimplementing the GGUF loader against safetensors — large, per-architecture, and it
+buys nothing a cached F16 GGUF doesn't. So **every option is "convert → load GGUF"**, differing only by
+precision and *where* the conversion runs.
+
+## The hard part is the tokenizer, not the tensors
+
+Reading safetensors is trivial (8-byte header length + JSON header + raw tensor blobs, per-tensor offsets
+→ streamable one tensor at a time, so RAM is bounded). The genuinely hard, fragile work is **baking the HF
+tokenizer into GGUF metadata** (vocab, merges, scores, special tokens, pre-tokenizer regex) — upstream
+`convert_hf_to_gguf.py` spends thousands of lines on tokenizer variants. Any native reimplementation only
+supports the few tokenizers it explicitly handles.
+
+## Verified building blocks (already in-repo)
+
+- `llama.cpp/convert_hf_to_gguf.py` + `gguf-py/` — the full HF→GGUF converter, **ships in the submodule**.
+- `gguf_init_empty` / `gguf_set_val_*` / `gguf_add_tensor` / `gguf_write_to_file` (`ggml.h`) — native GGUF writer.
+- `llama_model_quantize` (`llama.h:663`) — native GGUF→GGUF quantize.
+- ik_llama quant types available as targets: `F16`, `Q8_0`, `Q4_K_M`, … and `IQ2_BN` (ternary).
+
+## Bonsai is the motivating model — and needs a model-specific pre-step
+
+`deepgrove/Bonsai` (0.5B) is `QLlamaForCausalLM` (`model_type: llama`) but:
+
+- weights are **BF16 unpacked ternary** {-1,0,+1} **plus per-output-channel `scales`** applied
+  **post-matmul** (`QLinear`); requires `trust_remote_code` / `modeling_qllama.py`.
+- **stock `convert_hf_to_gguf.py` fails** (can't instantiate QLlama; post-matmul channel scales aren't
+  GGUF-native).
+
+**Escape hatch (math):** `y = (x·Wᵀ)·scales = x·(W·scales[:,None])ᵀ`. Fold the per-row scale into the
+weight → `W_eff = W_ternary × scale` → a normal real-valued Llama weight → stock-convertible → quantize.
+This is **lossy vs. the native 1.58-bit format** (lossless ternary only exists in PrismML's `Q2_0` fork,
+which ik_llama lacks), but yields a working low-end GGUF (0.5B @ `Q4_K_M` ≈ 350 MB).
+
+Consequence: the converter cannot be fully generic — **Bonsai needs a small `QLinear` scale-fold adapter**
+before the stock convert path. Plain `LlamaForCausalLM` safetensors need no adapter.
+
+## Design: phased, recommendation-first
+
+### Phase B1 — host/build-time converter + library consumption  (RECOMMENDED, ship first)
+
+**Where it runs: a dev box / CI, not the phone.** "Low-end devices" is the North Star — converting a
+~1 GB fp model is desktop-class work we do **once**, never on the weakest device.
+
+1. **Repo tool** `tools/safetensors-convert/` (thin wrapper + Gradle task over the in-repo
+   `convert_hf_to_gguf.py` + a quantize step):
+   - `--source <hf-repo|local-dir>`  `--precision {f16|q8_0|q4_k_m|iq2_bn}`  `--out <file.gguf>`
+   - `--adapter bonsai-qlinear` → numpy/safetensors pre-pass: read `scales`, compute `W_eff = W×scale`,
+     drop scale tensors, rewrite as stock Llama, then run the normal converter.
+   - generic stock-Llama/Mistral models work with no adapter.
+2. **Library consumption API** (the "option in the library"):
+   - Existing `ModelSpec.huggingFace(...)` / `ModelSpec.localFile(...)` already load any produced GGUF.
+   - Add `ModelSpec.safetensors(source, precision)` that **resolves** to a converted GGUF: looks for a
+     cached/companion converted file (cache key includes source + precision); if present, loads it; if
+     absent, fails fast with an actionable error naming the `tools/safetensors-convert` command (and, if
+     B2 is built, transparently invokes the on-device converter instead).
+   - `precision` enum on the spec → F16 ("direct") vs quantized ("lossy").
+3. **Bonsai** becomes a documented, supported model end-to-end via the tool → sideload/host the GGUF →
+   `ModelSpec.localFile(...)` / `huggingFace(...)`. Folds into Track A's appendix.
+
+Deliverable surface: one Python adapter + Gradle task + one new `ModelSpec` variant + resolver hook + docs.
+Effort: days. Risk: low (reuses upstream converter).
+
+### Phase B2 — on-device native converter, stock-Llama only  (OPTIONAL, larger, later)
+
+Only if a concrete need to convert *on the device* emerges (rare for low-end).
+
+- JNI converter: hand-rolled native safetensors reader (streaming, per-tensor) → HF→llama tensor-name map
+  for Llama-family → **bake Llama/SPM tokenizer from `tokenizer.json`** into GGUF (the fragile core) →
+  `gguf_*` write → optional `llama_model_quantize`.
+- Same `precision` param (F16 = "direct", quantized = "lossy").
+- **Explicitly excludes custom-modeling models** (Bonsai's QLlama — needs the host fold step) and any
+  tokenizer the native baker doesn't implement.
+- RAM bounded by streaming, but conversion CPU/time is still heavy on low-end — document and gate (e.g.
+  refuse below a RAM threshold).
+- Effort: weeks. Risk: high (tokenizer fidelity). Recommend deferring until B1 is in use.
+
+## Recommendation
+
+Build **B1 now**. It satisfies "conversion as a library option" with a real `ModelSpec.safetensors(…,
+precision)` API and unblocks Bonsai, reusing the converter that already ships in-repo — without a
+weeks-long, fragile native tokenizer reimplementation that runs desktop-class work on the weakest phones.
+Treat **B2 as a separate, opt-in phase** with its own plan, pursued only if on-device conversion is truly
+required.
+
+## Open question for the user
+
+Should v1 target **only Bonsai + stock Llama/Mistral**, or aim for **arbitrary HF architectures**?
+Recommendation: Llama/Mistral + the Bonsai adapter for v1 — arbitrary-arch support is mostly upstream
+converter coverage and can grow incrementally.
+
+## Risks
+
+1. **Tokenizer fidelity** (B2 especially) — wrong vocab/merges = subtly broken generation. B1 sidesteps
+   this by reusing the upstream Python tokenizer baker.
+2. **Bonsai fold correctness** — verify `W_eff` produces matching logits vs. the `trust_remote_code`
+   reference on a few prompts before trusting the GGUF.
+3. **Quantizing folded ternary** — `Q4_K_M`/`IQ2_BN` of folded weights drifts from native ternary; measure
+   perplexity vs. the reference and document expected quality.
+4. **`ModelSpec.safetensors` UX** — must fail loudly and actionably when no converted GGUF exists, never
+   silently download a 1 GB safetensors the runtime can't load.
+
+## Testing
+
+- **B1:** unit-test the Bonsai fold (`W_eff` equals `W×scale`); golden-file the converted GGUF metadata;
+  smoke-test loading a small converted model. Verify the resolver's cache-hit / missing-GGUF error paths.
+- **B2 (if built):** tokenizer round-trip tests (encode/decode parity vs. HF), per-arch load tests,
+  RAM-gate behavior.

--- a/docs/superpowers/specs/2026-06-01-safetensors-conversion-design.md
+++ b/docs/superpowers/specs/2026-06-01-safetensors-conversion-design.md
@@ -1,7 +1,7 @@
 # Safetensors → GGUF conversion as a library option — design (Track B)
 
 **Date:** 2026-06-01
-**Status:** Design for approval
+**Status:** B1 implemented + unit-tested (host converter + `ModelSpec.safetensors(...)` API); B2 (on-device native) deferred
 **Branch:** `feat/low-end-models`
 **Depends on:** Track A presets spec (independent; can land before or after)
 

--- a/docs/superpowers/specs/2026-06-01-safetensors-conversion-design.md
+++ b/docs/superpowers/specs/2026-06-01-safetensors-conversion-design.md
@@ -86,9 +86,13 @@ before the stock convert path. Plain `LlamaForCausalLM` safetensors need no adap
 Deliverable surface: one Python adapter + Gradle task + one new `ModelSpec` variant + resolver hook + docs.
 Effort: days. Risk: low (reuses upstream converter).
 
-### Phase B2 — on-device native converter, stock-Llama only  (OPTIONAL, larger, later)
+### Phase B2 — on-device native converter  (APPROVED, sequenced after B1)
 
-Only if a concrete need to convert *on the device* emerges (rare for low-end).
+User approved building the on-device path too, targeting arbitrary HF architectures. Sequenced **after**
+B1 lands. Honest constraint: on-device native conversion cannot match upstream's arbitrary-arch +
+arbitrary-tokenizer coverage on day one — B1 (reusing upstream `convert_hf_to_gguf.py`) carries the broad
+"arbitrary architecture" promise; B2's native coverage grows incrementally (Llama/Mistral tokenizers
+first), refusing unsupported arch/tokenizer with a clear error rather than emitting a broken GGUF.
 
 - JNI converter: hand-rolled native safetensors reader (streaming, per-tensor) → HF→llama tensor-name map
   for Llama-family → **bake Llama/SPM tokenizer from `tokenizer.json`** into GGUF (the fragile core) →
@@ -100,19 +104,12 @@ Only if a concrete need to convert *on the device* emerges (rare for low-end).
   refuse below a RAM threshold).
 - Effort: weeks. Risk: high (tokenizer fidelity). Recommend deferring until B1 is in use.
 
-## Recommendation
+## Sequencing
 
-Build **B1 now**. It satisfies "conversion as a library option" with a real `ModelSpec.safetensors(…,
-precision)` API and unblocks Bonsai, reusing the converter that already ships in-repo — without a
-weeks-long, fragile native tokenizer reimplementation that runs desktop-class work on the weakest phones.
-Treat **B2 as a separate, opt-in phase** with its own plan, pursued only if on-device conversion is truly
-required.
-
-## Open question for the user
-
-Should v1 target **only Bonsai + stock Llama/Mistral**, or aim for **arbitrary HF architectures**?
-Recommendation: Llama/Mistral + the Bonsai adapter for v1 — arbitrary-arch support is mostly upstream
-converter coverage and can grow incrementally.
+Land **B1 first** (real `ModelSpec.safetensors(…, precision)` API + tool, unblocks Bonsai, reuses the
+in-repo converter), then build **B2** (on-device native). B1 carries the broad "arbitrary architecture"
+promise via upstream `convert_hf_to_gguf.py`; B2's native coverage grows incrementally and fails loudly on
+anything it can't yet handle.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-06-02-b2-native-converter-plan.md
+++ b/docs/superpowers/specs/2026-06-02-b2-native-converter-plan.md
@@ -1,8 +1,32 @@
 # B2 — on-device native safetensors → GGUF converter (implementation plan)
 
 **Date:** 2026-06-02
-**Status:** In progress (multi-session). Branch `feat/low-end-models`.
+**Status:** Layers 1–3 done + verified (tensor path oracle-green vs upstream); Layer 4 (tokenizer baking) is the next boundary. Multi-session. Branch `feat/low-end-models`.
 **Parent spec:** `2026-06-01-safetensors-conversion-design.md`
+
+## Progress (verified)
+
+- **Layer 1 — safetensors reader** ✅ `cpp/convert/safetensors_reader.*`; round-trip test passes.
+- **Layer 2 — GGUF writer** ✅ `cpp/convert/gguf_writer.*`; output cross-verified by canonical `gguf-py`.
+- **Layer 3 — Llama tensor+hparam converter** ✅ `cpp/convert/hf_to_gguf.*`. Ground-truth oracle GREEN:
+  converted SmolLM-135M and diffed **272/272 tensors** (shapes + fp32 values, rtol/atol 2e-3) against the
+  upstream `convert_hf_to_gguf.py` output — proving the HF→GGUF name map, the Q/K RoPE permutation, tied
+  embeddings, and bf16→f16 are all correct. (Exact tensor match ⇒ inference is identical by construction,
+  so a separate greedy-token oracle is redundant for the tensor path.)
+
+### Boundary reached this session → Layer 4 = next
+
+- **Layer 4 — tokenizer baking** (NOT done; the fragile per-tokenizer-family core). For SmolLM (GPT2-BPE)
+  the converted GGUF must emit, from `tokenizer.json`/`tokenizer_config.json`:
+  `tokenizer.ggml.model` (="gpt2"), `tokenizer.ggml.pre` (**fragile** — upstream picks it by hashing the
+  tokenizer against a known list; getting it wrong shifts tokenization → wrong output),
+  `tokens[vocab]`, `token_type[vocab]`, `merges[]`, `bos/eos/unknown/padding_token_id`,
+  `add_space_prefix`/`add_bos_token`, `chat_template`. Verify by KV-diff against the reference GGUF's
+  `tokenizer.ggml.*` arrays (independent of the tensor path). Until this lands, the converted GGUF carries
+  tensors+hparams only and is not loadable without a borrowed tokenizer.
+- **Layer 5 — JNI + Kotlin wiring**: `nativeConvertSafetensors(...)` + hook into
+  `DefaultModelRepository.resolve` (the `ModelSpec.safetensors` else-branch).
+- **Layer 6 — quantize (`llama_model_quantize`) + Bonsai QLinear fold (port B1's fold to C++).**
 
 ## Decision: reimplement in C++ (reuse ruled out)
 

--- a/docs/superpowers/specs/2026-06-02-b2-native-converter-plan.md
+++ b/docs/superpowers/specs/2026-06-02-b2-native-converter-plan.md
@@ -1,0 +1,70 @@
+# B2 — on-device native safetensors → GGUF converter (implementation plan)
+
+**Date:** 2026-06-02
+**Status:** In progress (multi-session). Branch `feat/low-end-models`.
+**Parent spec:** `2026-06-01-safetensors-conversion-design.md`
+
+## Decision: reimplement in C++ (reuse ruled out)
+
+`llama.cpp/convert_hf_to_gguf.py` has a hard top-level `import torch` (254 uses, `LazyTorchTensor`).
+Embedding it on-device (Chaquopy/CPython) would require full PyTorch in the APK — impractical. Confirmed,
+not assumed. So B2 is a native C++/JNI reimplementation.
+
+## Honest scope (v1)
+
+**One vertical slice: Llama architecture + SentencePiece tokenizer** (covers Bonsai/Llama). NOT "arbitrary
+architectures" — `convert_hf_to_gguf` is multi-month of per-arch/per-tokenizer logic. Coverage grows
+incrementally; anything unsupported **fails loudly** (clear error), never emits a broken GGUF. The
+`ModelSpec.safetensors` API stays arbitrary-looking, but B2's engine is explicitly single-arch in v1.
+
+## The oracle is non-negotiable and comes first
+
+"Generates non-empty / looks coherent" already hid pure garbage this session. A converter that flips a
+tensor layout or a tokenizer score produces *plausible* garbage. So the verification oracle is a
+**ground-truth diff against an official GGUF**:
+
+- Reference model: **SmolLM-135M** (Llama-arch, tiny, ships both safetensors and an official GGUF).
+- Convert safetensors → GGUF at **F16**, compare against an **F16/Q8 reference at the same precision**
+  (never vs a Q4 — quant noise masks bugs).
+- Assertion: **identical greedy tokens** (or matching first-token logits within tolerance) on fixed
+  prompts, run through the host `libsmollm`.
+
+Build the oracle harness before trusting any conversion output.
+
+## Isolate the two halves (verify independently)
+
+1. **Tensors + hparams** — convert tensors + config.json hparams, but **borrow the `tokenizer.ggml.*` KV
+   from the official GGUF**. Validates the tensor/hparam path alone via the logit oracle.
+2. **Tokenizer baking** — emit `tokenizer.ggml.*` from `tokenizer.model`/`tokenizer.json`, validated by
+   **diffing the emitted KV arrays against the official GGUF's arrays** (tokens, scores, token_type,
+   merges, special-token ids). Do not combine with (1) until both pass independently.
+
+## Components (`llmedge/src/main/cpp/convert/`)
+
+- `safetensors_reader.{h,cpp}` — parse the 8-byte header-len + JSON header; mmap tensor data; yield
+  `{name, dtype, shape, offset, nbytes}`. Backend-agnostic, host-testable. **(Layer 1 — start here.)**
+- `gguf_writer_support` — thin use of ggml `gguf_init_empty` / `gguf_set_val_*` / `gguf_add_tensor` /
+  `gguf_write_to_file`, with bf16/f16→f16 casting via ggml.
+- `hf_to_gguf.{h,cpp}` — orchestrator: read config.json → arch/hparams → HF→llama tensor-name map (Llama)
+  → set GGUF KV → (bake or borrow) tokenizer → write tensors.
+- `tokenizer_bake.{h,cpp}` — SentencePiece (`tokenizer.model`, protobuf) → `tokenizer.ggml.*`. BPE later.
+- `convert_jni.cpp` — `nativeConvertSafetensors(srcDir, outPath, quantType)`; quantize via the
+  already-built `llama_model_quantize`.
+- Kotlin `SafetensorsConverter` + wire into `DefaultModelRepository.resolve` (replace the "throw
+  instructions" branch with actual conversion when the native converter is available).
+
+## Build verification ladder (each layer independently verified)
+
+1. **Reader** → parse a known safetensors; assert tensor count/names/shapes/dtypes (ground truth:
+   Bonsai = 259 BF16 tensors, known shapes). Host unit test.
+2. **GGUF writer** → write + read back (round-trip) a GGUF; assert KV/tensors survive.
+3. **Tensors+hparams** (borrowed tokenizer) → logit/greedy-token oracle vs official SmolLM-135M GGUF.
+4. **Tokenizer baking** → KV diff vs official GGUF.
+5. **Full path** → end-to-end safetensors → GGUF → generate, oracle-checked; then quantize (IQ2_BN) +
+   the Bonsai QLinear fold adapter (reuse B1's fold logic, ported to C++).
+
+## Out of scope v1 (fail loudly)
+
+Non-Llama archs, BPE/WordPiece/Unigram-only tokenizers, sharded > simple cases, models needing custom
+remote code beyond the Bonsai fold. Each emits a clear "unsupported … convert on host with
+tools/safetensors-convert" error.

--- a/docs/superpowers/specs/2026-06-02-b2-native-converter-plan.md
+++ b/docs/superpowers/specs/2026-06-02-b2-native-converter-plan.md
@@ -1,7 +1,9 @@
 # B2 — on-device native safetensors → GGUF converter (implementation plan)
 
 **Date:** 2026-06-02
-**Status:** Layers 1–3 done + verified (tensor path oracle-green vs upstream); Layer 4 (tokenizer baking) is the next boundary. Multi-session. Branch `feat/low-end-models`.
+**Status:** Layers 1–6 done + verified end-to-end on host arm64 (convert → bake tokenizer → quantize →
+load → generate). Only the on-device Bonsai QLinear *adapter* remains (verification-blocked: no local
+Bonsai model). Branch `feat/low-end-models`.
 **Parent spec:** `2026-06-01-safetensors-conversion-design.md`
 
 ## Progress (verified)
@@ -11,22 +13,39 @@
 - **Layer 3 — Llama tensor+hparam converter** ✅ `cpp/convert/hf_to_gguf.*`. Ground-truth oracle GREEN:
   converted SmolLM-135M and diffed **272/272 tensors** (shapes + fp32 values, rtol/atol 2e-3) against the
   upstream `convert_hf_to_gguf.py` output — proving the HF→GGUF name map, the Q/K RoPE permutation, tied
-  embeddings, and bf16→f16 are all correct. (Exact tensor match ⇒ inference is identical by construction,
-  so a separate greedy-token oracle is redundant for the tensor path.)
+  embeddings, and bf16→f16 are all correct.
+- **Layer 4 — tokenizer baking** ✅ `cpp/convert/tokenizer_bake.*`. Emits the GPT2-BPE
+  `tokenizer.ggml.*` KVs (model, pre, tokens[vocab], token_type[vocab], merges[], bos/eos/unk/pad ids,
+  add_space_prefix/add_bos_token, chat_template). `tokenizer.ggml.pre` is **caller-supplied** (a
+  `ModelConversion.tokenizerPre` hint, mirroring `chatTemplate`) and required — upstream derives it by
+  hashing the real tokenizer's output, which v1 does not reimplement; an empty pre throws rather than
+  guessing (a wrong pre loads silently and mis-tokenizes). Fail-loud guards: model.type=="BPE",
+  space-joined string merges (array-pair form rejected), contiguous vocab ids. Oracle GREEN:
+  `compare_tokenizer_kv.py` byte-matches **all 12 tokenizer KVs** vs the upstream reference.
+- **Layer 5 — JNI + Kotlin wiring** ✅ `smollm_jni_convert.cpp` exposes
+  `SmolLM.nativeConvertSafetensors`; `convert/*.cpp` added to both Android + desktop smollm targets.
+  `DefaultModelRepository.resolveConvertedModel` (now suspend) downloads the HF model dir (or uses the
+  local dir) and converts into the cache target — with fail-fast on missing tokenizerPre, atomic
+  temp+rename, and an UnsatisfiedLinkError fallback to the host-tool instructions.
+- **Layer 6 — quantize** ✅ in the JNI wrapper via `llama_model_quantize` (convert→temp-F16→requantize),
+  supporting q8_0 / q4_k_m / iq2_bn / iq2_bn_r4.
 
-### Boundary reached this session → Layer 4 = next
+### End-to-end verification (B2ConvertE2ETest, host arm64)
 
-- **Layer 4 — tokenizer baking** (NOT done; the fragile per-tokenizer-family core). For SmolLM (GPT2-BPE)
-  the converted GGUF must emit, from `tokenizer.json`/`tokenizer_config.json`:
-  `tokenizer.ggml.model` (="gpt2"), `tokenizer.ggml.pre` (**fragile** — upstream picks it by hashing the
-  tokenizer against a known list; getting it wrong shifts tokenization → wrong output),
-  `tokens[vocab]`, `token_type[vocab]`, `merges[]`, `bos/eos/unknown/padding_token_id`,
-  `add_space_prefix`/`add_bos_token`, `chat_template`. Verify by KV-diff against the reference GGUF's
-  `tokenizer.ggml.*` arrays (independent of the tensor path). Until this lands, the converted GGUF carries
-  tensors+hparams only and is not loadable without a borrowed tokenizer.
-- **Layer 5 — JNI + Kotlin wiring**: `nativeConvertSafetensors(...)` + hook into
-  `DefaultModelRepository.resolve` (the `ModelSpec.safetensors` else-branch).
-- **Layer 6 — quantize (`llama_model_quantize`) + Bonsai QLinear fold (port B1's fold to C++).**
+Drives the **real** `DefaultModelRepository.resolve(safetensorsLocal(SmolLM-135M, tokenizerPre="smollm"))`:
+- **F16** → 270 MB GGUF in `llmedge-converted/` → loads → generates **"The capital of France is Paris!"**
+- **Q4_K_M** → 105 MB GGUF (2.6× smaller than the source) → generates **"The capital of France!"**
+This proves the baked tokenizer builds a working `llama_vocab` and the baked chat_template is used —
+the whole pipeline, not just KV/tensor equivalence.
+
+### Remaining → on-device Bonsai QLinear adapter
+
+- **Bonsai fold (adapter=BONSAI_QLINEAR) on-device**: NOT done. Needs `convert_llama_dir` to accept the
+  QLlama arch and fold per-output-channel `.scales` into the weights (`W_eff = W × scale`) before the
+  GGUF write, then IQ2_BN quantize. Verification-blocked: no Bonsai model is available locally and IQ2_BN
+  is a ternary quant, so an end-to-end oracle can't run this session. The fold *math* is already
+  unit-tested in B1 (`tools/safetensors-convert/bonsai_fold.py`, 5/5), and the **B1 host path converts
+  Bonsai offline today** (`--adapter bonsai-qlinear`), so this is an enhancement, not a blocker.
 
 ## Decision: reimplement in C++ (reuse ruled out)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -415,7 +415,7 @@ See [Examples](examples.md#chatsession-pattern) for a focused session snippet, o
 by the bundled ik_llama.cpp runtime:
 
 ```kotlin
-// Microsoft BitNet b1.58 2B4T — native 1-bit LLM (IQ2_BN_R4, ~988 MB).
+// Microsoft BitNet b1.58 2B4T — native 1-bit LLM (IQ2_BN, ~988 MB).
 // The canonical chat template ships on the preset (BitNet's GGUF metadata one is wrong),
 // so this is well-formed without setting TextModelOptions.chatTemplate.
 val reply = edge.text.generate(prompt = "Hi", model = ModelPresets.bitnet)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -436,21 +436,35 @@ always overrides a preset's `ModelHints.chatTemplate`.
 ### Converting safetensors models
 
 The runtime loads GGUF, not safetensors. `ModelSpec.safetensors(...)` declares a safetensors source plus
-a target precision; resolution loads a converted GGUF from the app cache, and if none exists yet, fails
-fast with instructions instead of downloading a model the runtime can't load.
+a target precision; resolution returns a converted GGUF from the app cache, and if none exists yet it
+**converts on-device**: it downloads the model directory (config + safetensors + tokenizer files), runs
+the native converter, optionally quantizes, caches the result, then loads it. `safetensorsLocal(path,…)`
+does the same from a local model directory (no download).
 
 ```kotlin
 // "direct" = F16 (no precision loss); or Q8_0 / Q4_K_M / IQ2_BN for smaller, lossy output.
-val bonsai = ModelSpec.safetensors(
-    repoId = "deepgrove/Bonsai",
-    precision = ConversionPrecision.IQ2_BN,
-    adapter = ConversionAdapter.BONSAI_QLINEAR, // Bonsai/QLlama need the scale-fold; omit for stock models
+val smol = ModelSpec.safetensors(
+    repoId = "HuggingFaceTB/SmolLM-135M-Instruct",
+    precision = ConversionPrecision.Q4_K_M,
+    tokenizerPre = "smollm", // REQUIRED: the tokenizer.ggml.pre id to bake (see below)
 )
+val reply = edge.text.generate(prompt = "Hi", model = smol)
 ```
 
-On-device conversion is not yet available (tracked as Phase B2). Produce the GGUF once on a dev box / CI
-with [`tools/safetensors-convert`](../tools/safetensors-convert/README.md), then either drop it where the
-error message points (the app cache) or load it directly via `ModelSpec.localFile("…/model.gguf")`.
+`tokenizerPre` is mandatory for on-device conversion of a text model: a GGUF without a baked tokenizer is
+not loadable, and the BPE pre-tokenizer id cannot be derived safely on-device, so the caller declares it
+(it comes straight from upstream's `convert_hf_to_gguf.py` table — e.g. `"smollm"`, `"llama-bpe"`,
+`"gpt-2"`). Omit it and resolution fails fast, before downloading anything.
+
+**Scope (v1):** the on-device converter handles **Llama-architecture models with a GPT2-BPE tokenizer**
+and a single-file `model.safetensors`. Anything else — other architectures, sharded safetensors, or the
+Bonsai `ConversionAdapter.BONSAI_QLINEAR` scale-fold — fails loud with instructions; for those, produce the
+GGUF once on a dev box / CI with [`tools/safetensors-convert`](../tools/safetensors-convert/README.md) and
+drop it where the error message points (the app cache), or load it directly via
+`ModelSpec.localFile("…/model.gguf")`.
+
+Verified end-to-end on a real arm64 device: HF safetensors → convert → bake tokenizer → quantize Q4_K_M →
+load → generate, all on-device.
 
 ### Downloading Models from Hugging Face
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -409,6 +409,30 @@ you explicitly want the model runtime to own all chat history.
 
 See [Examples](examples.md#chatsession-pattern) for a focused session snippet, or [LocalAssetDemoActivity](examples.md#localassetdemoactivity) for a complete app-level example.
 
+### Built-in low-end model presets
+
+`ModelPresets` provides ready-to-use specs for models that run well on low-end devices and are supported
+by the bundled ik_llama.cpp runtime:
+
+```kotlin
+// Microsoft BitNet b1.58 2B4T — native 1-bit LLM (IQ2_BN_R4, ~988 MB).
+// The canonical chat template ships on the preset (BitNet's GGUF metadata one is wrong),
+// so this is well-formed without setting TextModelOptions.chatTemplate.
+val reply = edge.text.generate(prompt = "Hi", model = ModelPresets.bitnet)
+
+// SmolVLM2-256M — tiny vision model (~280 MB total: base + projector).
+val caption = edge.vision.analyze(
+    image = bitmap,
+    prompt = "Describe this image.",
+    model = ModelPresets.smolVlm2.model,
+    projector = ModelPresets.smolVlm2.projector,
+)
+```
+
+Presets are plain `ModelSpec`s, so they compose with everything else (`edge.models.prefetch(...)`,
+`ModelRegistry`, per-call `model =` overrides). A template passed via `TextModelOptions.chatTemplate`
+always overrides a preset's `ModelHints.chatTemplate`.
+
 ### Downloading Models from Hugging Face
 
 For app code, prefer the facade-managed model repository:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -433,6 +433,25 @@ Presets are plain `ModelSpec`s, so they compose with everything else (`edge.mode
 `ModelRegistry`, per-call `model =` overrides). A template passed via `TextModelOptions.chatTemplate`
 always overrides a preset's `ModelHints.chatTemplate`.
 
+### Converting safetensors models
+
+The runtime loads GGUF, not safetensors. `ModelSpec.safetensors(...)` declares a safetensors source plus
+a target precision; resolution loads a converted GGUF from the app cache, and if none exists yet, fails
+fast with instructions instead of downloading a model the runtime can't load.
+
+```kotlin
+// "direct" = F16 (no precision loss); or Q8_0 / Q4_K_M / IQ2_BN for smaller, lossy output.
+val bonsai = ModelSpec.safetensors(
+    repoId = "deepgrove/Bonsai",
+    precision = ConversionPrecision.IQ2_BN,
+    adapter = ConversionAdapter.BONSAI_QLINEAR, // Bonsai/QLlama need the scale-fold; omit for stock models
+)
+```
+
+On-device conversion is not yet available (tracked as Phase B2). Produce the GGUF once on a dev box / CI
+with [`tools/safetensors-convert`](../tools/safetensors-convert/README.md), then either drop it where the
+error message points (the app cache) or load it directly via `ModelSpec.localFile("…/model.gguf")`.
+
 ### Downloading Models from Hugging Face
 
 For app code, prefer the facade-managed model repository:

--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/EmulatorPresetE2ETest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/EmulatorPresetE2ETest.kt
@@ -1,0 +1,112 @@
+package io.aatricks.llmedge
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.aatricks.llmedge.model.ModelArtifactKind
+import io.aatricks.llmedge.model.ModelCapability
+import io.aatricks.llmedge.model.ModelChatTemplates
+import io.aatricks.llmedge.model.ModelHints
+import io.aatricks.llmedge.model.ModelSpec
+import io.aatricks.llmedge.text.TextModelOptions
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device E2E for the low-end presets (BitNet text + SmolVLM2 vision). Provision the GGUFs into the
+ * test app's external files dir (adb push to /sdcard/Android/data/io.aatricks.llmedge.test/files/);
+ * tests skip via [Assume] if absent.
+ *
+ * Intended for a real arm64 device. NOTE: on the Android emulator running on Apple-Silicon hosts, the
+ * inference thread hits SIGILL on a pointer-authentication (PAC `autia`) instruction inside the NDK's
+ * prebuilt libc++ — a known HVF PAC-virtualization quirk, not a code bug (the same build generates
+ * correct output on real arm64; verified on the desktop host JNI build → "Paris"). To run on that
+ * emulator, the native libs must be built without PAC (incl. a PAC-free libc++) or PAC disabled in the
+ * guest kernel.
+ */
+@RunWith(AndroidJUnit4::class)
+class EmulatorPresetE2ETest {
+    private val ctx = ApplicationProvider.getApplicationContext<Context>()
+    private fun modelDir() = ctx.getExternalFilesDir(null)!!
+
+    @Test
+    fun bitnet_generates_paris_on_device() = runBlocking {
+        val model = File(modelDir(), "bitnet1582b4t-iq2_bn.gguf")
+        Assume.assumeTrue("BitNet not provisioned at ${model.absolutePath}", model.exists())
+
+        val edge = LLMEdge.create(ctx, CoroutineScope(Dispatchers.Default))
+        try {
+            // localFile + the preset's chat template hint exercises the Track A template threading.
+            val spec = ModelSpec.localFile(
+                model.absolutePath,
+                ModelHints(
+                    artifactKind = ModelArtifactKind.GGUF_MODEL,
+                    capabilities = setOf(ModelCapability.TEXT),
+                    chatTemplate = ModelChatTemplates.BITNET,
+                ),
+            )
+            val resp = edge.text.generate(
+                prompt = "What is the capital of France? Answer in one word.",
+                model = spec,
+                // useMmap=false: read the GGUF into RAM instead of mmap over the emulator's FUSE
+                // /sdcard (large-file mmap there destabilizes the FuseDaemon). 6 GB AVD has room.
+                options = TextModelOptions(temperature = 0.0f, contextSize = 1024L, useMmap = false),
+                maxTokens = 16,
+            )
+            android.util.Log.i("EmulatorPresetE2ETest", "BitNet -> '$resp'")
+            val cleaned = resp.replace(Regex("<\\|[^|]*\\|>"), "").trim()
+            assertTrue("Expected coherent text, got '$resp'", cleaned.length >= 3)
+            assertTrue("Expected 'Paris' in '$resp'", cleaned.contains("Paris", ignoreCase = true))
+        } finally {
+            edge.close()
+        }
+    }
+
+    @Test
+    fun smolvlm2_describes_image_on_device() = runBlocking {
+        val base = File(modelDir(), "SmolVLM2-256M-Video-Instruct-Q8_0.gguf")
+        val proj = File(modelDir(), "mmproj-SmolVLM2-256M-Video-Instruct-Q8_0.gguf")
+        Assume.assumeTrue("SmolVLM2 not provisioned", base.exists() && proj.exists())
+
+        val edge = LLMEdge.create(ctx, CoroutineScope(Dispatchers.Default))
+        try {
+            val bmp = Bitmap.createBitmap(128, 128, Bitmap.Config.ARGB_8888).also {
+                val c = Canvas(it)
+                c.drawColor(Color.WHITE)
+                c.drawCircle(64f, 64f, 40f, Paint().apply { color = Color.RED })
+            }
+            val desc = edge.vision.analyze(
+                image = bmp,
+                prompt = "Describe this image briefly.",
+                model = ModelSpec.localFile(
+                    base.absolutePath,
+                    ModelHints(
+                        artifactKind = ModelArtifactKind.GGUF_MODEL,
+                        capabilities = setOf(ModelCapability.TEXT, ModelCapability.VISION),
+                    ),
+                ),
+                projector = ModelSpec.localFile(
+                    proj.absolutePath,
+                    ModelHints(
+                        artifactKind = ModelArtifactKind.PROJECTOR,
+                        capabilities = setOf(ModelCapability.PROJECTOR),
+                    ),
+                ),
+            )
+            android.util.Log.i("EmulatorPresetE2ETest", "SmolVLM2 -> '$desc'")
+            assertTrue("Expected non-empty vision description, got '$desc'", desc.trim().length >= 3)
+        } finally {
+            edge.close()
+        }
+    }
+}

--- a/llmedge/src/main/cpp/cmake/llmedge-common.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-common.cmake
@@ -104,6 +104,12 @@ set(SMOLLM_SOURCES
         ${LLMEDGE_CPP_ROOT}/smollm_jni_embeddings.cpp
         ${LLMEDGE_CPP_ROOT}/smollm_jni_load.cpp
         ${LLMEDGE_CPP_ROOT}/smollm_jni_state.cpp
+        ${LLMEDGE_CPP_ROOT}/smollm_jni_convert.cpp
+        # On-device safetensors -> GGUF converter (Track B / Phase B2). No ggml/llama dependency.
+        ${LLMEDGE_CPP_ROOT}/convert/safetensors_reader.cpp
+        ${LLMEDGE_CPP_ROOT}/convert/gguf_writer.cpp
+        ${LLMEDGE_CPP_ROOT}/convert/tokenizer_bake.cpp
+        ${LLMEDGE_CPP_ROOT}/convert/hf_to_gguf.cpp
         # libmtmd (multimodal projector) from llama.cpp
         ${MTMD_DIR}/mtmd.cpp
         ${MTMD_DIR}/mtmd-helper.cpp

--- a/llmedge/src/main/cpp/convert/compare_gguf.py
+++ b/llmedge/src/main/cpp/convert/compare_gguf.py
@@ -1,0 +1,63 @@
+"""Tensor-by-tensor oracle: compare two GGUFs (mine vs a reference) as fp32.
+
+    python compare_gguf.py <mine.gguf> <ref.gguf> <repo_root>
+
+Verifies every tensor in <mine> exists in <ref> with the same shape and (dtype-agnostic) values.
+This is the ground-truth check for the converter: a wrong Q/K permutation or name map shows up as a
+shape mismatch or large value diff, not as plausible-looking garbage.
+"""
+import sys
+import numpy as np
+
+mine_path, ref_path = sys.argv[1], sys.argv[2]
+repo_root = sys.argv[3] if len(sys.argv) > 3 else "."
+sys.path.insert(0, f"{repo_root}/llama.cpp/gguf-py")
+from gguf import GGUFReader  # noqa: E402
+
+
+def tensors(path):
+    r = GGUFReader(path)
+    return {t.name: t for t in r.tensors}
+
+
+mine, ref = tensors(mine_path), tensors(ref_path)
+print(f"mine: {len(mine)} tensors, ref: {len(ref)} tensors")
+
+failures = 0
+checked = 0
+for name, mt in sorted(mine.items()):
+    if name not in ref:
+        print(f"FAIL: {name} not in reference")
+        failures += 1
+        continue
+    rt = ref[name]
+    ms = [int(x) for x in mt.shape]
+    rs = [int(x) for x in rt.shape]
+    if ms != rs:
+        print(f"FAIL: {name} shape {ms} != ref {rs}")
+        failures += 1
+        continue
+    a = np.array(mt.data, dtype=np.float32).flatten()
+    b = np.array(rt.data, dtype=np.float32).flatten()
+    if a.shape != b.shape:
+        print(f"FAIL: {name} element count {a.shape} != {b.shape}")
+        failures += 1
+        continue
+    if not np.allclose(a, b, rtol=2e-3, atol=2e-3):
+        diff = np.max(np.abs(a - b))
+        nbad = int(np.sum(np.abs(a - b) > 2e-3))
+        print(f"FAIL: {name} value mismatch (max|d|={diff:.4g}, {nbad}/{a.size} off)")
+        failures += 1
+        continue
+    checked += 1
+
+missing_in_mine = sorted(set(ref) - set(mine))
+# Reference may legitimately have nothing extra for a tied-embedding Llama; report if it does.
+if missing_in_mine:
+    print(f"NOTE: {len(missing_in_mine)} tensor(s) in ref but not mine: {missing_in_mine[:6]}")
+
+if failures == 0:
+    print(f"OK: {checked} tensors match the upstream reference (values + shapes)")
+    sys.exit(0)
+print(f"{failures} tensor(s) failed")
+sys.exit(1)

--- a/llmedge/src/main/cpp/convert/compare_tokenizer_kv.py
+++ b/llmedge/src/main/cpp/convert/compare_tokenizer_kv.py
@@ -1,0 +1,77 @@
+"""KV oracle: compare the tokenizer.* metadata of two GGUFs (mine vs a reference).
+
+    python compare_tokenizer_kv.py <mine.gguf> <ref.gguf> <repo_root>
+
+Checks every `tokenizer.*` key in the reference exists in mine with an identical value (strings,
+scalars, and arrays element-by-element). Also flags tokenizer.* keys present in mine but not ref.
+This is the ground-truth check for Layer 4 (tokenizer baking): a wrong token_type, a missing merge,
+or a shifted special-token id shows up as a concrete diff, not as plausible-looking output.
+"""
+import sys
+
+import numpy as np
+
+mine_path, ref_path = sys.argv[1], sys.argv[2]
+repo_root = sys.argv[3] if len(sys.argv) > 3 else "."
+sys.path.insert(0, f"{repo_root}/llama.cpp/gguf-py")
+from gguf import GGUFReader  # noqa: E402
+from gguf.constants import GGUFValueType  # noqa: E402
+
+
+def field_value(f):
+    """Return a comparable Python value for a GGUF field."""
+    t = f.types
+    if t and t[-1] == GGUFValueType.STRING:
+        if len(t) > 1 and t[0] == GGUFValueType.ARRAY:
+            return [str(bytes(f.parts[d]), "utf-8") for d in f.data]
+        return str(bytes(f.parts[f.data[0]]), "utf-8")
+    if t and t[0] == GGUFValueType.ARRAY:
+        return [int(f.parts[d][0]) if isinstance(f.parts[d][0], np.integer) else f.parts[d][0].item()
+                for d in f.data]
+    v = f.parts[f.data[0]][0]
+    return v.item() if hasattr(v, "item") else v
+
+
+def tok_fields(path):
+    r = GGUFReader(path)
+    return {k: field_value(f) for k, f in r.fields.items() if k.startswith("tokenizer.")}
+
+
+mine, ref = tok_fields(mine_path), tok_fields(ref_path)
+print(f"mine: {len(mine)} tokenizer KVs, ref: {len(ref)} tokenizer KVs")
+
+failures = 0
+for key, rv in sorted(ref.items()):
+    if key not in mine:
+        print(f"FAIL: {key} missing in mine")
+        failures += 1
+        continue
+    mv = mine[key]
+    if isinstance(rv, list):
+        if len(mv) != len(rv):
+            print(f"FAIL: {key} length {len(mv)} != ref {len(rv)}")
+            failures += 1
+            continue
+        nbad = sum(1 for a, b in zip(mv, rv) if a != b)
+        if nbad:
+            first = next((i for i, (a, b) in enumerate(zip(mv, rv)) if a != b))
+            print(f"FAIL: {key} {nbad}/{len(rv)} elems differ (first at [{first}]: {mv[first]!r} != {rv[first]!r})")
+            failures += 1
+        else:
+            print(f"  ok: {key} (array, {len(rv)} elems)")
+    else:
+        if mv != rv:
+            print(f"FAIL: {key} {mv!r} != ref {rv!r}")
+            failures += 1
+        else:
+            print(f"  ok: {key} = {mv!r}")
+
+extra = sorted(set(mine) - set(ref))
+if extra:
+    print(f"NOTE: {len(extra)} tokenizer KV(s) in mine but not ref: {extra}")
+
+if failures == 0:
+    print(f"OK: all {len(ref)} tokenizer KVs match the reference")
+    sys.exit(0)
+print(f"{failures} tokenizer KV(s) failed")
+sys.exit(1)

--- a/llmedge/src/main/cpp/convert/gguf_writer.cpp
+++ b/llmedge/src/main/cpp/convert/gguf_writer.cpp
@@ -1,0 +1,156 @@
+#include "gguf_writer.h"
+
+#include <cstring>
+#include <fstream>
+#include <stdexcept>
+
+namespace llmedge {
+namespace convert {
+
+namespace {
+void put_u32(std::vector<uint8_t>& b, uint32_t v) { b.insert(b.end(), (uint8_t*)&v, (uint8_t*)&v + 4); }
+void put_u64(std::vector<uint8_t>& b, uint64_t v) { b.insert(b.end(), (uint8_t*)&v, (uint8_t*)&v + 8); }
+void put_bytes(std::vector<uint8_t>& b, const void* p, size_t n) {
+    b.insert(b.end(), (const uint8_t*)p, (const uint8_t*)p + n);
+}
+void put_gstr(std::vector<uint8_t>& b, const std::string& s) {
+    put_u64(b, s.size());
+    b.insert(b.end(), s.begin(), s.end());
+}
+uint64_t align_up(uint64_t v, uint64_t a) { return (v + a - 1) / a * a; }
+}  // namespace
+
+void GgufWriter::put_scalar(const std::string& key, uint32_t type, const void* bytes, size_t n) {
+    Kv kv;
+    kv.type = type;
+    kv.scalar_bytes.assign((const uint8_t*)bytes, (const uint8_t*)bytes + n);
+    kvs_.emplace_back(key, std::move(kv));
+}
+
+void GgufWriter::set_u32(const std::string& k, uint32_t v) { put_scalar(k, T_UINT32, &v, 4); }
+void GgufWriter::set_i32(const std::string& k, int32_t v) { put_scalar(k, T_INT32, &v, 4); }
+void GgufWriter::set_f32(const std::string& k, float v) { put_scalar(k, T_FLOAT32, &v, 4); }
+void GgufWriter::set_bool(const std::string& k, bool v) {
+    uint8_t b = v ? 1 : 0;
+    put_scalar(k, T_BOOL, &b, 1);
+}
+void GgufWriter::set_str(const std::string& k, const std::string& v) {
+    Kv kv;
+    kv.type = T_STRING;
+    kv.str_values = {v};
+    kvs_.emplace_back(k, std::move(kv));
+}
+
+void GgufWriter::set_arr_u32(const std::string& k, const std::vector<uint32_t>& vals) {
+    Kv kv;
+    kv.type = T_ARRAY;
+    kv.arr_subtype = T_UINT32;
+    kv.arr_count = vals.size();
+    kv.arr_bytes.assign((const uint8_t*)vals.data(), (const uint8_t*)vals.data() + vals.size() * 4);
+    kvs_.emplace_back(k, std::move(kv));
+}
+void GgufWriter::set_arr_i32(const std::string& k, const std::vector<int32_t>& vals) {
+    Kv kv;
+    kv.type = T_ARRAY;
+    kv.arr_subtype = T_INT32;
+    kv.arr_count = vals.size();
+    kv.arr_bytes.assign((const uint8_t*)vals.data(), (const uint8_t*)vals.data() + vals.size() * 4);
+    kvs_.emplace_back(k, std::move(kv));
+}
+void GgufWriter::set_arr_f32(const std::string& k, const std::vector<float>& vals) {
+    Kv kv;
+    kv.type = T_ARRAY;
+    kv.arr_subtype = T_FLOAT32;
+    kv.arr_count = vals.size();
+    kv.arr_bytes.assign((const uint8_t*)vals.data(), (const uint8_t*)vals.data() + vals.size() * 4);
+    kvs_.emplace_back(k, std::move(kv));
+}
+void GgufWriter::set_arr_str(const std::string& k, const std::vector<std::string>& vals) {
+    Kv kv;
+    kv.type = T_ARRAY;
+    kv.arr_subtype = T_STRING;
+    kv.arr_count = vals.size();
+    kv.str_values = vals;
+    kvs_.emplace_back(k, std::move(kv));
+}
+
+void GgufWriter::add_tensor(const std::string& name, GgmlType type, const std::vector<int64_t>& ne,
+                            const void* data, uint64_t nbytes) {
+    TensorInfo t;
+    t.name = name;
+    t.type = type;
+    t.ne = ne.empty() ? std::vector<int64_t>{1} : ne;
+    t.data.assign((const uint8_t*)data, (const uint8_t*)data + nbytes);
+    tensors_.push_back(std::move(t));
+}
+
+void GgufWriter::write(const std::string& path, uint32_t alignment) const {
+    std::vector<uint8_t> meta;
+    // Header
+    const char magic[4] = {'G', 'G', 'U', 'F'};
+    put_bytes(meta, magic, 4);
+    put_u32(meta, 3);  // version
+    put_u64(meta, tensors_.size());
+    put_u64(meta, kvs_.size());
+
+    // KV section
+    for (const auto& [key, kv] : kvs_) {
+        put_gstr(meta, key);
+        put_u32(meta, kv.type);
+        if (kv.type == T_STRING) {
+            put_gstr(meta, kv.str_values.at(0));
+        } else if (kv.type == T_ARRAY) {
+            put_u32(meta, kv.arr_subtype);
+            put_u64(meta, kv.arr_count);
+            if (kv.arr_subtype == T_STRING) {
+                for (const auto& s : kv.str_values) put_gstr(meta, s);
+            } else {
+                put_bytes(meta, kv.arr_bytes.data(), kv.arr_bytes.size());
+            }
+        } else {
+            put_bytes(meta, kv.scalar_bytes.data(), kv.scalar_bytes.size());
+        }
+    }
+
+    // Tensor offsets (relative to the data section start), each aligned.
+    std::vector<uint64_t> offsets(tensors_.size());
+    uint64_t cur = 0;
+    for (size_t i = 0; i < tensors_.size(); ++i) {
+        offsets[i] = cur;
+        cur = align_up(cur + tensors_[i].data.size(), alignment);
+    }
+
+    // Tensor info section
+    for (size_t i = 0; i < tensors_.size(); ++i) {
+        const auto& t = tensors_[i];
+        put_gstr(meta, t.name);
+        put_u32(meta, (uint32_t)t.ne.size());
+        for (int64_t d : t.ne) put_u64(meta, (uint64_t)d);
+        put_u32(meta, (uint32_t)t.type);
+        put_u64(meta, offsets[i]);
+    }
+
+    std::ofstream out(path, std::ios::binary);
+    if (!out) throw std::runtime_error("gguf: cannot open " + path + " for writing");
+    out.write((const char*)meta.data(), (std::streamsize)meta.size());
+
+    // Pad metadata to alignment -> data section start.
+    uint64_t data_start = align_up(meta.size(), alignment);
+    std::vector<uint8_t> pad(alignment, 0);
+    if (data_start > meta.size()) out.write((const char*)pad.data(), (std::streamsize)(data_start - meta.size()));
+
+    // Tensor data at data_start + offset[i].
+    uint64_t written = 0;  // bytes written into the data section
+    for (size_t i = 0; i < tensors_.size(); ++i) {
+        if (offsets[i] > written) {
+            out.write((const char*)pad.data(), (std::streamsize)(offsets[i] - written));
+            written = offsets[i];
+        }
+        out.write((const char*)tensors_[i].data.data(), (std::streamsize)tensors_[i].data.size());
+        written += tensors_[i].data.size();
+    }
+    if (!out) throw std::runtime_error("gguf: write failed for " + path);
+}
+
+}  // namespace convert
+}  // namespace llmedge

--- a/llmedge/src/main/cpp/convert/gguf_writer.h
+++ b/llmedge/src/main/cpp/convert/gguf_writer.h
@@ -1,0 +1,76 @@
+// Minimal, spec-conformant GGUF writer for the on-device HF -> GGUF converter (Track B / Phase B2).
+//
+// Writes GGUF v3: ["GGUF"][u32 version=3][u64 n_tensors][u64 n_kv][KV...][tensor-info...][pad][data...].
+// Hand-rolled (no ggml dependency) so it is host-testable and works unchanged inside the JNI lib.
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace llmedge {
+namespace convert {
+
+// ggml tensor type ids (subset we emit). Values match ggml.h GGML_TYPE_*.
+enum class GgmlType : int32_t {
+    F32 = 0,
+    F16 = 1,
+    Q4_0 = 2,
+    Q8_0 = 8,
+};
+
+class GgufWriter {
+public:
+    void set_str(const std::string& key, const std::string& val);
+    void set_u32(const std::string& key, uint32_t val);
+    void set_i32(const std::string& key, int32_t val);
+    void set_f32(const std::string& key, float val);
+    void set_bool(const std::string& key, bool val);
+    void set_arr_u32(const std::string& key, const std::vector<uint32_t>& vals);
+    void set_arr_i32(const std::string& key, const std::vector<int32_t>& vals);
+    void set_arr_f32(const std::string& key, const std::vector<float>& vals);
+    void set_arr_str(const std::string& key, const std::vector<std::string>& vals);
+
+    // ne is in ggml order: ne[0] is the fastest-varying (contiguous) dimension.
+    // data points to `nbytes` of tensor payload (already in `type`'s layout).
+    void add_tensor(const std::string& name, GgmlType type, const std::vector<int64_t>& ne,
+                    const void* data, uint64_t nbytes);
+
+    // Serialize to `path`. Throws std::runtime_error on I/O failure.
+    void write(const std::string& path, uint32_t alignment = 32) const;
+
+    size_t kv_count() const { return kvs_.size(); }
+    size_t tensor_count() const { return tensors_.size(); }
+
+private:
+    // gguf metadata value types (gguf.h gguf_type)
+    enum GgufType : uint32_t {
+        T_UINT8 = 0, T_INT8 = 1, T_UINT16 = 2, T_INT16 = 3,
+        T_UINT32 = 4, T_INT32 = 5, T_FLOAT32 = 6, T_BOOL = 7,
+        T_STRING = 8, T_ARRAY = 9, T_UINT64 = 10, T_INT64 = 11, T_FLOAT64 = 12,
+    };
+
+    struct Kv {
+        uint32_t type;            // GgufType
+        uint32_t arr_subtype;     // valid when type == T_ARRAY
+        std::vector<uint8_t> scalar_bytes;     // for scalar types
+        std::vector<std::string> str_values;   // for STRING (size 1) or ARRAY of STRING
+        std::vector<uint8_t> arr_bytes;         // for ARRAY of numeric
+        uint64_t arr_count = 0;
+    };
+    struct TensorInfo {
+        std::string name;
+        GgmlType type;
+        std::vector<int64_t> ne;
+        std::vector<uint8_t> data;
+    };
+
+    std::vector<std::pair<std::string, Kv>> kvs_;  // preserve insertion order
+    std::vector<TensorInfo> tensors_;
+
+    void put_scalar(const std::string& key, uint32_t type, const void* bytes, size_t n);
+};
+
+}  // namespace convert
+}  // namespace llmedge

--- a/llmedge/src/main/cpp/convert/hf_to_gguf.cpp
+++ b/llmedge/src/main/cpp/convert/hf_to_gguf.cpp
@@ -10,6 +10,7 @@
 #include "gguf_writer.h"
 #include "nlohmann/json.hpp"
 #include "safetensors_reader.h"
+#include "tokenizer_bake.h"
 
 namespace llmedge {
 namespace convert {
@@ -121,7 +122,8 @@ std::vector<uint8_t> permute_rows(const std::vector<uint8_t>& data, int64_t out_
 
 }  // namespace
 
-size_t convert_llama_dir(const std::string& model_dir, const std::string& out_path) {
+size_t convert_llama_dir(const std::string& model_dir, const std::string& out_path,
+                         const std::string& tokenizer_pre) {
     json cfg = json::parse(read_file(model_dir + "/config.json"));
     const std::string arch = cfg.value("model_type", "");
     if (arch != "llama") throw std::runtime_error("convert v1 supports model_type=llama only, got: " + arch);
@@ -204,6 +206,8 @@ size_t convert_llama_dir(const std::string& model_dir, const std::string& out_pa
         emit(p + "input_layernorm.weight", b + "attn_norm.weight", 0);
         emit(p + "post_attention_layernorm.weight", b + "ffn_norm.weight", 0);
     }
+
+    if (!tokenizer_pre.empty()) bake_gpt2_tokenizer(w, model_dir, tokenizer_pre);
 
     w.write(out_path, 32);
     return written;

--- a/llmedge/src/main/cpp/convert/hf_to_gguf.cpp
+++ b/llmedge/src/main/cpp/convert/hf_to_gguf.cpp
@@ -1,0 +1,213 @@
+#include "hf_to_gguf.h"
+
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "gguf_writer.h"
+#include "nlohmann/json.hpp"
+#include "safetensors_reader.h"
+
+namespace llmedge {
+namespace convert {
+
+using json = nlohmann::json;
+
+uint16_t f32_to_f16(float f) {
+    uint32_t x;
+    std::memcpy(&x, &f, 4);
+    uint32_t sign = (x >> 16) & 0x8000u;
+    int32_t exp = (int32_t)((x >> 23) & 0xff) - 127 + 15;
+    uint32_t mant = x & 0x7fffffu;
+    if (((x >> 23) & 0xff) == 0xff) {  // inf/nan
+        return (uint16_t)(sign | 0x7c00u | (mant ? 0x200u : 0));
+    }
+    if (exp >= 0x1f) return (uint16_t)(sign | 0x7c00u);  // overflow -> inf
+    if (exp <= 0) {
+        if (exp < -10) return (uint16_t)sign;  // underflow -> 0
+        mant |= 0x800000u;
+        uint32_t shift = (uint32_t)(14 - exp);
+        uint32_t half = mant >> shift;
+        uint32_t rem = mant & ((1u << shift) - 1);
+        uint32_t halfway = 1u << (shift - 1);
+        if (rem > halfway || (rem == halfway && (half & 1))) half++;  // round to nearest even
+        return (uint16_t)(sign | half);
+    }
+    uint16_t h = (uint16_t)(sign | ((uint32_t)exp << 10) | (mant >> 13));
+    uint32_t rem = mant & 0x1fffu;
+    if (rem > 0x1000u || (rem == 0x1000u && (h & 1))) h++;  // round to nearest even (may carry into exp)
+    return h;
+}
+
+uint16_t bf16_to_f16(uint16_t bf) {
+    uint32_t f32 = (uint32_t)bf << 16;
+    float f;
+    std::memcpy(&f, &f32, 4);
+    return f32_to_f16(f);
+}
+
+namespace {
+
+std::string read_file(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) throw std::runtime_error("convert: cannot read " + path);
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+// Convert a tensor's raw bytes to F16 (from BF16/F16/F32). Returns f16 bytes.
+std::vector<uint8_t> to_f16(const std::vector<uint8_t>& src, StDType dt, int64_t n) {
+    std::vector<uint8_t> out(n * 2);
+    uint16_t* o = (uint16_t*)out.data();
+    if (dt == StDType::BF16) {
+        const uint16_t* s = (const uint16_t*)src.data();
+        for (int64_t i = 0; i < n; ++i) o[i] = bf16_to_f16(s[i]);
+    } else if (dt == StDType::F16) {
+        std::memcpy(out.data(), src.data(), n * 2);
+    } else if (dt == StDType::F32) {
+        const float* s = (const float*)src.data();
+        for (int64_t i = 0; i < n; ++i) o[i] = f32_to_f16(s[i]);
+    } else {
+        throw std::runtime_error("convert: unsupported source dtype for f16");
+    }
+    return out;
+}
+
+// Convert a tensor's raw bytes to F32 (from BF16/F16/F32).
+std::vector<uint8_t> to_f32(const std::vector<uint8_t>& src, StDType dt, int64_t n) {
+    std::vector<uint8_t> out(n * 4);
+    float* o = (float*)out.data();
+    if (dt == StDType::BF16) {
+        const uint16_t* s = (const uint16_t*)src.data();
+        for (int64_t i = 0; i < n; ++i) {
+            uint32_t f = (uint32_t)s[i] << 16;
+            std::memcpy(&o[i], &f, 4);
+        }
+    } else if (dt == StDType::F32) {
+        std::memcpy(out.data(), src.data(), n * 4);
+    } else if (dt == StDType::F16) {
+        throw std::runtime_error("convert: f16->f32 not needed here");
+    } else {
+        throw std::runtime_error("convert: unsupported source dtype for f32");
+    }
+    return out;
+}
+
+// llama.cpp Q/K RoPE permutation, applied on a [out, in] row-major matrix.
+// out rows are grouped per head; within each head the two halves are interleaved.
+// Mirrors convert_hf_to_gguf.py LlamaModel.permute(weights, n_head).
+std::vector<uint8_t> permute_rows(const std::vector<uint8_t>& data, int64_t out_rows, int64_t in_cols,
+                                  size_t elt_size, int n_head) {
+    if (out_rows % n_head != 0) throw std::runtime_error("permute: out not divisible by n_head");
+    int64_t head_dim = out_rows / n_head;
+    if (head_dim % 2 != 0) throw std::runtime_error("permute: head_dim not even");
+    int64_t hd2 = head_dim / 2;
+    int64_t row_bytes = in_cols * (int64_t)elt_size;
+    std::vector<uint8_t> out(data.size());
+    for (int h = 0; h < n_head; ++h) {
+        for (int64_t a = 0; a < 2; ++a) {
+            for (int64_t j = 0; j < hd2; ++j) {
+                int64_t src_row = h * head_dim + a * hd2 + j;       // input layout (n_head,2,hd2)
+                int64_t dst_row = h * head_dim + j * 2 + a;          // output layout (n_head,hd2,2)
+                std::memcpy(out.data() + dst_row * row_bytes,
+                            data.data() + src_row * row_bytes, row_bytes);
+            }
+        }
+    }
+    return out;
+}
+
+}  // namespace
+
+size_t convert_llama_dir(const std::string& model_dir, const std::string& out_path) {
+    json cfg = json::parse(read_file(model_dir + "/config.json"));
+    const std::string arch = cfg.value("model_type", "");
+    if (arch != "llama") throw std::runtime_error("convert v1 supports model_type=llama only, got: " + arch);
+
+    const int n_embd = cfg.at("hidden_size");
+    const int n_layer = cfg.at("num_hidden_layers");
+    const int n_head = cfg.at("num_attention_heads");
+    const int n_head_kv = cfg.value("num_key_value_heads", n_head);
+    const int n_ff = cfg.at("intermediate_size");
+    const int n_vocab = cfg.at("vocab_size");
+    const int n_ctx = cfg.value("max_position_embeddings", 2048);
+    const float rms_eps = cfg.value("rms_norm_eps", 1e-5);
+    const float rope_theta = cfg.value("rope_theta", 10000.0);
+    const int head_dim = n_embd / n_head;
+
+    SafetensorsFile st = read_safetensors_header(model_dir + "/model.safetensors");
+
+    GgufWriter w;
+    w.set_str("general.architecture", "llama");
+    w.set_str("general.name", "converted");
+    w.set_u32("llama.context_length", (uint32_t)n_ctx);
+    w.set_u32("llama.embedding_length", (uint32_t)n_embd);
+    w.set_u32("llama.block_count", (uint32_t)n_layer);
+    w.set_u32("llama.feed_forward_length", (uint32_t)n_ff);
+    w.set_u32("llama.attention.head_count", (uint32_t)n_head);
+    w.set_u32("llama.attention.head_count_kv", (uint32_t)n_head_kv);
+    w.set_f32("llama.attention.layer_norm_rms_epsilon", rms_eps);
+    w.set_u32("llama.rope.dimension_count", (uint32_t)head_dim);
+    w.set_f32("llama.rope.freq_base", rope_theta);
+    w.set_u32("llama.vocab_size", (uint32_t)n_vocab);
+
+    auto find = [&](const std::string& name) -> const StTensor* {
+        for (const auto& t : st.tensors)
+            if (t.name == name) return &t;
+        return nullptr;
+    };
+
+    // Emit one tensor: name mapping handled by caller; perm_heads>0 applies Q/K permutation;
+    // 1-D tensors stay F32, 2-D weights become F16 (values compared dtype-agnostically by the oracle).
+    size_t written = 0;
+    auto emit = [&](const std::string& hf_name, const std::string& gguf_name, int perm_heads) {
+        const StTensor* t = find(hf_name);
+        if (!t) throw std::runtime_error("convert: missing tensor " + hf_name);
+        int64_t n = st_num_elements(*t);
+        std::vector<uint8_t> raw = st_read_tensor_bytes(st, *t);
+        const bool is_1d = t->shape.size() == 1;
+
+        if (perm_heads > 0) {
+            int64_t out_rows = t->shape[0], in_cols = t->shape[1];
+            raw = permute_rows(raw, out_rows, in_cols, st_dtype_size(t->dtype), perm_heads);
+        }
+
+        std::vector<int64_t> ne;  // ggml order: ne[0] = fastest (in), ne[1] = out
+        for (auto it = t->shape.rbegin(); it != t->shape.rend(); ++it) ne.push_back(*it);
+
+        if (is_1d) {
+            std::vector<uint8_t> f32 = to_f32(raw, t->dtype, n);
+            w.add_tensor(gguf_name, GgmlType::F32, ne, f32.data(), f32.size());
+        } else {
+            std::vector<uint8_t> f16 = to_f16(raw, t->dtype, n);
+            w.add_tensor(gguf_name, GgmlType::F16, ne, f16.data(), f16.size());
+        }
+        ++written;
+    };
+
+    emit("model.embed_tokens.weight", "token_embd.weight", 0);
+    emit("model.norm.weight", "output_norm.weight", 0);
+    if (find("lm_head.weight")) emit("lm_head.weight", "output.weight", 0);  // absent when tied
+
+    for (int i = 0; i < n_layer; ++i) {
+        const std::string p = "model.layers." + std::to_string(i) + ".";
+        const std::string b = "blk." + std::to_string(i) + ".";
+        emit(p + "self_attn.q_proj.weight", b + "attn_q.weight", n_head);
+        emit(p + "self_attn.k_proj.weight", b + "attn_k.weight", n_head_kv);
+        emit(p + "self_attn.v_proj.weight", b + "attn_v.weight", 0);
+        emit(p + "self_attn.o_proj.weight", b + "attn_output.weight", 0);
+        emit(p + "mlp.gate_proj.weight", b + "ffn_gate.weight", 0);
+        emit(p + "mlp.up_proj.weight", b + "ffn_up.weight", 0);
+        emit(p + "mlp.down_proj.weight", b + "ffn_down.weight", 0);
+        emit(p + "input_layernorm.weight", b + "attn_norm.weight", 0);
+        emit(p + "post_attention_layernorm.weight", b + "ffn_norm.weight", 0);
+    }
+
+    w.write(out_path, 32);
+    return written;
+}
+
+}  // namespace convert
+}  // namespace llmedge

--- a/llmedge/src/main/cpp/convert/hf_to_gguf.h
+++ b/llmedge/src/main/cpp/convert/hf_to_gguf.h
@@ -1,0 +1,23 @@
+// HF (Llama-family) safetensors -> GGUF orchestrator for the on-device converter (Track B / Phase B2).
+//
+// v1 scope: Llama architecture, tensors + hyperparameters. Tokenizer is NOT baked here (Layer 4); the
+// resulting GGUF carries tensors + llama.* KVs only. Verified against the upstream convert_hf_to_gguf.py
+// output by a tensor-by-tensor value diff (see test_convert.cpp + compare_gguf.py).
+#pragma once
+
+#include <string>
+
+namespace llmedge {
+namespace convert {
+
+// Convert a Llama-arch HF model directory (config.json + *.safetensors) to a GGUF at out_path.
+// Throws std::runtime_error on unsupported architecture or malformed input.
+// Returns the number of tensors written.
+size_t convert_llama_dir(const std::string& model_dir, const std::string& out_path);
+
+// fp32 -> fp16 (round to nearest even) and bf16 -> fp16, exposed for tests.
+uint16_t f32_to_f16(float f);
+uint16_t bf16_to_f16(uint16_t bf);
+
+}  // namespace convert
+}  // namespace llmedge

--- a/llmedge/src/main/cpp/convert/hf_to_gguf.h
+++ b/llmedge/src/main/cpp/convert/hf_to_gguf.h
@@ -1,8 +1,9 @@
 // HF (Llama-family) safetensors -> GGUF orchestrator for the on-device converter (Track B / Phase B2).
 //
-// v1 scope: Llama architecture, tensors + hyperparameters. Tokenizer is NOT baked here (Layer 4); the
-// resulting GGUF carries tensors + llama.* KVs only. Verified against the upstream convert_hf_to_gguf.py
-// output by a tensor-by-tensor value diff (see test_convert.cpp + compare_gguf.py).
+// v1 scope: Llama architecture (tensors + hyperparameters, Layer 3) plus a baked GPT2-BPE tokenizer
+// (Layer 4) when `tokenizer_pre` is supplied. Tensors are verified against the upstream
+// convert_hf_to_gguf.py output by a tensor-by-tensor value diff; tokenizer KVs by a KV diff
+// (see test_convert.cpp + compare_gguf.py + compare_tokenizer_kv.py).
 #pragma once
 
 #include <string>
@@ -11,9 +12,15 @@ namespace llmedge {
 namespace convert {
 
 // Convert a Llama-arch HF model directory (config.json + *.safetensors) to a GGUF at out_path.
+//
+// When `tokenizer_pre` is non-empty, the GPT2-BPE tokenizer is also baked from tokenizer.json /
+// tokenizer_config.json (see tokenizer_bake.h for why `pre` must be caller-supplied). When it is
+// empty, only tensors + llama.* hparams are written (the Layer 3 tensor-only path).
+//
 // Throws std::runtime_error on unsupported architecture or malformed input.
 // Returns the number of tensors written.
-size_t convert_llama_dir(const std::string& model_dir, const std::string& out_path);
+size_t convert_llama_dir(const std::string& model_dir, const std::string& out_path,
+                         const std::string& tokenizer_pre = "");
 
 // fp32 -> fp16 (round to nearest even) and bf16 -> fp16, exposed for tests.
 uint16_t f32_to_f16(float f);

--- a/llmedge/src/main/cpp/convert/hf_to_gguf.h
+++ b/llmedge/src/main/cpp/convert/hf_to_gguf.h
@@ -1,9 +1,10 @@
 // HF (Llama-family) safetensors -> GGUF orchestrator for the on-device converter (Track B / Phase B2).
 //
 // v1 scope: Llama architecture (tensors + hyperparameters, Layer 3) plus a baked GPT2-BPE tokenizer
-// (Layer 4) when `tokenizer_pre` is supplied. Tensors are verified against the upstream
-// convert_hf_to_gguf.py output by a tensor-by-tensor value diff; tokenizer KVs by a KV diff
-// (see test_convert.cpp + compare_gguf.py + compare_tokenizer_kv.py).
+// (Layer 4) when `tokenizer_pre` is supplied. Output is F16; quantization (Layer 6) is applied by the
+// JNI wrapper via llama_model_quantize, not here, so this stays ggml/llama-free and host-testable.
+// Tensors are verified against the upstream convert_hf_to_gguf.py output by a tensor-by-tensor value
+// diff; tokenizer KVs by a KV diff (see test_convert.cpp + compare_gguf.py + compare_tokenizer_kv.py).
 #pragma once
 
 #include <string>

--- a/llmedge/src/main/cpp/convert/safetensors_reader.cpp
+++ b/llmedge/src/main/cpp/convert/safetensors_reader.cpp
@@ -1,0 +1,145 @@
+#include "safetensors_reader.h"
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <stdexcept>
+
+#include "nlohmann/json.hpp"
+
+namespace llmedge {
+namespace convert {
+
+using json = nlohmann::json;
+
+size_t st_dtype_size(StDType d) {
+    switch (d) {
+        case StDType::F64:
+        case StDType::I64: return 8;
+        case StDType::F32:
+        case StDType::I32: return 4;
+        case StDType::F16:
+        case StDType::BF16:
+        case StDType::I16: return 2;
+        case StDType::I8:
+        case StDType::U8:
+        case StDType::BOOL: return 1;
+        default: return 0;
+    }
+}
+
+const char* st_dtype_name(StDType d) {
+    switch (d) {
+        case StDType::F64: return "F64";
+        case StDType::F32: return "F32";
+        case StDType::F16: return "F16";
+        case StDType::BF16: return "BF16";
+        case StDType::I64: return "I64";
+        case StDType::I32: return "I32";
+        case StDType::I16: return "I16";
+        case StDType::I8: return "I8";
+        case StDType::U8: return "U8";
+        case StDType::BOOL: return "BOOL";
+        default: return "UNKNOWN";
+    }
+}
+
+StDType st_dtype_from_string(const std::string& s) {
+    if (s == "F64") return StDType::F64;
+    if (s == "F32") return StDType::F32;
+    if (s == "F16") return StDType::F16;
+    if (s == "BF16") return StDType::BF16;
+    if (s == "I64") return StDType::I64;
+    if (s == "I32") return StDType::I32;
+    if (s == "I16") return StDType::I16;
+    if (s == "I8") return StDType::I8;
+    if (s == "U8") return StDType::U8;
+    if (s == "BOOL") return StDType::BOOL;
+    return StDType::UNKNOWN;
+}
+
+int64_t st_num_elements(const StTensor& t) {
+    int64_t n = 1;
+    for (int64_t d : t.shape) n *= d;
+    return t.shape.empty() ? 0 : n;
+}
+
+uint64_t st_tensor_nbytes(const StTensor& t) {
+    return t.data_end - t.data_begin;
+}
+
+SafetensorsFile read_safetensors_header(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) throw std::runtime_error("safetensors: cannot open " + path);
+
+    uint64_t header_len = 0;
+    in.read(reinterpret_cast<char*>(&header_len), 8);
+    if (!in || in.gcount() != 8) throw std::runtime_error("safetensors: truncated length prefix");
+    // safetensors is little-endian; assume host is LE (Android/ARM/x86 all are).
+    if (header_len == 0 || header_len > (1ull << 32)) {
+        throw std::runtime_error("safetensors: implausible header length");
+    }
+
+    std::string header_json(static_cast<size_t>(header_len), '\0');
+    in.read(header_json.data(), static_cast<std::streamsize>(header_len));
+    if (!in || static_cast<uint64_t>(in.gcount()) != header_len) {
+        throw std::runtime_error("safetensors: truncated header");
+    }
+
+    json hdr;
+    try {
+        hdr = json::parse(header_json);
+    } catch (const std::exception& e) {
+        throw std::runtime_error(std::string("safetensors: header is not valid JSON: ") + e.what());
+    }
+    if (!hdr.is_object()) throw std::runtime_error("safetensors: header is not a JSON object");
+
+    SafetensorsFile out;
+    out.path = path;
+    out.data_blob_start = 8 + header_len;
+
+    for (auto it = hdr.begin(); it != hdr.end(); ++it) {
+        const std::string& name = it.key();
+        if (name == "__metadata__") {
+            if (it.value().is_object() && it.value().contains("format")) {
+                out.metadata_format = it.value()["format"].get<std::string>();
+            }
+            continue;
+        }
+        const json& v = it.value();
+        if (!v.is_object() || !v.contains("dtype") || !v.contains("shape") || !v.contains("data_offsets")) {
+            throw std::runtime_error("safetensors: malformed entry for tensor '" + name + "'");
+        }
+        StTensor t;
+        t.name = name;
+        t.dtype = st_dtype_from_string(v["dtype"].get<std::string>());
+        for (const auto& d : v["shape"]) t.shape.push_back(d.get<int64_t>());
+        const auto& off = v["data_offsets"];
+        if (!off.is_array() || off.size() != 2) {
+            throw std::runtime_error("safetensors: bad data_offsets for '" + name + "'");
+        }
+        t.data_begin = off[0].get<uint64_t>();
+        t.data_end = off[1].get<uint64_t>();
+        if (t.data_end < t.data_begin) {
+            throw std::runtime_error("safetensors: negative-length region for '" + name + "'");
+        }
+        out.tensors.push_back(std::move(t));
+    }
+    return out;
+}
+
+std::vector<uint8_t> st_read_tensor_bytes(const SafetensorsFile& f, const StTensor& t) {
+    const uint64_t nbytes = st_tensor_nbytes(t);
+    std::ifstream in(f.path, std::ios::binary);
+    if (!in) throw std::runtime_error("safetensors: cannot reopen " + f.path);
+    in.seekg(static_cast<std::streamoff>(f.data_blob_start + t.data_begin));
+    std::vector<uint8_t> buf(static_cast<size_t>(nbytes));
+    in.read(reinterpret_cast<char*>(buf.data()), static_cast<std::streamsize>(nbytes));
+    if (!in || static_cast<uint64_t>(in.gcount()) != nbytes) {
+        throw std::runtime_error("safetensors: truncated tensor data for '" + t.name + "'");
+    }
+    return buf;
+}
+
+}  // namespace convert
+}  // namespace llmedge

--- a/llmedge/src/main/cpp/convert/safetensors_reader.h
+++ b/llmedge/src/main/cpp/convert/safetensors_reader.h
@@ -1,0 +1,46 @@
+// Minimal safetensors reader for the on-device HF -> GGUF converter (Track B / Phase B2).
+//
+// safetensors layout: [u64 little-endian header_len][header_len bytes of JSON][tensor data blob].
+// The JSON header maps each tensor name to {dtype, shape, data_offsets:[begin,end]} where the offsets
+// are relative to the start of the data blob (i.e. file offset 8 + header_len).
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace llmedge {
+namespace convert {
+
+enum class StDType { F64, F32, F16, BF16, I64, I32, I16, I8, U8, BOOL, UNKNOWN };
+
+struct StTensor {
+    std::string name;
+    StDType dtype = StDType::UNKNOWN;
+    std::vector<int64_t> shape;
+    uint64_t data_begin = 0;  // relative to the data blob
+    uint64_t data_end = 0;
+};
+
+struct SafetensorsFile {
+    std::string path;
+    uint64_t data_blob_start = 0;  // absolute file offset where tensor data begins (8 + header_len)
+    std::string metadata_format;   // __metadata__.format, if present
+    std::vector<StTensor> tensors; // in declaration order
+};
+
+size_t st_dtype_size(StDType d);
+const char* st_dtype_name(StDType d);
+StDType st_dtype_from_string(const std::string& s);
+
+int64_t st_num_elements(const StTensor& t);
+uint64_t st_tensor_nbytes(const StTensor& t);
+
+// Parse only the header (no tensor data read). Throws std::runtime_error on malformed input.
+SafetensorsFile read_safetensors_header(const std::string& path);
+
+// Read a tensor's raw bytes from disk. Throws if the file is shorter than the tensor's region.
+std::vector<uint8_t> st_read_tensor_bytes(const SafetensorsFile& f, const StTensor& t);
+
+}  // namespace convert
+}  // namespace llmedge

--- a/llmedge/src/main/cpp/convert/test_convert.cpp
+++ b/llmedge/src/main/cpp/convert/test_convert.cpp
@@ -1,16 +1,19 @@
-// CLI: convert a Llama HF dir -> GGUF.   test_convert <model_dir> <out.gguf>
+// CLI: convert a Llama HF dir -> GGUF.   test_convert <model_dir> <out.gguf> [tokenizer_pre]
+// When tokenizer_pre is given (e.g. "smollm"), the GPT2-BPE tokenizer is baked in too (Layer 4).
 #include <cstdio>
 
 #include "hf_to_gguf.h"
 
 int main(int argc, char** argv) {
     if (argc < 3) {
-        std::fprintf(stderr, "usage: %s <model_dir> <out.gguf>\n", argv[0]);
+        std::fprintf(stderr, "usage: %s <model_dir> <out.gguf> [tokenizer_pre]\n", argv[0]);
         return 2;
     }
+    const std::string pre = argc > 3 ? argv[3] : "";
     try {
-        size_t n = llmedge::convert::convert_llama_dir(argv[1], argv[2]);
-        std::printf("converted %zu tensors -> %s\n", n, argv[2]);
+        size_t n = llmedge::convert::convert_llama_dir(argv[1], argv[2], pre);
+        std::printf("converted %zu tensors -> %s%s\n", n, argv[2],
+                    pre.empty() ? "" : " (+tokenizer)");
         return 0;
     } catch (const std::exception& e) {
         std::fprintf(stderr, "convert failed: %s\n", e.what());

--- a/llmedge/src/main/cpp/convert/test_convert.cpp
+++ b/llmedge/src/main/cpp/convert/test_convert.cpp
@@ -1,0 +1,19 @@
+// CLI: convert a Llama HF dir -> GGUF.   test_convert <model_dir> <out.gguf>
+#include <cstdio>
+
+#include "hf_to_gguf.h"
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: %s <model_dir> <out.gguf>\n", argv[0]);
+        return 2;
+    }
+    try {
+        size_t n = llmedge::convert::convert_llama_dir(argv[1], argv[2]);
+        std::printf("converted %zu tensors -> %s\n", n, argv[2]);
+        return 0;
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "convert failed: %s\n", e.what());
+        return 1;
+    }
+}

--- a/llmedge/src/main/cpp/convert/test_gguf_writer.cpp
+++ b/llmedge/src/main/cpp/convert/test_gguf_writer.cpp
@@ -1,0 +1,30 @@
+// Writes a sample GGUF with GgufWriter; verified by the canonical gguf-py reader (verify_gguf.py).
+//   clang++ -std=c++17 -I . test_gguf_writer.cpp gguf_writer.cpp -o /tmp/gguf_test && /tmp/gguf_test
+#include <cstdio>
+#include <vector>
+
+#include "gguf_writer.h"
+
+using namespace llmedge::convert;
+
+int main() {
+    GgufWriter w;
+    w.set_str("general.architecture", "llama");
+    w.set_u32("llama.block_count", 16);
+    w.set_u32("llama.context_length", 2048);
+    w.set_f32("llama.attention.layer_norm_rms_epsilon", 1e-5f);
+    w.set_bool("test.flag", true);
+    w.set_arr_u32("test.arr_u32", {10, 20, 30});
+    w.set_arr_str("tokenizer.ggml.tokens", {"<s>", "hello", "world"});
+
+    // ggml order ne[0]=3 (fastest/contiguous), ne[1]=2 -> 6 F32 elements.
+    std::vector<float> data = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    w.add_tensor("token_embd.weight", GgmlType::F32, {3, 2}, data.data(), data.size() * 4);
+
+    std::vector<float> norm = {0.5f, 0.25f};
+    w.add_tensor("output_norm.weight", GgmlType::F32, {2}, norm.data(), norm.size() * 4);
+
+    w.write("/tmp/test_write.gguf", 32);
+    std::printf("wrote /tmp/test_write.gguf (kv=%zu tensors=%zu)\n", w.kv_count(), w.tensor_count());
+    return 0;
+}

--- a/llmedge/src/main/cpp/convert/test_safetensors_reader.cpp
+++ b/llmedge/src/main/cpp/convert/test_safetensors_reader.cpp
@@ -1,0 +1,111 @@
+// Standalone host test for safetensors_reader. Build:
+//   clang++ -std=c++17 -I . -I ../../../../../../llama.cpp/vendor \
+//     test_safetensors_reader.cpp safetensors_reader.cpp -o /tmp/streader_test && /tmp/streader_test
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+#include "safetensors_reader.h"
+
+using namespace llmedge::convert;
+using json = nlohmann::json;
+
+static int g_failures = 0;
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::printf("FAIL: %s (line %d)\n", #cond, __LINE__);              \
+            ++g_failures;                                                      \
+        }                                                                      \
+    } while (0)
+
+static std::string write_synth(const std::string& path) {
+    // Two tensors: F32 [2,3] (24 bytes), BF16 [4] (8 bytes). Data blob = 32 bytes.
+    json hdr;
+    hdr["t_f32"] = {{"dtype", "F32"}, {"shape", {2, 3}}, {"data_offsets", {0, 24}}};
+    hdr["t_bf16"] = {{"dtype", "BF16"}, {"shape", {4}}, {"data_offsets", {24, 32}}};
+    hdr["__metadata__"] = {{"format", "pt"}};
+    std::string js = hdr.dump();
+
+    std::vector<float> f32 = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    std::vector<uint16_t> bf16 = {0x3f80, 0x4000, 0x4040, 0x4080};  // bf16 for 1,2,3,4
+
+    std::ofstream out(path, std::ios::binary);
+    uint64_t n = js.size();
+    out.write(reinterpret_cast<const char*>(&n), 8);
+    out.write(js.data(), static_cast<std::streamsize>(js.size()));
+    out.write(reinterpret_cast<const char*>(f32.data()), 24);
+    out.write(reinterpret_cast<const char*>(bf16.data()), 8);
+    out.close();
+    return path;
+}
+
+static const StTensor& find(const SafetensorsFile& f, const std::string& name) {
+    for (const auto& t : f.tensors)
+        if (t.name == name) return t;
+    throw std::runtime_error("tensor not found: " + name);
+}
+
+int main() {
+    const std::string path = "/tmp/synth.safetensors";
+    write_synth(path);
+
+    SafetensorsFile f = read_safetensors_header(path);
+    CHECK(f.tensors.size() == 2);
+    CHECK(f.metadata_format == "pt");
+
+    const StTensor& a = find(f, "t_f32");
+    CHECK(a.dtype == StDType::F32);
+    CHECK(a.shape.size() == 2 && a.shape[0] == 2 && a.shape[1] == 3);
+    CHECK(st_num_elements(a) == 6);
+    CHECK(st_tensor_nbytes(a) == 24);
+    CHECK(st_dtype_size(a.dtype) == 4);
+
+    const StTensor& b = find(f, "t_bf16");
+    CHECK(b.dtype == StDType::BF16);
+    CHECK(b.shape.size() == 1 && b.shape[0] == 4);
+    CHECK(st_tensor_nbytes(b) == 8);
+    CHECK(st_dtype_size(b.dtype) == 2);
+
+    // Data round-trips.
+    auto bytes_a = st_read_tensor_bytes(f, a);
+    CHECK(bytes_a.size() == 24);
+    float first = 0.f;
+    std::memcpy(&first, bytes_a.data(), 4);
+    CHECK(first == 1.f);
+    float last = 0.f;
+    std::memcpy(&last, bytes_a.data() + 20, 4);
+    CHECK(last == 6.f);
+
+    auto bytes_b = st_read_tensor_bytes(f, b);
+    CHECK(bytes_b.size() == 8);
+    uint16_t bf0 = 0;
+    std::memcpy(&bf0, bytes_b.data(), 2);
+    CHECK(bf0 == 0x3f80);
+
+    // Malformed: truncated length prefix.
+    {
+        std::ofstream bad("/tmp/bad.safetensors", std::ios::binary);
+        bad.write("\x03\x00", 2);
+        bad.close();
+        bool threw = false;
+        try {
+            read_safetensors_header("/tmp/bad.safetensors");
+        } catch (const std::exception&) {
+            threw = true;
+        }
+        CHECK(threw);
+    }
+
+    if (g_failures == 0) {
+        std::printf("OK: all safetensors_reader checks passed\n");
+        return 0;
+    }
+    std::printf("%d check(s) failed\n", g_failures);
+    return 1;
+}

--- a/llmedge/src/main/cpp/convert/tokenizer_bake.cpp
+++ b/llmedge/src/main/cpp/convert/tokenizer_bake.cpp
@@ -1,0 +1,149 @@
+#include "tokenizer_bake.h"
+
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gguf_writer.h"
+#include "nlohmann/json.hpp"
+
+namespace llmedge {
+namespace convert {
+
+using json = nlohmann::json;
+
+namespace {
+
+// GGUF token types (gguf.TokenType in gguf-py / llama.cpp llama_token_type).
+constexpr int32_t TOKEN_TYPE_NORMAL = 1;
+constexpr int32_t TOKEN_TYPE_CONTROL = 3;
+
+std::string read_file(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) throw std::runtime_error("tokenizer: cannot read " + path);
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+// A token's content can be stored as a bare string or as an object {"content": "...", ...}.
+std::string token_content(const json& v) {
+    if (v.is_string()) return v.get<std::string>();
+    if (v.is_object() && v.contains("content") && v["content"].is_string()) return v["content"].get<std::string>();
+    return std::string();
+}
+
+bool get_bool(const json& o, const char* key, bool def) {
+    return (o.contains(key) && o[key].is_boolean()) ? o[key].get<bool>() : def;
+}
+
+}  // namespace
+
+void bake_gpt2_tokenizer(GgufWriter& w, const std::string& model_dir, const std::string& pre) {
+    if (pre.empty()) {
+        throw std::runtime_error(
+            "tokenizer: tokenizer.ggml.pre hint is required (e.g. \"smollm\"); refusing to guess "
+            "(a wrong pre-tokenizer loads silently and mis-tokenizes)");
+    }
+
+    json tj = json::parse(read_file(model_dir + "/tokenizer.json"));
+    const json& model = tj.at("model");
+    const std::string type = model.value("type", "");
+    if (type != "BPE") {
+        throw std::runtime_error("tokenizer: v1 bakes BPE tokenizers only, got model.type=" + type);
+    }
+
+    // ---- vocab: {token -> id}, must cover ids 0..N-1 contiguously ----
+    const json& vocab = model.at("vocab");
+    const int n = (int)vocab.size();
+    std::vector<std::string> tokens(n);
+    std::vector<bool> seen(n, false);
+    for (auto it = vocab.begin(); it != vocab.end(); ++it) {
+        const int id = it.value().get<int>();
+        if (id < 0 || id >= n) throw std::runtime_error("tokenizer: vocab id out of range: " + std::to_string(id));
+        if (seen[id]) throw std::runtime_error("tokenizer: duplicate vocab id: " + std::to_string(id));
+        tokens[id] = it.key();
+        seen[id] = true;
+    }
+    for (int i = 0; i < n; ++i) {
+        if (!seen[i]) throw std::runtime_error("tokenizer: vocab ids not contiguous (gap at " + std::to_string(i) + ")");
+    }
+
+    // ---- token_type: NORMAL, overridden to CONTROL for special added tokens ----
+    std::vector<int32_t> token_type(n, TOKEN_TYPE_NORMAL);
+    if (tj.contains("added_tokens")) {
+        for (const json& at : tj["added_tokens"]) {
+            const int id = at.at("id").get<int>();
+            if (id < 0 || id >= n) {
+                throw std::runtime_error("tokenizer: added token id out of range: " + std::to_string(id));
+            }
+            const std::string content = at.value("content", std::string());
+            if (!content.empty() && tokens[id] != content) {
+                throw std::runtime_error("tokenizer: added token content mismatch at id " + std::to_string(id));
+            }
+            if (at.value("special", false)) token_type[id] = TOKEN_TYPE_CONTROL;
+        }
+    }
+
+    // ---- merges: space-joined string pairs, verbatim ----
+    const json& merges_j = model.at("merges");
+    std::vector<std::string> merges;
+    merges.reserve(merges_j.size());
+    for (const json& m : merges_j) {
+        if (!m.is_string()) {
+            throw std::runtime_error(
+                "tokenizer: v1 expects space-joined string merges; got the array-pair form (unsupported)");
+        }
+        merges.push_back(m.get<std::string>());
+    }
+
+    // ---- special-token ids + flags + chat template from tokenizer_config.json (+ special_tokens_map) ----
+    json cfg = json::parse(read_file(model_dir + "/tokenizer_config.json"));
+    json stm;
+    {
+        std::ifstream stm_in(model_dir + "/special_tokens_map.json", std::ios::binary);
+        if (stm_in) stm = json::parse(std::string((std::istreambuf_iterator<char>(stm_in)), std::istreambuf_iterator<char>()));
+    }
+
+    std::unordered_map<std::string, int> tok2id;
+    tok2id.reserve(n * 2);
+    for (int i = 0; i < n; ++i) tok2id.emplace(tokens[i], i);
+
+    // Resolve a special token's id by its content string, preferring tokenizer_config then special_tokens_map.
+    auto resolve_id = [&](const char* key) -> long {
+        std::string content;
+        if (cfg.contains(key)) content = token_content(cfg[key]);
+        if (content.empty() && stm.is_object() && stm.contains(key)) content = token_content(stm[key]);
+        if (content.empty()) return -1;
+        auto found = tok2id.find(content);
+        return found == tok2id.end() ? -1 : (long)found->second;
+    };
+    const long bos = resolve_id("bos_token");
+    const long eos = resolve_id("eos_token");
+    const long unk = resolve_id("unk_token");
+    const long pad = resolve_id("pad_token");
+
+    const bool add_bos = get_bool(cfg, "add_bos_token", false);
+    const bool add_space_prefix = get_bool(cfg, "add_prefix_space", false);
+
+    // ---- emit ----
+    w.set_str("tokenizer.ggml.model", "gpt2");
+    w.set_str("tokenizer.ggml.pre", pre);
+    w.set_arr_str("tokenizer.ggml.tokens", tokens);
+    w.set_arr_i32("tokenizer.ggml.token_type", token_type);
+    w.set_arr_str("tokenizer.ggml.merges", merges);
+    if (bos >= 0) w.set_u32("tokenizer.ggml.bos_token_id", (uint32_t)bos);
+    if (eos >= 0) w.set_u32("tokenizer.ggml.eos_token_id", (uint32_t)eos);
+    if (unk >= 0) w.set_u32("tokenizer.ggml.unknown_token_id", (uint32_t)unk);
+    if (pad >= 0) w.set_u32("tokenizer.ggml.padding_token_id", (uint32_t)pad);
+    w.set_bool("tokenizer.ggml.add_space_prefix", add_space_prefix);
+    w.set_bool("tokenizer.ggml.add_bos_token", add_bos);
+
+    if (cfg.contains("chat_template") && cfg["chat_template"].is_string()) {
+        w.set_str("tokenizer.chat_template", cfg["chat_template"].get<std::string>());
+    }
+}
+
+}  // namespace convert
+}  // namespace llmedge

--- a/llmedge/src/main/cpp/convert/tokenizer_bake.h
+++ b/llmedge/src/main/cpp/convert/tokenizer_bake.h
@@ -1,0 +1,28 @@
+// Layer 4 of the on-device HF -> GGUF converter: bake a GPT2-BPE tokenizer into the GGUF KV store.
+//
+// Reads tokenizer.json / tokenizer_config.json (+ optional special_tokens_map.json) from a HF model
+// dir and emits the `tokenizer.ggml.*` + `tokenizer.chat_template` keys that llama.cpp expects.
+//
+// SCOPE (v1): byte-level BPE only (model.type == "BPE", space-joined string merges). Anything else
+// fails loudly rather than emitting a tokenizer that loads but mis-tokenizes.
+#pragma once
+
+#include <string>
+
+namespace llmedge {
+namespace convert {
+
+class GgufWriter;
+
+// Bake the tokenizer KVs into `w`.
+//
+// `pre` is the value for `tokenizer.ggml.pre` (the BPE pre-tokenizer identifier, e.g. "smollm").
+// It MUST be supplied by the caller and non-empty: upstream derives it by hashing the output of the
+// real tokenizer over a probe string, which we do not reimplement in v1. A wrong/guessed `pre` loads
+// without error and silently mis-tokenizes, so we refuse to guess and throw when it is empty.
+//
+// Throws std::runtime_error on a missing file, an unsupported tokenizer, or a malformed vocab.
+void bake_gpt2_tokenizer(GgufWriter& w, const std::string& model_dir, const std::string& pre);
+
+}  // namespace convert
+}  // namespace llmedge

--- a/llmedge/src/main/cpp/convert/verify_gguf.py
+++ b/llmedge/src/main/cpp/convert/verify_gguf.py
@@ -1,0 +1,51 @@
+"""Verify a GGUF written by GgufWriter using the canonical gguf-py reader.
+
+    python verify_gguf.py /tmp/test_write.gguf <repo_root>
+"""
+import sys
+import numpy as np
+
+path = sys.argv[1]
+repo_root = sys.argv[2] if len(sys.argv) > 2 else "."
+sys.path.insert(0, f"{repo_root}/llama.cpp/gguf-py")
+
+from gguf import GGUFReader  # noqa: E402
+
+r = GGUFReader(path)
+failures = 0
+
+
+def check(cond, msg):
+    global failures
+    if not cond:
+        print("FAIL:", msg)
+        failures += 1
+
+
+keys = set(r.fields.keys())
+for k in [
+    "general.architecture", "llama.block_count", "llama.context_length",
+    "llama.attention.layer_norm_rms_epsilon", "test.flag", "test.arr_u32",
+    "tokenizer.ggml.tokens",
+]:
+    check(k in keys, f"missing KV {k}")
+
+tensors = {t.name: t for t in r.tensors}
+check("token_embd.weight" in tensors, "missing tensor token_embd.weight")
+check("output_norm.weight" in tensors, "missing tensor output_norm.weight")
+
+if "token_embd.weight" in tensors:
+    t = tensors["token_embd.weight"]
+    check(int(np.prod(t.shape)) == 6, f"token_embd element count {list(t.shape)}")
+    check(np.allclose(np.array(t.data).flatten(), [1, 2, 3, 4, 5, 6]),
+          f"token_embd data {np.array(t.data).flatten()}")
+if "output_norm.weight" in tensors:
+    t = tensors["output_norm.weight"]
+    check(np.allclose(np.array(t.data).flatten(), [0.5, 0.25]),
+          f"output_norm data {np.array(t.data).flatten()}")
+
+if failures == 0:
+    print("OK: gguf-py read the GgufWriter output; KVs + tensors verified")
+    sys.exit(0)
+print(f"{failures} check(s) failed")
+sys.exit(1)

--- a/llmedge/src/main/cpp/smollm_jni_convert.cpp
+++ b/llmedge/src/main/cpp/smollm_jni_convert.cpp
@@ -1,17 +1,51 @@
-// JNI bridge for the on-device safetensors -> GGUF converter (Track B / Phase B2, Layer 5).
+// JNI bridge for the on-device safetensors -> GGUF converter (Track B / Phase B2, Layers 5-6).
 //
 // Exposes io.aatricks.llmedge.text.runtime.SmolLM.nativeConvertSafetensors as a static native method.
-// The heavy lifting lives in llmedge::convert (convert/*.cpp), which has no JNI dependency and is
-// host-testable on its own; this file is only the thin JNI marshalling layer.
+// The architecture/tensor/tokenizer conversion lives in llmedge::convert (convert/*.cpp), which has no
+// ggml/llama dependency and is host-testable on its own. Quantization (Layer 6) is layered on here in
+// the JNI wrapper, where the linked llama runtime's llama_model_quantize is available: F16 conversion
+// happens first, then the result is requantized to the requested precision.
+#include <cstdio>
+#include <string>
+
 #include "convert/hf_to_gguf.h"
+#include "llama.h"
 #include "smollm_jni_shared.h"
 
+namespace {
+
+// Map a ConversionPrecision.ggufLabel to a llama_ftype. Returns false for "f16" / unknown labels;
+// the caller treats "f16" as "no quantization" and any other unknown label as an error.
+bool ftypeForLabel(const std::string& label, llama_ftype& out) {
+    if (label == "q8_0") {
+        out = LLAMA_FTYPE_MOSTLY_Q8_0;
+        return true;
+    }
+    if (label == "q4_k_m") {
+        out = LLAMA_FTYPE_MOSTLY_Q4_K_M;
+        return true;
+    }
+    if (label == "iq2_bn") {
+        out = LLAMA_FTYPE_MOSTLY_IQ2_BN;
+        return true;
+    }
+    if (label == "iq2_bn_r4") {
+        out = LLAMA_FTYPE_MOSTLY_IQ2_BN_R4;
+        return true;
+    }
+    return false;
+}
+
+}  // namespace
+
 extern "C" JNIEXPORT void JNICALL Java_io_aatricks_llmedge_text_runtime_SmolLM_nativeConvertSafetensors(
-        JNIEnv* env, jclass /*clazz*/, jstring modelDir, jstring outPath, jstring tokenizerPre) {
+        JNIEnv* env, jclass /*clazz*/, jstring modelDir, jstring outPath, jstring tokenizerPre,
+        jstring precision) {
     ScopedUtfChars dir(env, modelDir);
     ScopedUtfChars out(env, outPath);
     ScopedUtfChars pre(env, tokenizerPre);
-    if (!dir.ok() || !out.ok() || !pre.ok()) {
+    ScopedUtfChars prec(env, precision);
+    if (!dir.ok() || !out.ok() || !pre.ok() || !prec.ok()) {
         throwJavaException(env, "java/lang/IllegalArgumentException", "failed to read string arguments");
         return;
     }
@@ -19,8 +53,39 @@ extern "C" JNIEXPORT void JNICALL Java_io_aatricks_llmedge_text_runtime_SmolLM_n
         throwJavaException(env, "java/lang/IllegalArgumentException", "modelDir and outPath are required");
         return;
     }
+    const std::string pre_s = pre.get() ? pre.get() : "";
+    const std::string label = prec.get() ? prec.get() : "f16";
+
     try {
-        llmedge::convert::convert_llama_dir(dir.get(), out.get(), pre.get() ? pre.get() : "");
+        // F16 is the converter's native output: no quantization step.
+        if (label.empty() || label == "f16") {
+            llmedge::convert::convert_llama_dir(dir.get(), out.get(), pre_s);
+            return;
+        }
+
+        llama_ftype ftype;
+        if (!ftypeForLabel(label, ftype)) {
+            throwJavaException(env, "java/lang/IllegalArgumentException",
+                              ("unsupported on-device conversion precision: " + label).c_str());
+            return;
+        }
+
+        // Convert to a temporary F16 GGUF, then requantize it into the requested precision.
+        const std::string tmp_f16 = std::string(out.get()) + ".f16.tmp";
+        llmedge::convert::convert_llama_dir(dir.get(), tmp_f16, pre_s);
+
+        llama_backend_init();
+        llama_model_quantize_params params = llama_model_quantize_default_params();
+        params.ftype = ftype;
+        const uint32_t rc = llama_model_quantize(tmp_f16.c_str(), out.get(), &params);
+        llama_backend_free();
+        std::remove(tmp_f16.c_str());
+
+        if (rc != 0) {
+            throwJavaException(env, "java/lang/IllegalStateException",
+                              ("llama_model_quantize failed (code " + std::to_string(rc) + ") for precision " +
+                               label).c_str());
+        }
     } catch (const std::exception& error) {
         throwJavaException(env, "java/lang/IllegalStateException", error.what());
     }

--- a/llmedge/src/main/cpp/smollm_jni_convert.cpp
+++ b/llmedge/src/main/cpp/smollm_jni_convert.cpp
@@ -1,0 +1,27 @@
+// JNI bridge for the on-device safetensors -> GGUF converter (Track B / Phase B2, Layer 5).
+//
+// Exposes io.aatricks.llmedge.text.runtime.SmolLM.nativeConvertSafetensors as a static native method.
+// The heavy lifting lives in llmedge::convert (convert/*.cpp), which has no JNI dependency and is
+// host-testable on its own; this file is only the thin JNI marshalling layer.
+#include "convert/hf_to_gguf.h"
+#include "smollm_jni_shared.h"
+
+extern "C" JNIEXPORT void JNICALL Java_io_aatricks_llmedge_text_runtime_SmolLM_nativeConvertSafetensors(
+        JNIEnv* env, jclass /*clazz*/, jstring modelDir, jstring outPath, jstring tokenizerPre) {
+    ScopedUtfChars dir(env, modelDir);
+    ScopedUtfChars out(env, outPath);
+    ScopedUtfChars pre(env, tokenizerPre);
+    if (!dir.ok() || !out.ok() || !pre.ok()) {
+        throwJavaException(env, "java/lang/IllegalArgumentException", "failed to read string arguments");
+        return;
+    }
+    if (!dir.get() || !out.get()) {
+        throwJavaException(env, "java/lang/IllegalArgumentException", "modelDir and outPath are required");
+        return;
+    }
+    try {
+        llmedge::convert::convert_llama_dir(dir.get(), out.get(), pre.get() ? pre.get() : "");
+    } catch (const std::exception& error) {
+        throwJavaException(env, "java/lang/IllegalStateException", error.what());
+    }
+}

--- a/llmedge/src/main/cpp/smollm_jni_convert.cpp
+++ b/llmedge/src/main/cpp/smollm_jni_convert.cpp
@@ -70,15 +70,21 @@ extern "C" JNIEXPORT void JNICALL Java_io_aatricks_llmedge_text_runtime_SmolLM_n
             return;
         }
 
-        // Convert to a temporary F16 GGUF, then requantize it into the requested precision.
+        // Convert to a temporary F16 GGUF, then requantize it into the requested precision. The temp
+        // file is removed on every path (success, non-zero code, or exception) so it never leaks.
         const std::string tmp_f16 = std::string(out.get()) + ".f16.tmp";
-        llmedge::convert::convert_llama_dir(dir.get(), tmp_f16, pre_s);
-
-        llama_backend_init();
-        llama_model_quantize_params params = llama_model_quantize_default_params();
-        params.ftype = ftype;
-        const uint32_t rc = llama_model_quantize(tmp_f16.c_str(), out.get(), &params);
-        llama_backend_free();
+        uint32_t rc;
+        try {
+            llmedge::convert::convert_llama_dir(dir.get(), tmp_f16, pre_s);
+            llama_backend_init();
+            llama_model_quantize_params params = llama_model_quantize_default_params();
+            params.ftype = ftype;
+            rc = llama_model_quantize(tmp_f16.c_str(), out.get(), &params);
+            llama_backend_free();
+        } catch (...) {
+            std::remove(tmp_f16.c_str());
+            throw;
+        }
         std::remove(tmp_f16.c_str());
 
         if (rc != 0) {

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/DefaultModelCatalog.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/DefaultModelCatalog.kt
@@ -56,11 +56,15 @@ internal object DefaultModelCatalog {
             capabilities = setOf(ModelCapability.PROJECTOR),
         )
 
-    /** Microsoft BitNet b1.58 2B4T — native 1-bit LLM (IQ2_BN_R4 for ik_llama.cpp). ~988 MB. */
+    /**
+     * Microsoft BitNet b1.58 2B4T — native 1-bit LLM (IQ2_BN for ik_llama.cpp). ~988 MB.
+     * Plain IQ2_BN is the portable default; the same repo also ships an `_r4` CPU row-interleaved
+     * repack (`bitnet1582b4t-iq2_bn_r4.gguf`) that can be faster on pure-CPU setups.
+     */
     val bitnetText: ModelSpec =
         huggingFaceSpec(
             repoId = "tdh111/bitnet-b1.58-2B-4T-GGUF",
-            filename = "bitnet1582b4t-iq2_bn_r4.gguf",
+            filename = "bitnet1582b4t-iq2_bn.gguf",
             preferredQuantizations = emptyList(),
             artifactKind = ModelArtifactKind.GGUF_MODEL,
             capabilities = setOf(ModelCapability.TEXT),

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/DefaultModelCatalog.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/DefaultModelCatalog.kt
@@ -56,6 +56,37 @@ internal object DefaultModelCatalog {
             capabilities = setOf(ModelCapability.PROJECTOR),
         )
 
+    /** Microsoft BitNet b1.58 2B4T — native 1-bit LLM (IQ2_BN_R4 for ik_llama.cpp). ~988 MB. */
+    val bitnetText: ModelSpec =
+        huggingFaceSpec(
+            repoId = "tdh111/bitnet-b1.58-2B-4T-GGUF",
+            filename = "bitnet1582b4t-iq2_bn_r4.gguf",
+            preferredQuantizations = emptyList(),
+            artifactKind = ModelArtifactKind.GGUF_MODEL,
+            capabilities = setOf(ModelCapability.TEXT),
+            chatTemplate = ModelChatTemplates.BITNET,
+        )
+
+    /** SmolVLM2-256M vision base model (loaded together with [smolVlm2Projector]). ~175 MB. */
+    val smolVlm2Model: ModelSpec =
+        huggingFaceSpec(
+            repoId = "ggml-org/SmolVLM2-256M-Video-Instruct-GGUF",
+            filename = "SmolVLM2-256M-Video-Instruct-Q8_0.gguf",
+            preferredQuantizations = emptyList(),
+            artifactKind = ModelArtifactKind.GGUF_MODEL,
+            capabilities = setOf(ModelCapability.TEXT, ModelCapability.VISION),
+        )
+
+    /** SmolVLM2-256M multimodal projector (mmproj) paired with [smolVlm2Model]. ~104 MB. */
+    val smolVlm2Projector: ModelSpec =
+        huggingFaceSpec(
+            repoId = "ggml-org/SmolVLM2-256M-Video-Instruct-GGUF",
+            filename = "mmproj-SmolVLM2-256M-Video-Instruct-Q8_0.gguf",
+            preferredQuantizations = emptyList(),
+            artifactKind = ModelArtifactKind.PROJECTOR,
+            capabilities = setOf(ModelCapability.PROJECTOR),
+        )
+
     val videoDiffusion: ModelSpec =
         huggingFaceSpec(
             repoId = "Comfy-Org/Wan_2.1_ComfyUI_repackaged",
@@ -89,11 +120,17 @@ internal object DefaultModelCatalog {
         preferredQuantizations: List<String> = HuggingFaceHub.DEFAULT_QUANTIZATION_PRIORITIES,
         artifactKind: ModelArtifactKind,
         capabilities: Set<ModelCapability>,
+        chatTemplate: String? = null,
     ): ModelSpec =
         ModelSpec.huggingFace(
             repoId = repoId,
             filename = filename,
             preferredQuantizations = preferredQuantizations,
-            hints = ModelHints(artifactKind = artifactKind, capabilities = capabilities),
+            hints =
+                ModelHints(
+                    artifactKind = artifactKind,
+                    capabilities = capabilities,
+                    chatTemplate = chatTemplate,
+                ),
         )
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelChatTemplates.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelChatTemplates.kt
@@ -1,0 +1,21 @@
+package io.aatricks.llmedge.model
+
+/**
+ * Chat templates carried by built-in model presets whose GGUF metadata does not ship a usable template.
+ */
+internal object ModelChatTemplates {
+    /**
+     * Canonical chat template for Microsoft BitNet b1.58 2B4T, copied verbatim from the
+     * `chat_template` field of `microsoft/bitnet-b1.58-2B-4T` `tokenizer_config.json`.
+     *
+     * Supplied explicitly because the ik_llama-compatible IQ2_BN GGUF builds do not carry the correct
+     * template in metadata, so relying on the embedded one yields malformed prompts.
+     */
+    const val BITNET: String =
+        "{% set loop_messages = messages %}" +
+            "{% for message in loop_messages %}" +
+            "{% set content = message['role'] | capitalize + ': '+ message['content'] | trim + '<|eot_id|>' %}" +
+            "{{ content }}" +
+            "{% endfor %}" +
+            "{% if add_generation_prompt %}{{ 'Assistant: ' }}{% endif %}"
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelConversion.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelConversion.kt
@@ -30,8 +30,15 @@ enum class ConversionAdapter(val cliFlag: String?) {
 data class ModelConversion(
     val precision: ConversionPrecision = ConversionPrecision.F16,
     val adapter: ConversionAdapter = ConversionAdapter.NONE,
+    /**
+     * The `tokenizer.ggml.pre` identifier baked into the converted GGUF (e.g. "smollm"). Required for
+     * on-device conversion of a text model: a GGUF without a baked tokenizer is not loadable, and the
+     * pre-tokenizer id cannot be derived safely on-device, so it must be declared by the caller.
+     */
+    val tokenizerPre: String? = null,
 ) {
     /** Stable token distinguishing one conversion target from another in cache keys. */
     val cacheToken: String
-        get() = "convert:${precision.ggufLabel}:${adapter.name.lowercase()}"
+        get() = "convert:${precision.ggufLabel}:${adapter.name.lowercase()}" +
+            (tokenizerPre?.let { ":pre=$it" }.orEmpty())
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelConversion.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelConversion.kt
@@ -1,0 +1,37 @@
+package io.aatricks.llmedge.model
+
+/**
+ * Target precision for an import-time safetensors → GGUF conversion.
+ *
+ * `F16` is "direct" (no precision loss); the others are progressively smaller "lossy" quantizations.
+ * Labels match the `--precision` values of `tools/safetensors-convert/convert.py`.
+ */
+enum class ConversionPrecision(val ggufLabel: String) {
+    F16("f16"),
+    Q8_0("q8_0"),
+    Q4_K_M("q4_k_m"),
+    IQ2_BN("iq2_bn"),
+    IQ2_BN_R4("iq2_bn_r4"),
+}
+
+/** Model-specific pre-processing applied before the stock safetensors → GGUF conversion. */
+enum class ConversionAdapter(val cliFlag: String?) {
+    /** Stock Hugging Face architecture; no special handling. */
+    NONE(null),
+
+    /** Bonsai / QLlama: fold per-output `.scales` into the weights before conversion. */
+    BONSAI_QLINEAR("bonsai-qlinear"),
+}
+
+/**
+ * Declares that a [ModelSpec] points at a safetensors source that must be converted to GGUF before the
+ * runtime can load it. Attached via [ModelHints.conversion] by [ModelSpec.safetensors].
+ */
+data class ModelConversion(
+    val precision: ConversionPrecision = ConversionPrecision.F16,
+    val adapter: ConversionAdapter = ConversionAdapter.NONE,
+) {
+    /** Stable token distinguishing one conversion target from another in cache keys. */
+    val cacheToken: String
+        get() = "convert:${precision.ggufLabel}:${adapter.name.lowercase()}"
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelHints.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelHints.kt
@@ -24,6 +24,12 @@ enum class ModelCapability {
 data class ModelHints(
     val artifactKind: ModelArtifactKind = ModelArtifactKind.AUTO,
     val capabilities: Set<ModelCapability> = emptySet(),
+    /**
+     * Optional chat template (Jinja source) the model should use when the caller does not supply one
+     * via inference options. Lets a preset stay self-contained for models whose GGUF metadata carries a
+     * missing or incorrect template (e.g. BitNet b1.58). A caller-provided template always wins.
+     */
+    val chatTemplate: String? = null,
 ) {
     fun hasCapability(capability: ModelCapability): Boolean = capability in capabilities
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelHints.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelHints.kt
@@ -30,6 +30,11 @@ data class ModelHints(
      * missing or incorrect template (e.g. BitNet b1.58). A caller-provided template always wins.
      */
     val chatTemplate: String? = null,
+    /**
+     * When non-null, marks this spec as a safetensors source that must be converted to GGUF before
+     * loading (see [ModelSpec.safetensors]). Resolution looks for a cached converted GGUF.
+     */
+    val conversion: ModelConversion? = null,
 ) {
     fun hasCapability(capability: ModelCapability): Boolean = capability in capabilities
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelPresets.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelPresets.kt
@@ -1,0 +1,37 @@
+package io.aatricks.llmedge.model
+
+/**
+ * Ready-to-use [ModelSpec] presets for models that run well on low-end devices and are supported by the
+ * bundled ik_llama.cpp runtime.
+ *
+ * Pass them directly to inference calls, or wire them into [ModelRegistry] / `LLMEdgeConfig`:
+ *
+ * ```kotlin
+ * val reply = edge.text.generate(prompt = "Hi", model = ModelPresets.bitnet)
+ *
+ * val caption = edge.vision.analyze(
+ *     image = bitmap,
+ *     prompt = "Describe this image.",
+ *     model = ModelPresets.smolVlm2.model,
+ *     projector = ModelPresets.smolVlm2.projector,
+ * )
+ * ```
+ */
+object ModelPresets {
+    /**
+     * Microsoft **BitNet b1.58 2B4T** — native 1-bit LLM (`IQ2_BN_R4`, ~988 MB) for the ik_llama.cpp
+     * runtime. The correct chat template ships on the spec ([ModelHints.chatTemplate]), so generation
+     * is well-formed without manually setting `TextModelOptions.chatTemplate`.
+     */
+    val bitnet: ModelSpec = DefaultModelCatalog.bitnetText
+
+    /**
+     * **SmolVLM2-256M** vision model — base + projector (~280 MB total). A tiny multimodal model for
+     * on-device image understanding through the mtmd/clip path.
+     */
+    val smolVlm2: VisionModels =
+        VisionModels(
+            model = DefaultModelCatalog.smolVlm2Model,
+            projector = DefaultModelCatalog.smolVlm2Projector,
+        )
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelPresets.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelPresets.kt
@@ -19,7 +19,7 @@ package io.aatricks.llmedge.model
  */
 object ModelPresets {
     /**
-     * Microsoft **BitNet b1.58 2B4T** — native 1-bit LLM (`IQ2_BN_R4`, ~988 MB) for the ik_llama.cpp
+     * Microsoft **BitNet b1.58 2B4T** — native 1-bit LLM (`IQ2_BN`, ~988 MB) for the ik_llama.cpp
      * runtime. The correct chat template ships on the spec ([ModelHints.chatTemplate]), so generation
      * is well-formed without manually setting `TextModelOptions.chatTemplate`.
      */

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelRepository.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelRepository.kt
@@ -116,7 +116,12 @@ private suspend fun resolveConvertedModel(
     target.parentFile?.mkdirs()
     val tmp = File(target.parentFile, "${target.name}.tmp${System.nanoTime()}")
     try {
-        SmolLM.convertSafetensorsToGguf(modelDir.absolutePath, tmp.absolutePath, tokenizerPre)
+        SmolLM.convertSafetensorsToGguf(
+            modelDir = modelDir.absolutePath,
+            outPath = tmp.absolutePath,
+            tokenizerPre = tokenizerPre,
+            precision = conversion.precision.ggufLabel,
+        )
     } catch (_: UnsatisfiedLinkError) {
         tmp.delete()
         throw LLMEdgeException(convertedModelInstructions(spec, conversion, target))

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelRepository.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelRepository.kt
@@ -1,6 +1,7 @@
 package io.aatricks.llmedge.model
 
 import android.content.Context
+import io.aatricks.llmedge.core.LLMEdgeException
 import io.aatricks.llmedge.core.ProgressEvent
 import io.aatricks.llmedge.huggingface.HuggingFaceHub
 import java.io.File
@@ -38,8 +39,9 @@ class DefaultModelRepository(
         context: Context,
         spec: ModelSpec,
         onProgress: ((ProgressEvent.Downloading) -> Unit)?,
-    ): File =
-        when (spec) {
+    ): File {
+        spec.hints.conversion?.let { return resolveConvertedModel(context, spec, it) }
+        return when (spec) {
             is ModelSpec.LocalFile -> {
                 ModelFileValidator.requireReadableFile(spec.file, "Model")
             }
@@ -47,6 +49,59 @@ class DefaultModelRepository(
             is ModelSpec.HuggingFace ->
                 ModelFileValidator.requireReadableFile(huggingFaceResolver(context, spec, onProgress), "Model")
         }
+    }
+}
+
+private const val CONVERTED_MODELS_DIR = "llmedge-converted"
+
+private fun convertedSourceLabel(spec: ModelSpec): String =
+    when (spec) {
+        is ModelSpec.HuggingFace -> "${spec.repoId}@${spec.revision}"
+        is ModelSpec.LocalFile -> spec.file.absolutePath
+    }
+
+private fun convertedSourceArg(spec: ModelSpec): String =
+    when (spec) {
+        is ModelSpec.HuggingFace -> spec.repoId
+        is ModelSpec.LocalFile -> spec.file.absolutePath
+    }
+
+internal fun convertedModelTarget(
+    context: Context,
+    spec: ModelSpec,
+    conversion: ModelConversion,
+): File {
+    val sanitized = convertedSourceLabel(spec).replace(Regex("[^A-Za-z0-9._-]"), "_")
+    return File(File(context.filesDir, CONVERTED_MODELS_DIR), "${sanitized}__${conversion.precision.ggufLabel}.gguf")
+}
+
+private fun resolveConvertedModel(
+    context: Context,
+    spec: ModelSpec,
+    conversion: ModelConversion,
+): File {
+    val target = convertedModelTarget(context, spec, conversion)
+    if (target.isFile && target.length() > 0L) {
+        return ModelFileValidator.requireReadableFile(target, "Converted model")
+    }
+    throw LLMEdgeException(convertedModelInstructions(spec, conversion, target))
+}
+
+private fun convertedModelInstructions(
+    spec: ModelSpec,
+    conversion: ModelConversion,
+    target: File,
+): String {
+    val adapterFlag = conversion.adapter.cliFlag?.let { " --adapter $it" }.orEmpty()
+    return buildString {
+        append("Safetensors model '${convertedSourceLabel(spec)}' has no converted GGUF yet, ")
+        append("and on-device conversion is not available in this build.\n")
+        append("Convert it offline on a dev box/CI:\n")
+        append("  python tools/safetensors-convert/convert.py --source ${convertedSourceArg(spec)}")
+        append("$adapterFlag --precision ${conversion.precision.ggufLabel} --out model.gguf\n")
+        append("then place the result at:\n  ${target.absolutePath}\n")
+        append("(or load a pre-converted GGUF directly with ModelSpec.localFile(...)).")
+    }
 }
 
 class BoundModelRepository internal constructor(

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelRepository.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import io.aatricks.llmedge.core.LLMEdgeException
 import io.aatricks.llmedge.core.ProgressEvent
 import io.aatricks.llmedge.huggingface.HuggingFaceHub
+import io.aatricks.llmedge.text.runtime.SmolLM
 import java.io.File
 
 interface ModelRepository {
@@ -40,7 +41,7 @@ class DefaultModelRepository(
         spec: ModelSpec,
         onProgress: ((ProgressEvent.Downloading) -> Unit)?,
     ): File {
-        spec.hints.conversion?.let { return resolveConvertedModel(context, spec, it) }
+        spec.hints.conversion?.let { return resolveConvertedModel(context, spec, it, onProgress) }
         return when (spec) {
             is ModelSpec.LocalFile -> {
                 ModelFileValidator.requireReadableFile(spec.file, "Model")
@@ -75,16 +76,121 @@ internal fun convertedModelTarget(
     return File(File(context.filesDir, CONVERTED_MODELS_DIR), "${sanitized}__${conversion.precision.ggufLabel}.gguf")
 }
 
-private fun resolveConvertedModel(
+// Files the on-device converter needs co-located in the model dir. Required ones must download;
+// optional ones are best-effort (some tokenizers omit special_tokens_map.json).
+private val CONVERTER_REQUIRED_FILES = listOf("config.json", "model.safetensors", "tokenizer.json", "tokenizer_config.json")
+private val CONVERTER_OPTIONAL_FILES = listOf("special_tokens_map.json")
+private val CONVERTER_FILE_EXTENSIONS = listOf(".json", ".safetensors", ".txt", ".model")
+
+private suspend fun resolveConvertedModel(
     context: Context,
     spec: ModelSpec,
     conversion: ModelConversion,
+    onProgress: ((ProgressEvent.Downloading) -> Unit)?,
 ): File {
     val target = convertedModelTarget(context, spec, conversion)
     if (target.isFile && target.length() > 0L) {
         return ModelFileValidator.requireReadableFile(target, "Converted model")
     }
-    throw LLMEdgeException(convertedModelInstructions(spec, conversion, target))
+
+    // A text GGUF without a baked tokenizer is not loadable, so the pre-tokenizer id is mandatory.
+    // Fail before downloading anything when it is absent.
+    val tokenizerPre = conversion.tokenizerPre
+    if (tokenizerPre.isNullOrBlank()) {
+        throw LLMEdgeException(
+            "On-device conversion of '${convertedSourceLabel(spec)}' needs ModelConversion.tokenizerPre " +
+                "(the tokenizer.ggml.pre id, e.g. \"smollm\"), which was not provided.\n" +
+                convertedModelInstructions(spec, conversion, target),
+        )
+    }
+
+    val modelDir = prepareSafetensorsDir(context, spec, onProgress)
+    if (!File(modelDir, "model.safetensors").isFile) {
+        throw LLMEdgeException(
+            "Source '${convertedSourceLabel(spec)}' has no single-file model.safetensors in " +
+                "${modelDir.absolutePath} (sharded or non-safetensors layouts are not supported by the " +
+                "on-device converter).\n" + convertedModelInstructions(spec, conversion, target),
+        )
+    }
+
+    target.parentFile?.mkdirs()
+    val tmp = File(target.parentFile, "${target.name}.tmp${System.nanoTime()}")
+    try {
+        SmolLM.convertSafetensorsToGguf(modelDir.absolutePath, tmp.absolutePath, tokenizerPre)
+    } catch (_: UnsatisfiedLinkError) {
+        tmp.delete()
+        throw LLMEdgeException(convertedModelInstructions(spec, conversion, target))
+    } catch (t: Throwable) {
+        tmp.delete()
+        throw t
+    }
+    if (!tmp.isFile || tmp.length() == 0L) {
+        tmp.delete()
+        throw LLMEdgeException("On-device conversion produced no output for '${convertedSourceLabel(spec)}'.")
+    }
+    // Publish atomically: a crash mid-convert leaves only the temp file, never a corrupt cached target.
+    if (!tmp.renameTo(target)) {
+        tmp.copyTo(target, overwrite = true)
+        tmp.delete()
+    }
+    return ModelFileValidator.requireReadableFile(target, "Converted model")
+}
+
+/** Provide a local directory containing config.json + model.safetensors + tokenizer files. */
+private suspend fun prepareSafetensorsDir(
+    context: Context,
+    spec: ModelSpec,
+    onProgress: ((ProgressEvent.Downloading) -> Unit)?,
+): File =
+    when (spec) {
+        is ModelSpec.LocalFile -> {
+            require(spec.file.isDirectory) {
+                "safetensorsLocal expects a directory with config.json + model.safetensors, got: ${spec.file.absolutePath}"
+            }
+            spec.file
+        }
+
+        is ModelSpec.HuggingFace -> downloadSafetensorsDir(context, spec, onProgress)
+    }
+
+/** Download the converter's input files for [spec] into one dir and return it (the flat HF cache dir). */
+private suspend fun downloadSafetensorsDir(
+    context: Context,
+    spec: ModelSpec.HuggingFace,
+    onProgress: ((ProgressEvent.Downloading) -> Unit)?,
+): File {
+    var modelDir: File? = null
+    for (name in CONVERTER_REQUIRED_FILES) {
+        val result =
+            HuggingFaceHub.ensureRepoFileOnDisk(
+                context = context,
+                modelId = spec.repoId,
+                revision = spec.revision,
+                filename = name,
+                allowedExtensions = CONVERTER_FILE_EXTENSIONS,
+                token = spec.token,
+                forceDownload = spec.forceDownload,
+                preferSystemDownloader = spec.preferSystemDownloader,
+                onProgress = onProgress?.asByteProgress(spec),
+            )
+        if (modelDir == null) modelDir = result.file.parentFile
+    }
+    for (name in CONVERTER_OPTIONAL_FILES) {
+        runCatching {
+            HuggingFaceHub.ensureRepoFileOnDisk(
+                context = context,
+                modelId = spec.repoId,
+                revision = spec.revision,
+                filename = name,
+                allowedExtensions = CONVERTER_FILE_EXTENSIONS,
+                token = spec.token,
+                forceDownload = spec.forceDownload,
+                preferSystemDownloader = spec.preferSystemDownloader,
+                onProgress = onProgress?.asByteProgress(spec),
+            )
+        }
+    }
+    return requireNotNull(modelDir) { "No converter input files downloaded for ${spec.repoId}." }
 }
 
 private fun convertedModelInstructions(
@@ -94,8 +200,8 @@ private fun convertedModelInstructions(
 ): String {
     val adapterFlag = conversion.adapter.cliFlag?.let { " --adapter $it" }.orEmpty()
     return buildString {
-        append("Safetensors model '${convertedSourceLabel(spec)}' has no converted GGUF yet, ")
-        append("and on-device conversion is not available in this build.\n")
+        append("Safetensors model '${convertedSourceLabel(spec)}' has no converted GGUF, and on-device ")
+        append("conversion did not run (unavailable in this build, or unsupported model).\n")
         append("Convert it offline on a dev box/CI:\n")
         append("  python tools/safetensors-convert/convert.py --source ${convertedSourceArg(spec)}")
         append("$adapterFlag --precision ${conversion.precision.ggufLabel} --out model.gguf\n")

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelSpec.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelSpec.kt
@@ -12,10 +12,12 @@ sealed interface ModelSpec {
         override val hints: ModelHints = ModelHints(),
     ) : ModelSpec {
         override val cacheKey: String =
-            listOf(
-                "file://${file.absolutePath}",
-                "artifact=${hints.artifactKind.name}",
-                "capabilities=${hints.capabilities.map(ModelCapability::name).sorted().joinToString(",")}",
+            (
+                listOf(
+                    "file://${file.absolutePath}",
+                    "artifact=${hints.artifactKind.name}",
+                    "capabilities=${hints.capabilities.map(ModelCapability::name).sorted().joinToString(",")}",
+                ) + listOfNotNull(hints.conversion?.cacheToken)
             ).joinToString("|")
     }
 
@@ -30,15 +32,17 @@ sealed interface ModelSpec {
         override val hints: ModelHints = ModelHints(),
     ) : ModelSpec {
         override val cacheKey: String =
-            listOf(
-                "hf",
-                repoId,
-                revision,
-                filename.orEmpty(),
-                preferredQuantizations.joinToString(","),
-                forceDownload.toString(),
-                "artifact=${hints.artifactKind.name}",
-                "capabilities=${hints.capabilities.map(ModelCapability::name).sorted().joinToString(",")}",
+            (
+                listOf(
+                    "hf",
+                    repoId,
+                    revision,
+                    filename.orEmpty(),
+                    preferredQuantizations.joinToString(","),
+                    forceDownload.toString(),
+                    "artifact=${hints.artifactKind.name}",
+                    "capabilities=${hints.capabilities.map(ModelCapability::name).sorted().joinToString(",")}",
+                ) + listOfNotNull(hints.conversion?.cacheToken)
             ).joinToString("|")
     }
 
@@ -78,6 +82,55 @@ sealed interface ModelSpec {
                 forceDownload = forceDownload,
                 preferSystemDownloader = preferSystemDownloader,
                 hints = hints,
+            )
+
+        /**
+         * A safetensors model on Hugging Face to be converted to GGUF (at [precision]) before loading.
+         *
+         * On-device conversion is not yet available; resolution looks for a pre-converted GGUF in the
+         * app cache and, if absent, fails with instructions for `tools/safetensors-convert`. Use
+         * [adapter] = [ConversionAdapter.BONSAI_QLINEAR] for Bonsai / QLlama models.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun safetensors(
+            repoId: String,
+            precision: ConversionPrecision = ConversionPrecision.F16,
+            adapter: ConversionAdapter = ConversionAdapter.NONE,
+            revision: String = "main",
+            token: String? = null,
+            capabilities: Set<ModelCapability> = setOf(ModelCapability.TEXT),
+        ): ModelSpec =
+            HuggingFace(
+                repoId = repoId,
+                revision = revision,
+                token = token,
+                hints =
+                    ModelHints(
+                        capabilities = capabilities,
+                        conversion = ModelConversion(precision, adapter),
+                    ),
+            )
+
+        /**
+         * A local safetensors model directory (or file) to be converted to GGUF before loading.
+         * See [safetensors] for conversion behavior.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun safetensorsLocal(
+            path: String,
+            precision: ConversionPrecision = ConversionPrecision.F16,
+            adapter: ConversionAdapter = ConversionAdapter.NONE,
+            capabilities: Set<ModelCapability> = setOf(ModelCapability.TEXT),
+        ): ModelSpec =
+            LocalFile(
+                file = File(path),
+                hints =
+                    ModelHints(
+                        capabilities = capabilities,
+                        conversion = ModelConversion(precision, adapter),
+                    ),
             )
     }
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelSpec.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelSpec.kt
@@ -87,9 +87,11 @@ sealed interface ModelSpec {
         /**
          * A safetensors model on Hugging Face to be converted to GGUF (at [precision]) before loading.
          *
-         * On-device conversion is not yet available; resolution looks for a pre-converted GGUF in the
-         * app cache and, if absent, fails with instructions for `tools/safetensors-convert`. Use
-         * [adapter] = [ConversionAdapter.BONSAI_QLINEAR] for Bonsai / QLlama models.
+         * Resolution first looks for a pre-converted GGUF in the app cache. If absent and
+         * [tokenizerPre] is set, the model dir is downloaded and converted on-device (Track B / Phase
+         * B2); otherwise it fails with instructions for `tools/safetensors-convert`. [tokenizerPre] is
+         * the `tokenizer.ggml.pre` id to bake (e.g. "smollm") and is required for on-device conversion.
+         * Use [adapter] = [ConversionAdapter.BONSAI_QLINEAR] for Bonsai / QLlama models.
          */
         @JvmStatic
         @JvmOverloads
@@ -100,6 +102,7 @@ sealed interface ModelSpec {
             revision: String = "main",
             token: String? = null,
             capabilities: Set<ModelCapability> = setOf(ModelCapability.TEXT),
+            tokenizerPre: String? = null,
         ): ModelSpec =
             HuggingFace(
                 repoId = repoId,
@@ -108,13 +111,13 @@ sealed interface ModelSpec {
                 hints =
                     ModelHints(
                         capabilities = capabilities,
-                        conversion = ModelConversion(precision, adapter),
+                        conversion = ModelConversion(precision, adapter, tokenizerPre),
                     ),
             )
 
         /**
-         * A local safetensors model directory (or file) to be converted to GGUF before loading.
-         * See [safetensors] for conversion behavior.
+         * A local safetensors model directory to be converted to GGUF before loading.
+         * See [safetensors] for conversion behavior; [tokenizerPre] is required for on-device conversion.
          */
         @JvmStatic
         @JvmOverloads
@@ -123,13 +126,14 @@ sealed interface ModelSpec {
             precision: ConversionPrecision = ConversionPrecision.F16,
             adapter: ConversionAdapter = ConversionAdapter.NONE,
             capabilities: Set<ModelCapability> = setOf(ModelCapability.TEXT),
+            tokenizerPre: String? = null,
         ): ModelSpec =
             LocalFile(
                 file = File(path),
                 hints =
                     ModelHints(
                         capabilities = capabilities,
-                        conversion = ModelConversion(precision, adapter),
+                        conversion = ModelConversion(precision, adapter, tokenizerPre),
                     ),
             )
     }

--- a/llmedge/src/main/java/io/aatricks/llmedge/text/TextClient.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/text/TextClient.kt
@@ -43,13 +43,16 @@ data class TextGenerationRequest(
     val batchSize: Int = 0,
 )
 
-internal fun TextModelOptions.toInferenceParams(config: LLMEdgeConfig): SmolLM.InferenceParams =
+internal fun TextModelOptions.toInferenceParams(
+    config: LLMEdgeConfig,
+    fallbackChatTemplate: String? = null,
+): SmolLM.InferenceParams =
     SmolLM.InferenceParams(
         minP = minP ?: config.text.minP,
         temperature = temperature ?: config.text.temperature,
         storeChats = false,
         contextSize = contextSize ?: config.text.contextSize,
-        chatTemplate = chatTemplate,
+        chatTemplate = chatTemplate ?: fallbackChatTemplate,
         numThreads = numThreads ?: config.text.promptThreads,
         generationThreads = generationThreads ?: numThreads ?: config.text.generationThreads,
         useMmap = useMmap ?: config.text.useMmap,

--- a/llmedge/src/main/java/io/aatricks/llmedge/text/TextRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/text/TextRuntimeSupport.kt
@@ -56,7 +56,7 @@ internal fun createTextRuntimePool(
                     RuntimeCacheKeyBuilder.prefix(
                         spec.cacheKey,
                         "ctx=${options.contextSize ?: config.text.contextSize ?: 0L}",
-                        "chatTemplate=${chatTemplateCacheToken(options.chatTemplate)}",
+                        "chatTemplate=${chatTemplateCacheToken(options.chatTemplate ?: spec.hints.chatTemplate)}",
                         "threads=${options.numThreads ?: config.text.promptThreads}",
                         "genThreads=${options.generationThreads ?: options.numThreads ?: config.text.generationThreads}",
                         "mmap=${options.useMmap ?: config.text.useMmap}",
@@ -69,7 +69,7 @@ internal fun createTextRuntimePool(
                     val smol = SmolLM(useVulkan = backend == ComputeBackend.VULKAN)
                     smol.load(
                         modelFile.absolutePath,
-                        options.toInferenceParams(config),
+                        options.toInferenceParams(config, spec.hints.chatTemplate),
                         preferredBackend = backend,
                     )
                     ManagedTextModel(fileSizeBytes = modelFile.length(), model = smol)

--- a/llmedge/src/main/java/io/aatricks/llmedge/text/runtime/SmolLM.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/text/runtime/SmolLM.kt
@@ -84,6 +84,28 @@ class SmolLM internal constructor(
         @JvmStatic
         private external fun nativeIsVulkanAvailable(): Boolean
 
+        @JvmStatic
+        private external fun nativeConvertSafetensors(
+            modelDir: String,
+            outPath: String,
+            tokenizerPre: String?,
+        )
+
+        /**
+         * Convert a Hugging Face safetensors model directory ([modelDir], containing config.json +
+         * model.safetensors + tokenizer files) to a GGUF at [outPath], on-device (Track B / Phase B2).
+         *
+         * [tokenizerPre] is the `tokenizer.ggml.pre` id to bake (e.g. "smollm"); it must be non-null
+         * (see the native tokenizer_bake.h for why a pre-tokenizer id cannot be guessed safely).
+         *
+         * Throws [UnsatisfiedLinkError] if the converter was not compiled into this build, or
+         * [IllegalStateException] if the model architecture/tokenizer is unsupported.
+         */
+        internal fun convertSafetensorsToGguf(modelDir: String, outPath: String, tokenizerPre: String?) {
+            currentNativeLibrarySupport().ensureLoaded()
+            nativeConvertSafetensors(modelDir, outPath, tokenizerPre)
+        }
+
         internal fun createLoadedForTests(
             nativePtr: Long,
             useVulkan: Boolean = false,

--- a/llmedge/src/main/java/io/aatricks/llmedge/text/runtime/SmolLM.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/text/runtime/SmolLM.kt
@@ -89,6 +89,7 @@ class SmolLM internal constructor(
             modelDir: String,
             outPath: String,
             tokenizerPre: String?,
+            precision: String,
         )
 
         /**
@@ -97,13 +98,21 @@ class SmolLM internal constructor(
          *
          * [tokenizerPre] is the `tokenizer.ggml.pre` id to bake (e.g. "smollm"); it must be non-null
          * (see the native tokenizer_bake.h for why a pre-tokenizer id cannot be guessed safely).
+         * [precision] is a [io.aatricks.llmedge.model.ConversionPrecision] ggufLabel: "f16" writes the
+         * converter's native F16 output directly; "q8_0" / "q4_k_m" / "iq2_bn" / "iq2_bn_r4" convert to
+         * F16 first and then requantize via the native llama quantizer.
          *
          * Throws [UnsatisfiedLinkError] if the converter was not compiled into this build, or
-         * [IllegalStateException] if the model architecture/tokenizer is unsupported.
+         * [IllegalStateException] if the model/tokenizer is unsupported or quantization fails.
          */
-        internal fun convertSafetensorsToGguf(modelDir: String, outPath: String, tokenizerPre: String?) {
+        internal fun convertSafetensorsToGguf(
+            modelDir: String,
+            outPath: String,
+            tokenizerPre: String?,
+            precision: String = "f16",
+        ) {
             currentNativeLibrarySupport().ensureLoaded()
-            nativeConvertSafetensors(modelDir, outPath, tokenizerPre)
+            nativeConvertSafetensors(modelDir, outPath, tokenizerPre, precision)
         }
 
         internal fun createLoadedForTests(

--- a/llmedge/src/test/java/io/aatricks/llmedge/B2ConvertE2ETest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/B2ConvertE2ETest.kt
@@ -1,0 +1,99 @@
+package io.aatricks.llmedge
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.aatricks.llmedge.model.ConversionPrecision
+import io.aatricks.llmedge.model.DefaultModelRepository
+import io.aatricks.llmedge.model.ModelSpec
+import io.aatricks.llmedge.runtime.GGUFReader
+import io.aatricks.llmedge.text.runtime.SmolLM
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Desktop-host E2E for the on-device safetensors → GGUF converter (Track B / Phase B2, Layer 5).
+ *
+ * Drives the REAL [DefaultModelRepository.resolve] with a [ModelSpec.safetensorsLocal] spec: it runs
+ * the native converter (nativeConvertSafetensors) on a local HF model dir, caches the GGUF, then loads
+ * and generates from it — proving the whole pipeline (convert → bake tokenizer → cache → load →
+ * tokenize → generate) works end-to-end, not just that the GGUF KVs match a reference.
+ *
+ * Gated like the other host E2E tests:
+ *   LLMEDGE_BUILD_NATIVE_LIB_PATH → host libsmollm built with the convert sources
+ *   LLMEDGE_TEST_SAFETENSORS_DIR  → a Llama-arch HF model dir (config.json + model.safetensors +
+ *                                   tokenizer.json + tokenizer_config.json), e.g. SmolLM-135M
+ *   LLMEDGE_TEST_TOKENIZER_PRE    → the tokenizer.ggml.pre id to bake (default "smollm")
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class B2ConvertE2ETest {
+    private val LIB_PATH_ENV = "LLMEDGE_BUILD_NATIVE_LIB_PATH"
+    private val ST_DIR_ENV = "LLMEDGE_TEST_SAFETENSORS_DIR"
+    private val PRE_ENV = "LLMEDGE_TEST_TOKENIZER_PRE"
+
+    private fun env(name: String): String? = System.getenv(name) ?: System.getProperty(name)
+
+    @Before fun reset() { SmolLM.resetNativeBridgeForTests(); GGUFReader.resetNativeBridgeForTests() }
+    @After fun tearDown() { SmolLM.resetNativeBridgeForTests(); GGUFReader.resetNativeBridgeForTests() }
+
+    @Test
+    fun `converts a local safetensors dir on-device then loads and generates`() = runBlocking {
+        val stDir = env(ST_DIR_ENV)
+        Assume.assumeTrue("No safetensors dir in $ST_DIR_ENV", !stDir.isNullOrBlank())
+        Assume.assumeTrue("$stDir is not a dir with model.safetensors", File(stDir, "model.safetensors").isFile)
+
+        DesktopNativeTestSupport.requireEnabled()
+        val libPath = env(LIB_PATH_ENV)
+        Assume.assumeTrue("No native lib in $LIB_PATH_ENV", !libPath.isNullOrBlank())
+        DesktopNativeTestSupport.requireAndLoadLibrary(libPath!!)
+
+        val pre = env(PRE_ENV) ?: "smollm"
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        // Real resolve path: LocalFile + conversion hint → native convert → cached GGUF.
+        val spec =
+            ModelSpec.safetensorsLocal(
+                path = stDir!!,
+                precision = ConversionPrecision.F16,
+                tokenizerPre = pre,
+            )
+        val gguf = DefaultModelRepository().resolve(context, spec)
+        println("[B2ConvertE2ETest] converted GGUF=${gguf.absolutePath} size=${gguf.length()}")
+
+        // Must be the on-device-converted cache artifact, not the input dir.
+        assertTrue("Converted GGUF missing/empty", gguf.isFile && gguf.length() > 0L)
+        assertTrue("Expected converted cache path, got ${gguf.absolutePath}", gguf.absolutePath.contains("llmedge-converted"))
+
+        val smol = SmolLM(useVulkan = false)
+        try {
+            smol.load(
+                gguf.absolutePath,
+                SmolLM.InferenceParams(
+                    contextSize = 2048,
+                    temperature = 0.0f, // greedy → deterministic
+                    storeChats = true,
+                ),
+            )
+            val prompt = "The capital of France is"
+            smol.addUserMessage(prompt)
+            val response = smol.getResponse(prompt, maxTokens = 16)
+            println("[B2ConvertE2ETest] response='$response'")
+
+            // The converted GGUF's baked tokenizer must build a working vocab and the model must
+            // tokenize + generate real text (mine ≡ upstream-ref by construction, so correctness of
+            // the tokens themselves is already proven by the KV/tensor oracles).
+            val cleaned = response.replace(Regex("<\\|[^|]*\\|>"), "").trim()
+            assertTrue("Expected real generated text, got: '$response'", cleaned.length >= 3)
+        } finally {
+            smol.close()
+        }
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/B2ConvertE2ETest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/B2ConvertE2ETest.kt
@@ -19,12 +19,12 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Desktop-host E2E for the on-device safetensors → GGUF converter (Track B / Phase B2, Layer 5).
+ * Desktop-host E2E for the on-device safetensors → GGUF converter (Track B / Phase B2, Layers 5-6).
  *
  * Drives the REAL [DefaultModelRepository.resolve] with a [ModelSpec.safetensorsLocal] spec: it runs
  * the native converter (nativeConvertSafetensors) on a local HF model dir, caches the GGUF, then loads
- * and generates from it — proving the whole pipeline (convert → bake tokenizer → cache → load →
- * tokenize → generate) works end-to-end, not just that the GGUF KVs match a reference.
+ * and generates from it — proving the whole pipeline (convert → bake tokenizer → [quantize] → cache →
+ * load → tokenize → generate) works end-to-end, not just that the GGUF KVs match a reference.
  *
  * Gated like the other host E2E tests:
  *   LLMEDGE_BUILD_NATIVE_LIB_PATH → host libsmollm built with the convert sources
@@ -44,8 +44,8 @@ class B2ConvertE2ETest {
     @Before fun reset() { SmolLM.resetNativeBridgeForTests(); GGUFReader.resetNativeBridgeForTests() }
     @After fun tearDown() { SmolLM.resetNativeBridgeForTests(); GGUFReader.resetNativeBridgeForTests() }
 
-    @Test
-    fun `converts a local safetensors dir on-device then loads and generates`() = runBlocking {
+    /** Resolve [stDir] through the real converter at [precision], then load + greedily generate. */
+    private fun convertAndGenerate(precision: ConversionPrecision): Pair<File, String> {
         val stDir = env(ST_DIR_ENV)
         Assume.assumeTrue("No safetensors dir in $ST_DIR_ENV", !stDir.isNullOrBlank())
         Assume.assumeTrue("$stDir is not a dir with model.safetensors", File(stDir, "model.safetensors").isFile)
@@ -58,42 +58,49 @@ class B2ConvertE2ETest {
         val pre = env(PRE_ENV) ?: "smollm"
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        // Real resolve path: LocalFile + conversion hint → native convert → cached GGUF.
-        val spec =
-            ModelSpec.safetensorsLocal(
-                path = stDir!!,
-                precision = ConversionPrecision.F16,
-                tokenizerPre = pre,
-            )
-        val gguf = DefaultModelRepository().resolve(context, spec)
-        println("[B2ConvertE2ETest] converted GGUF=${gguf.absolutePath} size=${gguf.length()}")
+        val spec = ModelSpec.safetensorsLocal(path = stDir!!, precision = precision, tokenizerPre = pre)
+        val gguf = runBlocking { DefaultModelRepository().resolve(context, spec) }
+        println("[B2ConvertE2ETest] precision=$precision GGUF=${gguf.absolutePath} size=${gguf.length()}")
 
-        // Must be the on-device-converted cache artifact, not the input dir.
         assertTrue("Converted GGUF missing/empty", gguf.isFile && gguf.length() > 0L)
         assertTrue("Expected converted cache path, got ${gguf.absolutePath}", gguf.absolutePath.contains("llmedge-converted"))
 
         val smol = SmolLM(useVulkan = false)
-        try {
-            smol.load(
-                gguf.absolutePath,
-                SmolLM.InferenceParams(
-                    contextSize = 2048,
-                    temperature = 0.0f, // greedy → deterministic
-                    storeChats = true,
-                ),
-            )
-            val prompt = "The capital of France is"
-            smol.addUserMessage(prompt)
-            val response = smol.getResponse(prompt, maxTokens = 16)
-            println("[B2ConvertE2ETest] response='$response'")
-
-            // The converted GGUF's baked tokenizer must build a working vocab and the model must
-            // tokenize + generate real text (mine ≡ upstream-ref by construction, so correctness of
-            // the tokens themselves is already proven by the KV/tensor oracles).
-            val cleaned = response.replace(Regex("<\\|[^|]*\\|>"), "").trim()
-            assertTrue("Expected real generated text, got: '$response'", cleaned.length >= 3)
-        } finally {
-            smol.close()
+        return runBlocking {
+            try {
+                smol.load(
+                    gguf.absolutePath,
+                    SmolLM.InferenceParams(contextSize = 2048, temperature = 0.0f, storeChats = true),
+                )
+                val prompt = "The capital of France is"
+                smol.addUserMessage(prompt)
+                val response = smol.getResponse(prompt, maxTokens = 16)
+                println("[B2ConvertE2ETest] precision=$precision response='$response'")
+                gguf to response
+            } finally {
+                smol.close()
+            }
         }
+    }
+
+    @Test
+    fun `converts a local safetensors dir on-device (f16) then loads and generates`() {
+        val (_, response) = convertAndGenerate(ConversionPrecision.F16)
+        val cleaned = response.replace(Regex("<\\|[^|]*\\|>"), "").trim()
+        assertTrue("Expected real generated text, got: '$response'", cleaned.length >= 3)
+    }
+
+    @Test
+    fun `converts then quantizes to q4_k_m on-device and generates`() {
+        val stDir = env(ST_DIR_ENV)
+        val (gguf, response) = convertAndGenerate(ConversionPrecision.Q4_K_M)
+        // Quantized output must be materially smaller than the source safetensors.
+        val sourceBytes = File(stDir!!, "model.safetensors").length()
+        assertTrue(
+            "Q4_K_M GGUF (${gguf.length()}) should be < source safetensors ($sourceBytes)",
+            gguf.length() in 1 until sourceBytes,
+        )
+        val cleaned = response.replace(Regex("<\\|[^|]*\\|>"), "").trim()
+        assertTrue("Expected real generated text from quantized model, got: '$response'", cleaned.length >= 3)
     }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/BitNetTemplateE2ETest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/BitNetTemplateE2ETest.kt
@@ -1,0 +1,69 @@
+package io.aatricks.llmedge
+
+import io.aatricks.llmedge.model.ModelChatTemplates
+import io.aatricks.llmedge.runtime.GGUFReader
+import io.aatricks.llmedge.text.runtime.SmolLM
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Desktop-host E2E proving the bundled BitNet b1.58 preset chat template ([ModelChatTemplates.BITNET])
+ * produces coherent generation, whereas the GGUF's embedded template does not.
+ *
+ * Gated like the other LinuxE2E tests: point LLMEDGE_TEST_TEXT_MODEL_PATH at a BitNet IQ2_BN GGUF and
+ * LLMEDGE_BUILD_NATIVE_LIB_PATH at a host libsmollm.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class BitNetTemplateE2ETest {
+    private val MODEL_PATH_ENV = "LLMEDGE_TEST_TEXT_MODEL_PATH"
+    private val LIB_PATH_ENV = "LLMEDGE_BUILD_NATIVE_LIB_PATH"
+
+    @Before fun reset() { SmolLM.resetNativeBridgeForTests(); GGUFReader.resetNativeBridgeForTests() }
+    @After fun tearDown() { SmolLM.resetNativeBridgeForTests(); GGUFReader.resetNativeBridgeForTests() }
+
+    @Test
+    fun `bitnet generates coherent text with the preset template`() = runBlocking {
+        val modelPath = System.getenv(MODEL_PATH_ENV) ?: System.getProperty(MODEL_PATH_ENV)
+        Assume.assumeTrue("No BitNet model in $MODEL_PATH_ENV", !modelPath.isNullOrBlank())
+        Assume.assumeTrue("Model is not a bitnet gguf", modelPath!!.contains("bitnet", ignoreCase = true))
+
+        DesktopNativeTestSupport.requireEnabled()
+        val libPath = System.getenv(LIB_PATH_ENV) ?: System.getProperty(LIB_PATH_ENV)
+        Assume.assumeTrue("No native lib in $LIB_PATH_ENV", !libPath.isNullOrBlank())
+        DesktopNativeTestSupport.requireAndLoadLibrary(libPath!!)
+
+        val smol = SmolLM(useVulkan = false)
+        try {
+            smol.load(
+                modelPath,
+                SmolLM.InferenceParams(
+                    contextSize = 2048,
+                    temperature = 0.0f, // greedy → deterministic
+                    storeChats = true,
+                    chatTemplate = ModelChatTemplates.BITNET,
+                ),
+            )
+            val prompt = "What is the capital of France? Answer in one word."
+            smol.addUserMessage(prompt)
+            val response = smol.getResponse(prompt, maxTokens = 24)
+            println("[BitNetTemplateE2ETest] response='$response'")
+
+            val cleaned = response.replace(Regex("<\\|[^|]*\\|>"), "").trim()
+            assertTrue("Expected coherent text, got special-token-only: '$response'", cleaned.length >= 3)
+            assertTrue(
+                "Expected 'Paris' in the answer, got: '$response'",
+                cleaned.contains("Paris", ignoreCase = true),
+            )
+        } finally {
+            smol.close()
+        }
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/model/ConvertedModelResolveTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/model/ConvertedModelResolveTest.kt
@@ -1,0 +1,52 @@
+package io.aatricks.llmedge.model
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.aatricks.llmedge.core.LLMEdgeException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ConvertedModelResolveTest {
+    @Test
+    fun `resolve throws actionable error when converted gguf is missing`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val spec =
+            ModelSpec.safetensors(
+                "deepgrove/Bonsai",
+                ConversionPrecision.IQ2_BN,
+                ConversionAdapter.BONSAI_QLINEAR,
+            )
+        try {
+            DefaultModelRepository().resolve(context, spec)
+            fail("expected LLMEdgeException for un-converted safetensors spec")
+        } catch (e: LLMEdgeException) {
+            val msg = e.message ?: ""
+            assertTrue(msg, msg.contains("safetensors-convert"))
+            assertTrue(msg, msg.contains("--adapter bonsai-qlinear"))
+            assertTrue(msg, msg.contains("--precision iq2_bn"))
+        }
+    }
+
+    @Test
+    fun `resolve returns the cached converted gguf when present`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val spec = ModelSpec.safetensorsLocal("/models/bonsai", ConversionPrecision.F16)
+        val target = convertedModelTarget(context, spec, spec.hints.conversion!!)
+        target.parentFile!!.mkdirs()
+        target.writeBytes(byteArrayOf(0x01))
+        try {
+            val resolved = DefaultModelRepository().resolve(context, spec)
+            assertEquals(target.absolutePath, resolved.absolutePath)
+        } finally {
+            target.delete()
+        }
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/model/ModelPresetsTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/model/ModelPresetsTest.kt
@@ -9,7 +9,7 @@ class ModelPresetsTest {
     fun `bitnet preset points at the ik_llama IQ2_BN gguf`() {
         val spec = ModelPresets.bitnet as ModelSpec.HuggingFace
         assertEquals("tdh111/bitnet-b1.58-2B-4T-GGUF", spec.repoId)
-        assertEquals("bitnet1582b4t-iq2_bn_r4.gguf", spec.filename)
+        assertEquals("bitnet1582b4t-iq2_bn.gguf", spec.filename)
         assertEquals(ModelArtifactKind.GGUF_MODEL, spec.hints.artifactKind)
         assertTrue(ModelCapability.TEXT in spec.hints.capabilities)
     }

--- a/llmedge/src/test/java/io/aatricks/llmedge/model/ModelPresetsTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/model/ModelPresetsTest.kt
@@ -1,0 +1,47 @@
+package io.aatricks.llmedge.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModelPresetsTest {
+    @Test
+    fun `bitnet preset points at the ik_llama IQ2_BN gguf`() {
+        val spec = ModelPresets.bitnet as ModelSpec.HuggingFace
+        assertEquals("tdh111/bitnet-b1.58-2B-4T-GGUF", spec.repoId)
+        assertEquals("bitnet1582b4t-iq2_bn_r4.gguf", spec.filename)
+        assertEquals(ModelArtifactKind.GGUF_MODEL, spec.hints.artifactKind)
+        assertTrue(ModelCapability.TEXT in spec.hints.capabilities)
+    }
+
+    @Test
+    fun `bitnet preset carries its own chat template so it works without caller config`() {
+        val template = ModelPresets.bitnet.hints.chatTemplate
+        assertTrue("BitNet preset must carry a non-empty chat template", !template.isNullOrBlank())
+        // Canonical BitNet b1.58 template markers (microsoft/bitnet-b1.58-2B-4T tokenizer_config.json).
+        assertTrue(template!!.contains("<|eot_id|>"))
+        assertTrue(template.contains("Assistant: "))
+        assertTrue(template.contains("add_generation_prompt"))
+    }
+
+    @Test
+    fun `smolVlm2 preset exposes base model and projector with matching repo`() {
+        val model = ModelPresets.smolVlm2.model as ModelSpec.HuggingFace
+        val projector = ModelPresets.smolVlm2.projector as ModelSpec.HuggingFace
+
+        assertEquals("ggml-org/SmolVLM2-256M-Video-Instruct-GGUF", model.repoId)
+        assertEquals("SmolVLM2-256M-Video-Instruct-Q8_0.gguf", model.filename)
+        assertEquals(ModelArtifactKind.GGUF_MODEL, model.hints.artifactKind)
+        assertTrue(ModelCapability.VISION in model.hints.capabilities)
+
+        assertEquals("ggml-org/SmolVLM2-256M-Video-Instruct-GGUF", projector.repoId)
+        assertEquals("mmproj-SmolVLM2-256M-Video-Instruct-Q8_0.gguf", projector.filename)
+        assertEquals(ModelArtifactKind.PROJECTOR, projector.hints.artifactKind)
+        assertTrue(ModelCapability.PROJECTOR in projector.hints.capabilities)
+    }
+
+    @Test
+    fun `default model hints leave chat template unset`() {
+        assertEquals(null, ModelHints().chatTemplate)
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/model/SafetensorsSpecTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/model/SafetensorsSpecTest.kt
@@ -1,0 +1,52 @@
+package io.aatricks.llmedge.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SafetensorsSpecTest {
+    @Test
+    fun `safetensors factory attaches conversion to hints`() {
+        val spec =
+            ModelSpec.safetensors(
+                repoId = "deepgrove/Bonsai",
+                precision = ConversionPrecision.IQ2_BN,
+                adapter = ConversionAdapter.BONSAI_QLINEAR,
+            ) as ModelSpec.HuggingFace
+        assertEquals("deepgrove/Bonsai", spec.repoId)
+        val conv = spec.hints.conversion
+        assertNotNull(conv)
+        assertEquals(ConversionPrecision.IQ2_BN, conv!!.precision)
+        assertEquals(ConversionAdapter.BONSAI_QLINEAR, conv.adapter)
+        assertTrue(ModelCapability.TEXT in spec.hints.capabilities)
+    }
+
+    @Test
+    fun `default factories leave conversion null`() {
+        val gguf = ModelSpec.huggingFace("a/b", "x.gguf") as ModelSpec.HuggingFace
+        assertNull(gguf.hints.conversion)
+        assertNull(ModelHints().conversion)
+    }
+
+    @Test
+    fun `conversion is tagged in the cache key and plain specs are unaffected`() {
+        val plain = ModelSpec.huggingFace("a/b", "x.gguf")
+        val f16 = ModelSpec.safetensors("a/b", ConversionPrecision.F16)
+        val q8 = ModelSpec.safetensors("a/b", ConversionPrecision.Q8_0)
+
+        assertTrue(!plain.cacheKey.contains("convert:"))
+        assertTrue(f16.cacheKey.contains("convert:f16:none"))
+        assertTrue(f16.cacheKey != q8.cacheKey) // precision differentiates
+    }
+
+    @Test
+    fun `local safetensors factory uses LocalFile with conversion`() {
+        val spec =
+            ModelSpec.safetensorsLocal("/models/bonsai", ConversionPrecision.Q4_K_M) as ModelSpec.LocalFile
+        assertEquals("/models/bonsai", spec.file.path)
+        assertEquals(ConversionPrecision.Q4_K_M, spec.hints.conversion?.precision)
+        assertTrue(spec.cacheKey.contains("convert:q4_k_m:none"))
+    }
+}

--- a/local.properties
+++ b/local.properties
@@ -5,4 +5,4 @@
 # For customization when using a Version Control System, please read the
 # header note.
 #Tue Sep 16 22:45:03 CEST 2025
-sdk.dir=/home/aatricks/Android/Sdk
+sdk.dir=/Users/aatricks/Library/Android/sdk

--- a/scripts/README-macos-host-build.md
+++ b/scripts/README-macos-host-build.md
@@ -1,0 +1,43 @@
+# Running the desktop (host) native tests on macOS
+
+The `scripts/*_linux.sh` host-build/E2E harness also works on macOS (Apple Silicon) with a few
+prerequisites, because stock macOS ships tools that are too old or BSD-flavored.
+
+## Prerequisites
+
+```bash
+brew install bash cmake ninja gpatch openjdk@17
+```
+
+- **bash 5** — the build scripts use `mapfile` and `local -n` namerefs (bash 4.3+); stock macOS bash is 3.2.
+  Run the scripts with Homebrew bash: `/opt/homebrew/bin/bash scripts/build_native_linux.sh smollm`.
+- **gpatch (GNU patch)** — the mod-overlay step (`android-vulkan-iqk.patch`) needs GNU `patch`; BSD `patch`
+  fails to create its temp files. Put GNU patch on `PATH` as `patch`, e.g.:
+  `mkdir -p /tmp/gnubin && ln -sf "$(brew --prefix gpatch)/bin/gpatch" /tmp/gnubin/patch` then prepend
+  `/tmp/gnubin` to `PATH`.
+- **A full JDK for JNI headers** — the Android Studio JBR ships no JNI headers, so cmake's `find_package(JNI)`
+  fails. Point the build at a full JDK: `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home`.
+
+The build emits both `libsmollm.so` and a `libsmollm.dylib` alias on macOS so the JVM name-based loader
+(`System.loadLibrary`) can find it.
+
+## Build + run a text model
+
+```bash
+PATCH_BIN=/tmp/gnubin   # dir containing a `patch` -> gpatch symlink (see above)
+JDK=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
+JBR="/Applications/Android Studio.app/Contents/jbr/Contents/Home"   # any JDK 17+ runs gradle
+
+# 1) Build the host smollm JNI library
+JAVA_HOME="$JDK" PATH="$PATCH_BIN:/opt/homebrew/bin:$PATH" \
+  /opt/homebrew/bin/bash scripts/build_native_linux.sh smollm
+
+# 2) Run the text E2E against any GGUF (here: BitNet b1.58 IQ2_BN)
+export LLMEDGE_BUILD_NATIVE_LIB_PATH="$PWD/llmedge/build/native/linux-aarch64/libsmollm.so"
+export LLMEDGE_TEST_TEXT_MODEL_PATH="$PWD/models/bitnet1582b4t-iq2_bn.gguf"
+JAVA_HOME="$JBR" ./gradlew :llmedge:testDebugUnitTest \
+  --tests "io.aatricks.llmedge.TextInferenceLinuxE2ETest" --no-daemon --rerun-tasks
+```
+
+`BitNetTemplateE2ETest` additionally checks that the bundled BitNet chat template produces coherent output
+(it answers "What is the capital of France?" with "Paris").

--- a/scripts/build_native_linux.sh
+++ b/scripts/build_native_linux.sh
@@ -27,15 +27,25 @@ case "$ARCH" in
   *) ARCH_DIR="linux-$ARCH" ;;
 esac
 
+# On macOS, System.loadLibrary() maps a name to lib<name>.dylib, but this harness names libraries
+# ".so" on every host. Emit a .dylib alias so the JVM name-based loader can find host builds on macOS.
+maybe_dylib_alias() {
+    local so_path="$1"
+    [[ "$(uname -s)" == "Darwin" && "$so_path" == *.so ]] || return 0
+    cp "$so_path" "${so_path%.so}.dylib"
+}
+
 copy_output() {
     local built_lib="$1"
     local output_name="$2"
 
     mkdir -p "$ROOT_DIR/llmedge/build/native/$ARCH_DIR"
     cp "$built_lib" "$ROOT_DIR/llmedge/build/native/$ARCH_DIR/$output_name"
+    maybe_dylib_alias "$ROOT_DIR/llmedge/build/native/$ARCH_DIR/$output_name"
 
     mkdir -p "$BUILD_BIN_DIR"
     cp "$built_lib" "$BUILD_BIN_DIR/$output_name"
+    maybe_dylib_alias "$BUILD_BIN_DIR/$output_name"
 }
 
 prepare_sdcpp_mods() {
@@ -154,6 +164,7 @@ copy_alias_outputs() {
         [[ -n "$alias_name" ]] || continue
         cp "$ROOT_DIR/llmedge/build/native/$ARCH_DIR/$output_name" \
             "$ROOT_DIR/llmedge/build/native/$ARCH_DIR/$alias_name"
+        maybe_dylib_alias "$ROOT_DIR/llmedge/build/native/$ARCH_DIR/$alias_name"
     done < <(llmedge_native_alias_outputs "$target")
 }
 
@@ -172,7 +183,7 @@ build_target() {
     cmake -S "$DESKTOP_CMAKE_DIR" -B "$build_dir" "${cmake_args[@]}"
 
     cmake_target="$(llmedge_native_cmake_target "$target")"
-    cmake --build "$build_dir" --target "$cmake_target" --parallel "$(nproc)"
+    cmake --build "$build_dir" --target "$cmake_target" --parallel "$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)"
 
     output_name="$(llmedge_native_output_name "$target")"
     lib_path=$(find "$build_dir" -type f -name "$output_name" -print -quit || true)

--- a/scripts/depacify_so.py
+++ b/scripts/depacify_so.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Strip ARM64 pointer-authentication (PAC) instructions from an ELF .so, in place.
+
+    python3 depacify_so.py <libfoo.so> [more.so ...]
+
+Why: the Android emulator on Apple-Silicon Macs mis-virtualizes ARM PAC keys, so the auth
+instructions baked into the NDK prebuilt libc++/libunwind fault with SIGILL (autia/autib...).
+Real arm64 devices virtualize PAC correctly, so this is an EMULATOR-ONLY workaround — never ship a
+depacified .so.
+
+Correctness invariant (the part that matters): depacify is whole-program — every `pac*` (sign) AND
+every `aut*` (auth) hint becomes NOP, and `retaa`/`retab` become plain `ret`. Removing sign without
+removing the matching auth (or vice versa) would leave a signed pointer used unauthenticated and
+crash differently; "never sign, never auth, plain ret" is internally consistent.
+
+Only bytes inside SHF_EXECINSTR (executable) sections are touched, so rodata that happens to contain
+these word patterns is never corrupted.
+"""
+import struct
+import sys
+
+NOP = 0xD503201F
+RET_X30 = 0xD65F03C0
+
+# HINT-space PAC sign/auth instructions (no register operand) -> NOP.
+PAC_HINTS = {
+    0xD503233F: "paciasp", 0xD50323BF: "autiasp",
+    0xD503231F: "paciaz", 0xD503239F: "autiaz",
+    0xD503237F: "pacibsp", 0xD50323FF: "autibsp",
+    0xD503235F: "pacibz", 0xD50323DF: "autibz",
+    0xD503211F: "pacia1716", 0xD503219F: "autia1716",
+    0xD503215F: "pacib1716", 0xD50321DF: "autib1716",
+}
+# Authenticated returns -> plain ret x30.
+PAC_RETS = {0xD65F0BFF: "retaa", 0xD65F0FFF: "retab"}
+# Combined auth+branch (braa/blraa/...) cannot become a bare NOP; detect and refuse so we never emit
+# a silently-broken binary. (Our libsmollm.so has none of these.)
+BR_AUTH_MASK = 0xFE1FF800  # BRAA/BRAB/BLRAA/BLRAB family fixed bits
+BR_AUTH_VAL = 0xD61F0800
+
+
+def exec_section_ranges(data: bytes):
+    """Yield (file_offset, size) for every SHF_EXECINSTR section of an ELF64 LE image."""
+    assert data[:4] == b"\x7fELF", "not an ELF file"
+    assert data[4] == 2, "only ELF64 supported"
+    e_shoff = struct.unpack_from("<Q", data, 40)[0]
+    e_shentsize = struct.unpack_from("<H", data, 58)[0]
+    e_shnum = struct.unpack_from("<H", data, 60)[0]
+    for i in range(e_shnum):
+        base = e_shoff + i * e_shentsize
+        sh_flags = struct.unpack_from("<Q", data, base + 8)[0]
+        sh_offset = struct.unpack_from("<Q", data, base + 24)[0]
+        sh_size = struct.unpack_from("<Q", data, base + 32)[0]
+        if sh_flags & 0x4:  # SHF_EXECINSTR
+            yield sh_offset, sh_size
+
+
+def depacify(path: str) -> int:
+    with open(path, "rb") as f:
+        data = bytearray(f.read())
+
+    counts = {}
+    refused = 0
+    for off, size in exec_section_ranges(data):
+        for p in range(off, off + size - (size % 4), 4):
+            w = struct.unpack_from("<I", data, p)[0]
+            if w in PAC_HINTS:
+                struct.pack_into("<I", data, p, NOP)
+                counts[PAC_HINTS[w]] = counts.get(PAC_HINTS[w], 0) + 1
+            elif w in PAC_RETS:
+                struct.pack_into("<I", data, p, RET_X30)
+                counts[PAC_RETS[w]] = counts.get(PAC_RETS[w], 0) + 1
+            elif (w & BR_AUTH_MASK) == BR_AUTH_VAL:
+                refused += 1
+
+    if refused:
+        raise SystemExit(f"{path}: REFUSING — found {refused} braa/blraa-style auth-branches that "
+                         f"cannot be NOP'd safely; this binary needs a smarter rewrite.")
+
+    total = sum(counts.values())
+    with open(path, "wb") as f:
+        f.write(data)
+    detail = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+    print(f"{path}: patched {total} PAC instruction(s) [{detail or 'none'}]")
+    return total
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise SystemExit(__doc__)
+    grand = 0
+    for arg in sys.argv[1:]:
+        grand += depacify(arg)
+    print(f"done: {grand} PAC instruction(s) removed across {len(sys.argv) - 1} file(s)")

--- a/scripts/generate_native_target_names.sh
+++ b/scripts/generate_native_target_names.sh
@@ -14,8 +14,15 @@ if [[ ! -f "${CMAKE_TARGETS_FILE}" ]]; then
   exit 1
 fi
 
-mapfile -t target_lines < <(sed -nE 's/^set\((LLMEDGE_TARGET_[A-Z0-9_]+) "([^"]+)"\)$/\1=\2/p' "${CMAKE_TARGETS_FILE}")
-mapfile -t list_lines < <(sed -nE 's/^set\((LLMEDGE_(DESKTOP|CI)_TARGETS) "([^"]*)"\)$/\1=\3/p' "${CMAKE_TARGETS_FILE}")
+# Portable array population (bash 3.2 has no `mapfile`, e.g. stock macOS /bin/bash).
+target_lines=()
+while IFS= read -r line; do
+  target_lines+=("${line}")
+done < <(sed -nE 's/^set\((LLMEDGE_TARGET_[A-Z0-9_]+) "([^"]+)"\)$/\1=\2/p' "${CMAKE_TARGETS_FILE}")
+list_lines=()
+while IFS= read -r line; do
+  list_lines+=("${line}")
+done < <(sed -nE 's/^set\((LLMEDGE_(DESKTOP|CI)_TARGETS) "([^"]*)"\)$/\1=\3/p' "${CMAKE_TARGETS_FILE}")
 
 if [[ ${#target_lines[@]} -eq 0 ]]; then
   echo "No LLMEDGE_TARGET_* constants found in ${CMAKE_TARGETS_FILE}" >&2

--- a/scripts/jni-desktop/CMakeLists.txt
+++ b/scripts/jni-desktop/CMakeLists.txt
@@ -119,10 +119,16 @@ if(BUILD_SMOLLM)
         ${LLMEDGE_CPP_ROOT}/smollm_jni_completion.cpp
         ${LLMEDGE_CPP_ROOT}/smollm_jni_embeddings.cpp
         ${LLMEDGE_CPP_ROOT}/smollm_jni_state.cpp
+        ${LLMEDGE_CPP_ROOT}/smollm_jni_convert.cpp
         ${LLMEDGE_CPP_ROOT}/LLMInference.cpp
         ${LLMEDGE_CPP_ROOT}/llm_backend_support.cpp
         ${LLMEDGE_CPP_ROOT}/gguf_reader_internal.cpp
         ${LLMEDGE_CPP_ROOT}/GGUFReader.cpp
+        # On-device safetensors -> GGUF converter (Track B / Phase B2). No ggml/llama dependency.
+        ${LLMEDGE_CPP_ROOT}/convert/safetensors_reader.cpp
+        ${LLMEDGE_CPP_ROOT}/convert/gguf_writer.cpp
+        ${LLMEDGE_CPP_ROOT}/convert/tokenizer_bake.cpp
+        ${LLMEDGE_CPP_ROOT}/convert/hf_to_gguf.cpp
     )
 
     target_include_directories(${LLMEDGE_TARGET_SMOLLM} PRIVATE

--- a/scripts/jni-desktop/CMakeLists.txt
+++ b/scripts/jni-desktop/CMakeLists.txt
@@ -145,6 +145,12 @@ if(BUILD_SMOLLM)
         mtmd
         ${JNI_LIBRARIES}
     )
+
+    if(APPLE)
+        # macOS produces .dylib by default; the desktop test harness loads the lib by an absolute
+        # `.so` path (System.load accepts any extension), so force the `.so` suffix on all hosts.
+        set_target_properties(${LLMEDGE_TARGET_SMOLLM} PROPERTIES SUFFIX ".so")
+    endif()
 endif()
 
 # ------------------------------------------------------------

--- a/tools/safetensors-convert/README.md
+++ b/tools/safetensors-convert/README.md
@@ -1,0 +1,63 @@
+# safetensors → GGUF converter (Track B / Phase B1)
+
+Host-side tool that turns a Hugging Face safetensors model into a GGUF the llmedge runtime
+(`ik_llama.cpp`) can load. One converter, a `--precision` parameter:
+
+| `--precision` | meaning | needs |
+|---|---|---|
+| `f16` | "direct" load, no precision loss | upstream converter only |
+| `q8_0` | light, near-lossless | upstream converter only |
+| `q4_k_m` / `q5_k_m` | "lossy" k-quant | a built `llama-quantize` |
+| `iq2_bn` / `iq2_bn_r4` | ik_llama ternary (ternary models only) | a built `llama-quantize` |
+
+Runs on a dev box / CI — **never on-device** (that's Phase B2). Converting a model loads it in full
+precision, which is desktop-class work; do it once and ship the GGUF.
+
+## Setup
+
+```bash
+git submodule update --init llama.cpp          # provides convert_hf_to_gguf.py + gguf-py
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r tools/safetensors-convert/requirements.txt
+```
+
+## Use
+
+```bash
+cd tools/safetensors-convert
+
+# Stock Llama/Mistral/Qwen… -> F16 (arbitrary archs inherit upstream converter coverage)
+python convert.py --source unsloth/Qwen3-0.6B --precision f16 --out qwen3-0.6b-f16.gguf
+
+# Bonsai 0.5B: fold the QLinear per-output scales, then quantize
+python convert.py --source deepgrove/Bonsai --adapter bonsai-qlinear \
+    --precision q8_0 --out bonsai-0.5b-q8_0.gguf
+```
+
+For `q4_k_m` / `iq2_bn`, build `llama-quantize` from the submodule (host build, **no Android NDK**):
+
+```bash
+cmake -S llama.cpp -B build-host -DGGML_IQK_FLASH_ATTENTION=ON && cmake --build build-host -t llama-quantize
+python convert.py --source deepgrove/Bonsai --adapter bonsai-qlinear \
+    --precision iq2_bn --out bonsai-0.5b-iq2_bn.gguf --quantize-bin build-host/bin/llama-quantize
+```
+
+Then load it from the app via `ModelSpec.localFile("…/bonsai-0.5b-q8_0.gguf")` (sideload) or upload to
+Hugging Face and use `ModelSpec.huggingFace(...)` / `ModelSpec.safetensors(...)`.
+
+## Why Bonsai needs the adapter
+
+Bonsai is `QLlamaForCausalLM`: ternary weights in BF16 **plus** a per-output `.scales` applied after the
+matmul. Stock `convert_hf_to_gguf.py` can't load it. Since `y = (x·Wᵀ)·scale = x·(W·scale[:,None])ᵀ`, the
+adapter folds the scale into the weight (`bonsai_fold.py`) and rewrites the config to plain Llama. This is
+**lossy vs. the native 1.58-bit format** (lossless ternary only exists in PrismML's `Q2_0` fork, which
+ik_llama lacks), but yields a small, working GGUF.
+
+## Tests
+
+The fold math is unit-tested with numpy alone (no torch / model download):
+
+```bash
+pip install numpy
+python tools/safetensors-convert/test_bonsai_fold.py
+```

--- a/tools/safetensors-convert/bonsai_fold.py
+++ b/tools/safetensors-convert/bonsai_fold.py
@@ -1,0 +1,79 @@
+"""Bonsai (QLlama) -> stock Llama adapter.
+
+Bonsai stores ternary {-1,0,+1} weights in BF16 plus a per-output-channel ``.scales`` tensor
+that ``QLinear`` applies *after* the matmul:
+
+    y = (x @ W^T) * scales        # scales has shape [out_features]
+
+Because the scale is per output row, it folds into the weight exactly:
+
+    y = x @ (W * scales[:, None])^T
+
+so ``W_eff = W * scales[:, None]`` turns each ``QLinear`` back into an ordinary ``nn.Linear``.
+After folding (and rewriting ``config.json`` so the architecture is plain ``LlamaForCausalLM``)
+the checkpoint is a stock Llama model that the upstream ``convert_hf_to_gguf.py`` can consume.
+
+This module is backend-agnostic: it works with numpy arrays or torch tensors (anything that
+supports ``*``, ``.reshape`` and ``.ndim``), so the math can be unit-tested with numpy alone.
+"""
+
+from __future__ import annotations
+
+SCALE_SUFFIX = ".scales"
+WEIGHT_SUFFIX = ".weight"
+
+
+def _row_scale(weight, scale):
+    """Multiply each output row ``o`` of ``weight`` by ``scale[o]``.
+
+    ``weight`` has shape ``[out, in]`` (or ``[out, ...]``); ``scale`` has shape ``[out]``.
+    """
+    if scale.ndim != 1:
+        raise ValueError(f"scale must be 1-D [out_features], got shape {tuple(scale.shape)}")
+    if weight.shape[0] != scale.shape[0]:
+        raise ValueError(
+            f"out_features mismatch: weight {tuple(weight.shape)} vs scale {tuple(scale.shape)}"
+        )
+    broadcast = (-1,) + (1,) * (weight.ndim - 1)
+    return weight * scale.reshape(broadcast)
+
+
+def fold_scales(tensors):
+    """Return a new tensor dict with every ``X.scales`` folded into ``X.weight`` and dropped.
+
+    Tensors without a paired ``.scales`` (embeddings, lm_head, layernorms) pass through unchanged.
+    Raises if a ``.scales`` has no matching ``.weight``.
+    """
+    scale_keys = [k for k in tensors if k.endswith(SCALE_SUFFIX)]
+    consumed = set()
+    out = {}
+    for sk in scale_keys:
+        wk = sk[: -len(SCALE_SUFFIX)] + WEIGHT_SUFFIX
+        if wk not in tensors:
+            raise KeyError(f"scale tensor {sk!r} has no matching weight {wk!r}")
+        out[wk] = _row_scale(tensors[wk], tensors[sk])
+        consumed.add(wk)
+        consumed.add(sk)
+    for k, v in tensors.items():
+        if k in consumed:
+            continue
+        out[k] = v
+    return out
+
+
+def num_folded(tensors) -> int:
+    """How many ``.scales`` tensors would be folded (for logging / sanity checks)."""
+    return sum(1 for k in tensors if k.endswith(SCALE_SUFFIX))
+
+
+def rewrite_config(config: dict) -> dict:
+    """Rewrite a Bonsai ``config.json`` dict into a stock Llama one.
+
+    Drops the custom-modeling hooks so transformers / the GGUF converter treat it as plain Llama.
+    """
+    c = dict(config)
+    c["architectures"] = ["LlamaForCausalLM"]
+    c["model_type"] = "llama"
+    for key in ("auto_map", "quantization_config"):
+        c.pop(key, None)
+    return c

--- a/tools/safetensors-convert/convert.py
+++ b/tools/safetensors-convert/convert.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Host-side safetensors -> GGUF converter for llmedge (Track B / Phase B1).
+
+One converter, a precision parameter:
+  * ``--precision f16``     -> "direct" (no precision loss), produced straight by the upstream converter
+  * ``--precision q8_0``    -> light, near-lossless quantization (upstream converter)
+  * ``--precision q4_k_m``  -> "lossy", needs a built ``llama-quantize`` (pass ``--quantize-bin``)
+  * ``--precision iq2_bn``  -> ik_llama ternary quant, needs ``llama-quantize`` (ternary models only)
+
+Generic HF architectures inherit the coverage of the in-repo ``llama.cpp/convert_hf_to_gguf.py``.
+Bonsai needs ``--adapter bonsai-qlinear`` first: it folds the per-output ``.scales`` into the weights
+(see bonsai_fold.py) and rewrites the config to stock ``LlamaForCausalLM`` so the upstream converter
+accepts it.
+
+Examples
+--------
+    # Stock Llama-family model -> F16 GGUF
+    python convert.py --source unsloth/Qwen3-0.6B --precision f16 --out qwen3-0.6b-f16.gguf
+
+    # Bonsai 0.5B -> Q8_0 GGUF (fold QLinear scales first)
+    python convert.py --source deepgrove/Bonsai --adapter bonsai-qlinear \
+        --precision q8_0 --out bonsai-0.5b-q8_0.gguf
+
+Requirements: see requirements.txt (torch, safetensors, numpy, huggingface_hub, sentencepiece).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UPSTREAM_CONVERTER = REPO_ROOT / "llama.cpp" / "convert_hf_to_gguf.py"
+
+# precision -> upstream --outtype it can emit directly (others go through llama-quantize from f16)
+DIRECT_OUTTYPE = {"f16": "f16", "q8_0": "q8_0", "bf16": "bf16"}
+QUANTIZE_ONLY = {"q4_k_m": "Q4_K_M", "q5_k_m": "Q5_K_M", "iq2_bn": "IQ2_BN", "iq2_bn_r4": "IQ2_BN_R4"}
+
+
+def log(msg: str) -> None:
+    print(f"[convert] {msg}", flush=True)
+
+
+def resolve_source(source: str) -> Path:
+    """Return a local dir for ``source`` (a path, or a HF repo id to snapshot-download)."""
+    p = Path(source)
+    if p.is_dir():
+        return p
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        sys.exit("huggingface_hub not installed and --source is not a local dir. pip install -r requirements.txt")
+    log(f"downloading {source} from Hugging Face ...")
+    return Path(snapshot_download(repo_id=source, allow_patterns=[
+        "*.safetensors", "*.json", "*.model", "tokenizer*", "*.txt",
+    ]))
+
+
+def _load_all_safetensors(src: Path):
+    from safetensors.torch import load_file
+    index = src / "model.safetensors.index.json"
+    files = []
+    if index.exists():
+        weight_map = json.loads(index.read_text())["weight_map"]
+        files = sorted({src / shard for shard in weight_map.values()})
+    else:
+        single = src / "model.safetensors"
+        if not single.exists():
+            cand = sorted(src.glob("*.safetensors"))
+            if not cand:
+                sys.exit(f"no .safetensors found in {src}")
+            files = cand
+        else:
+            files = [single]
+    tensors = {}
+    for f in files:
+        log(f"loading {f.name}")
+        tensors.update(load_file(str(f)))
+    return tensors
+
+
+def apply_bonsai_adapter(src: Path, work: Path) -> Path:
+    """Fold Bonsai QLinear scales and rewrite config into a stock-Llama dir under ``work``."""
+    import torch
+    from safetensors.torch import save_file
+
+    from bonsai_fold import fold_scales, num_folded, rewrite_config
+
+    out_dir = work / "bonsai_stock_llama"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    tensors = _load_all_safetensors(src)
+    log(f"folding {num_folded(tensors)} .scales tensors into their weights")
+    # Upcast to float32 for an exact fold, then let the converter requantize.
+    tensors = {k: v.to(torch.float32) for k, v in tensors.items()}
+    folded = fold_scales(tensors)
+    save_file(folded, str(out_dir / "model.safetensors"), metadata={"format": "pt"})
+
+    cfg = json.loads((src / "config.json").read_text())
+    (out_dir / "config.json").write_text(json.dumps(rewrite_config(cfg), indent=2))
+
+    # Copy tokenizer / aux files the converter needs (but not the original weights/config/custom code).
+    for f in src.iterdir():
+        if f.suffix == ".safetensors" or f.name in {"config.json"} or f.name.endswith(".py"):
+            continue
+        if f.is_file():
+            shutil.copy2(f, out_dir / f.name)
+    log(f"stock-Llama checkpoint written to {out_dir}")
+    return out_dir
+
+
+def run_converter(model_dir: Path, out_gguf: Path, outtype: str) -> None:
+    if not UPSTREAM_CONVERTER.exists():
+        sys.exit(f"upstream converter not found at {UPSTREAM_CONVERTER} "
+                 "(run: git submodule update --init llama.cpp)")
+    cmd = [sys.executable, str(UPSTREAM_CONVERTER), str(model_dir),
+           "--outfile", str(out_gguf), "--outtype", outtype]
+    log("running: " + " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def quantize(in_gguf: Path, out_gguf: Path, qtype: str, quantize_bin: str | None) -> None:
+    if not quantize_bin:
+        sys.exit(f"--precision needs llama-quantize for {qtype}; pass --quantize-bin /path/to/llama-quantize "
+                 "(build it from the ik_llama submodule with cmake -- a host build, no Android NDK needed)")
+    cmd = [quantize_bin, str(in_gguf), str(out_gguf), qtype]
+    log("running: " + " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="safetensors -> GGUF for llmedge")
+    ap.add_argument("--source", required=True, help="HF repo id or local model dir")
+    ap.add_argument("--out", required=True, help="output .gguf path")
+    ap.add_argument("--precision", default="f16",
+                    choices=sorted(set(DIRECT_OUTTYPE) | set(QUANTIZE_ONLY)))
+    ap.add_argument("--adapter", default="none", choices=["none", "bonsai-qlinear"])
+    ap.add_argument("--quantize-bin", default=os.environ.get("LLAMA_QUANTIZE"),
+                    help="path to a built llama-quantize (needed for k-quants / iq2_bn)")
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="llmedge-convert-") as tmp:
+        work = Path(tmp)
+        model_dir = resolve_source(args.source)
+        if args.adapter == "bonsai-qlinear":
+            model_dir = apply_bonsai_adapter(model_dir, work)
+
+        if args.precision in DIRECT_OUTTYPE:
+            run_converter(model_dir, out, DIRECT_OUTTYPE[args.precision])
+        else:
+            f16 = work / "model-f16.gguf"
+            run_converter(model_dir, f16, "f16")
+            quantize(f16, out, QUANTIZE_ONLY[args.precision], args.quantize_bin)
+
+    log(f"done -> {out}  ({out.stat().st_size / 1e6:.0f} MB)" if out.exists() else "done")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/safetensors-convert/requirements.txt
+++ b/tools/safetensors-convert/requirements.txt
@@ -1,0 +1,8 @@
+# Host-side converter deps (run on a dev box / CI, not on-device).
+# The fold math (bonsai_fold.py) only needs numpy; full conversion needs the rest.
+numpy>=1.24
+torch>=2.1
+safetensors>=0.4
+huggingface_hub>=0.23
+sentencepiece>=0.2
+# gguf is vendored in the repo at llama.cpp/gguf-py and used by convert_hf_to_gguf.py.

--- a/tools/safetensors-convert/test_bonsai_fold.py
+++ b/tools/safetensors-convert/test_bonsai_fold.py
@@ -1,0 +1,86 @@
+"""Unit tests for the Bonsai scale-fold math. Runnable with numpy alone (no torch/model download).
+
+    python -m pytest tools/safetensors-convert/test_bonsai_fold.py
+    # or, without pytest:
+    python tools/safetensors-convert/test_bonsai_fold.py
+"""
+
+import numpy as np
+
+from bonsai_fold import fold_scales, num_folded, rewrite_config
+
+
+def test_row_scale_matches_post_matmul_scaling():
+    rng = np.random.default_rng(0)
+    # Ternary weight {-1,0,+1}, shape [out=4, in=3]; per-output scale [4].
+    w = rng.integers(-1, 2, size=(4, 3)).astype(np.float32)
+    scale = rng.standard_normal(4).astype(np.float32)
+    x = rng.standard_normal((5, 3)).astype(np.float32)
+
+    tensors = {"layer.weight": w.copy(), "layer.scales": scale.copy()}
+    folded = fold_scales(tensors)
+
+    # QLinear semantics: y = (x @ W^T) * scale  must equal  x @ W_eff^T
+    expected = (x @ w.T) * scale
+    got = x @ folded["layer.weight"].T
+    np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_scales_are_dropped_and_others_pass_through():
+    tensors = {
+        "model.layers.0.self_attn.q_proj.weight": np.ones((6, 4), np.float32),
+        "model.layers.0.self_attn.q_proj.scales": np.full((6,), 2.0, np.float32),
+        "model.embed_tokens.weight": np.ones((8, 4), np.float32),  # no scale -> untouched
+        "model.layers.0.input_layernorm.weight": np.ones((4,), np.float32),
+    }
+    assert num_folded(tensors) == 1
+    out = fold_scales(tensors)
+
+    assert not any(k.endswith(".scales") for k in out), "scales must be removed"
+    assert "model.embed_tokens.weight" in out
+    np.testing.assert_array_equal(out["model.embed_tokens.weight"], np.ones((8, 4), np.float32))
+    # q_proj weight was all ones, scale all twos -> folded all twos
+    np.testing.assert_array_equal(
+        out["model.layers.0.self_attn.q_proj.weight"], np.full((6, 4), 2.0, np.float32)
+    )
+
+
+def test_missing_weight_raises():
+    try:
+        fold_scales({"x.scales": np.ones((3,), np.float32)})
+    except KeyError:
+        return
+    raise AssertionError("expected KeyError for scale without matching weight")
+
+
+def test_shape_mismatch_raises():
+    try:
+        fold_scales(
+            {"x.weight": np.ones((4, 3), np.float32), "x.scales": np.ones((5,), np.float32)}
+        )
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for out_features mismatch")
+
+
+def test_rewrite_config_strips_custom_modeling():
+    cfg = {
+        "architectures": ["QLlamaForCausalLM"],
+        "model_type": "llama",
+        "auto_map": {"AutoModelForCausalLM": "modeling_qllama.QLlamaForCausalLM"},
+        "hidden_size": 1536,
+    }
+    out = rewrite_config(cfg)
+    assert out["architectures"] == ["LlamaForCausalLM"]
+    assert out["model_type"] == "llama"
+    assert "auto_map" not in out
+    assert out["hidden_size"] == 1536  # untouched
+    assert cfg["architectures"] == ["QLlamaForCausalLM"]  # input not mutated
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\n{len(fns)} passed")


### PR DESCRIPTION
This pull request introduces significant improvements to low-end device support in llmedge by adding ready-to-use model presets for lightweight models and laying out a design for on-device safetensors-to-GGUF model conversion. The main focus is to make it easier for users to run efficient models on low-resource devices without manual setup, and to provide a clear path for converting and loading models not natively supported by the runtime.

**Low-end model presets (Track A):**

- Added public `ModelPresets` in Kotlin, exposing ready-to-use specs for Microsoft BitNet b1.58 2B4T (IQ2_BN, ~988 MB) and SmolVLM2-256M (vision, ~280 MB), optimized for low-end devices. These models are now easily accessible and do not require manual repo/filename entry. [[1]](diffhunk://#diff-0a0d9f28a7323f523defe4d1a191725af810f7c0199762dcb521dbe5f129723aR1-R190) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R22) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R10) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R176-R201)
- Enhanced `ModelHints` to include an optional `chatTemplate` field, ensuring BitNet loads with the correct template and produces well-formed output out of the box.
- Updated documentation to showcase the new presets and clarify usage, including notes on model size and template handling. [[1]](diffhunk://#diff-0a0d9f28a7323f523defe4d1a191725af810f7c0199762dcb521dbe5f129723aR1-R190) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R176-R201) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R22) [[4]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R10)

**Safetensors → GGUF conversion (Track B):**

- Added a design spec for a safetensors-to-GGUF conversion pipeline, enabling users to convert and quantize Hugging Face safetensors models for use in llmedge. The spec outlines a two-phase approach: a host-side converter (shipping first) and an optional on-device native converter (deferred).
- The spec details special handling for models like Bonsai, which require a pre-processing step to fold ternary scales before conversion, and describes the new `ModelSpec.safetensors(...)` API for seamless integration.

These changes make it much easier to run efficient, supported models on low-end Android devices and provide a clear path for supporting additional models through conversion.

**Low-end model support:**
- Introduced `ModelPresets` for Microsoft BitNet b1.58 2B4T and SmolVLM2-256M, making them easily accessible for apps targeting low-end devices. [[1]](diffhunk://#diff-0a0d9f28a7323f523defe4d1a191725af810f7c0199762dcb521dbe5f129723aR1-R190) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R22) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R10) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R176-R201)
- Ensured BitNet uses the correct chat template by extending `ModelHints` and updating the load path to prioritize the preset's template.

**Safetensors conversion pipeline:**
- Designed a safetensors-to-GGUF conversion flow (host-side tool and API), supporting both direct (F16) and quantized (Q8_0, Q4_K_M, IQ2_BN) conversion, and handling special cases like Bonsai.
- Outlined a future on-device native converter for broader architecture coverage, sequenced after the host-side tool.

**Documentation updates:**
- Updated `README.md` and usage docs to highlight new presets, clarify template handling, and document model sizes and limitations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R176-R201) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R22) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R10) [[4]](diffhunk://#diff-0a0d9f28a7323f523defe4d1a191725af810f7c0199762dcb521dbe5f129723aR1-R190)
- Added detailed specs for both the low-end presets and the safetensors conversion pipeline for future reference and implementation guidance. [[1]](diffhunk://#diff-0a0d9f28a7323f523defe4d1a191725af810f7c0199762dcb521dbe5f129723aR1-R190) [[2]](diffhunk://#diff-cf8e62baed4234b7a00c6e14928512f6e06ecf65cb5fb7a35833f11fd8cac1b9R1-R130)