### PR TITLE
Restore a reachable CPU backend for image/video generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,6 +762,7 @@ Troubleshooting
 - If you see "Vulkan 1.2 required" or linker errors for Vulkan symbols, confirm `minSdk` is set to 30 or higher in `llmedge/build.gradle.kts` and that your NDK provides the expected Vulkan headers.
 - If experimental OpenCL is not available, or if a GPU backend fails to initialize or execute, llmedge falls back to Vulkan or CPU automatically. For text, Whisper, and image/video, a failing backend is blacklisted per subsystem for the rest of the process and the next backend is retried once.
 - If your device lacks both usable OpenCL and Vulkan support, the native code falls back to the CPU backend.
+- If the Vulkan driver initializes but the first generate hangs forever at the first compute dispatch (observed on PowerVR DXT-48 / Pixel 10 Tensor G5), the automatic fallback cannot trigger — load succeeds, so no failure is observed. Force the CPU backend for image/video generation with `LLMEdgeConfig(image = ImageRuntimeConfig(useVulkan = false))`.
 
 #### Notes:
 

--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -50,7 +50,7 @@ private:
     std::string original_value_;
 };
 
-static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, bool offloadToCpu) {
+static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, bool offloadToCpu, bool useVulkan) {
     if (!modelPath) {
         return nullptr;
     }
@@ -66,9 +66,11 @@ static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, b
 
     ggml_backend_t backend = nullptr;
 #ifdef SD_USE_VULKAN
-    if (ggml_backend_vk_get_device_count() > 0) {
+    if (useVulkan && ggml_backend_vk_get_device_count() > 0) {
         backend = ggml_backend_vk_init(0);
     }
+#else
+    (void)useVulkan;
 #endif
     if (!backend) {
         backend = ggml_backend_cpu_init();
@@ -117,7 +119,7 @@ static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, b
 // Encoder-only handle for FLUX.2 sequential mode (llmedge Lever 1): loads ONLY the Qwen3 text
 // encoder (no diffusion transformer), so the precompute phase peaks at the encoder size instead of
 // encoder+DiT. Mirrors try_create_t5_only_handle but builds an LLMEmbedder.
-static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bool offloadToCpu) {
+static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bool offloadToCpu, bool useVulkan) {
     if (!llmPath) {
         return nullptr;
     }
@@ -132,9 +134,11 @@ static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bo
 
     ggml_backend_t backend = nullptr;
 #ifdef SD_USE_VULKAN
-    if (ggml_backend_vk_get_device_count() > 0) {
+    if (useVulkan && ggml_backend_vk_get_device_count() > 0) {
         backend = ggml_backend_vk_init(0);
     }
+#else
+    (void)useVulkan;
 #endif
     if (!backend) {
         backend = ggml_backend_cpu_init();
@@ -435,7 +439,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
 
     if (!ctx) {
         if (isLlmOnly) {
-            SdHandle* llmOnlyHandle = try_create_llm_only_handle(env, llmPathValue.c_str(), offloadToCpu == JNI_TRUE);
+            SdHandle* llmOnlyHandle = try_create_llm_only_handle(env, llmPathValue.c_str(), offloadToCpu == JNI_TRUE, useVulkan == JNI_TRUE);
             if (llmOnlyHandle) {
                 if (jModelPath) env->ReleaseStringUTFChars(jModelPath, modelPath);
                 if (jVaePath)   env->ReleaseStringUTFChars(jVaePath, vaePath);
@@ -446,7 +450,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
             }
         }
         if (isT5OnlyRequest) {
-            SdHandle* t5OnlyHandle = try_create_t5_only_handle(env, modelPath, offloadToCpu == JNI_TRUE);
+            SdHandle* t5OnlyHandle = try_create_t5_only_handle(env, modelPath, offloadToCpu == JNI_TRUE, useVulkan == JNI_TRUE);
             if (t5OnlyHandle) {
                 if (jModelPath) env->ReleaseStringUTFChars(jModelPath, modelPath);
                 if (jVaePath)   env->ReleaseStringUTFChars(jVaePath, vaePath);

--- a/llmedge/src/main/java/io/aatricks/llmedge/LLMEdgeConfig.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/LLMEdgeConfig.kt
@@ -72,6 +72,14 @@ data class SpeechRuntimeConfig(
 data class ImageRuntimeConfig(
     val cache: RuntimeCacheConfig = RuntimeCacheConfig(maxEntries = 1, maxMemoryMb = 4096),
     val preferPerformanceMode: Boolean = false,
+    /**
+     * GPU (Vulkan, or OpenCL where built in) stays eligible by default: diffusion is compute-bound
+     * and the sd.cpp Vulkan path is the fast one on most devices — unlike text/vision, whose ik
+     * fork favors CPU. Set false to force the CPU backend for image/video generation: the escape
+     * hatch for devices whose Vulkan driver loads fine but deadlocks at the first compute dispatch
+     * (observed on PowerVR DXT-48, Pixel 10 / Tensor G5), where no automatic fallback can trigger.
+     */
+    val useVulkan: Boolean = true,
 )
 
 data class VisionRuntimeConfig(

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
@@ -39,7 +39,7 @@ internal object ImageRuntimeRequestPlanner {
                     subsystem = ComputeSubsystem.IMAGE,
                     // Keep GPU backends eligible by default. preferPerformanceMode tunes
                     // heuristics, but should not silently force CPU or CPU-offloaded weights.
-                    allowGpu = true,
+                    allowGpu = config.image.useVulkan,
                     nThreads = CpuTopology.getOptimalThreadCount(CpuTopology.TaskType.DIFFUSION),
                     // Split models (FLUX.2 Klein) bundle a multi-GB DiT + Qwen3 encoder; offload to
                     // CPU and keep the encoder/VAE off-GPU so they fit mobile memory budgets.
@@ -73,7 +73,7 @@ internal object ImageRuntimeRequestPlanner {
         val baseOptions =
             DiffusionLoadOptions(
                 subsystem = ComputeSubsystem.IMAGE,
-                allowGpu = true,
+                allowGpu = config.image.useVulkan,
                 nThreads = CpuTopology.getOptimalThreadCount(CpuTopology.TaskType.DIFFUSION),
                 offloadToCpu = true,
                 keepClipOnCpu = true,
@@ -222,7 +222,7 @@ internal object ImageRuntimeRequestPlanner {
         offloadAllToCpu: Boolean,
         vaeDecodeOnly: Boolean,
     ): DiffusionLoadOptions {
-        val allowGpu = params.taehv == null
+        val allowGpu = params.taehv == null && config.image.useVulkan
         return DiffusionLoadOptions(
             subsystem = ComputeSubsystem.VIDEO,
             allowGpu = allowGpu,

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
@@ -1,0 +1,46 @@
+package io.aatricks.llmedge.image
+
+import io.aatricks.llmedge.ImageRuntimeConfig
+import io.aatricks.llmedge.LLMEdgeConfig
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ImageRuntimeRequestPlannerTest {
+    private val cpuOnlyConfig = LLMEdgeConfig(image = ImageRuntimeConfig(useVulkan = false))
+
+    @Test
+    fun `image request keeps gpu eligible by default`() {
+        val request = ImageRuntimeRequestPlanner.imageRequest(ImageGenerationRequest(prompt = "x"), LLMEdgeConfig())
+        assertTrue(request.options.allowGpu)
+    }
+
+    @Test
+    fun `image request forces cpu when config disables vulkan`() {
+        val request = ImageRuntimeRequestPlanner.imageRequest(ImageGenerationRequest(prompt = "x"), cpuOnlyConfig)
+        assertFalse(request.options.allowGpu)
+    }
+
+    @Test
+    fun `sequential image plan forces cpu when config disables vulkan`() {
+        val params = ImageGenerationRequest(prompt = "x", textEncoder = cpuOnlyConfig.models.image)
+        val plan = ImageRuntimeRequestPlanner.imageSequentialPlan(params, cpuOnlyConfig)
+        assertFalse(plan.diffusionRequest.options.allowGpu)
+        // The conditioning phase is CPU-pinned regardless of config (peak-RAM promise).
+        assertFalse(plan.conditioningRequest.options.allowGpu)
+    }
+
+    @Test
+    fun `video request forces cpu when config disables vulkan`() {
+        val defaultRequest = ImageRuntimeRequestPlanner.directVideoRequest(VideoGenerationRequest(prompt = "x"), LLMEdgeConfig())
+        assertTrue(defaultRequest.options.allowGpu)
+
+        val cpuRequest = ImageRuntimeRequestPlanner.directVideoRequest(VideoGenerationRequest(prompt = "x"), cpuOnlyConfig)
+        assertFalse(cpuRequest.options.allowGpu)
+    }
+}


### PR DESCRIPTION
The Pixel 10 PowerVR report turned up a regression rather than a missing feature: the Kotlin backend fallback asks for CPU by setting GGML_DISABLE_VULKAN, but the compiled stable-diffusion.cpp stopped reading that variable when the mods/ overlays were retired. On any device with a working Vulkan driver the CPU backend was unreachable. On the Pixel 10 the driver loads the model fine and then deadlocks at the first compute dispatch, which the load-time fallback can never catch, so there was no way to generate at all.

Changes:

The sd.cpp fork's init_backend() honors GGML_DISABLE_VULKAN and GGML_DISABLE_OPENCL again (submodule bump to the fork branch fix/runtime-backend-disable-env). The T5-only and LLM-only encoder handles in the JNI take the useVulkan flag directly since they run outside the env-var scope. ImageRuntimeConfig gains useVulkan (default true) so an app can force CPU generation, wired through the request planner for image, sequential and video paths. README gets a troubleshooting note.

Tested: planner unit tests, both ABIs compile, and the new gate is present in the packaged arm64 libsdcpp.so. Real CPU generation through this path was later verified on an S22 as part of the process-isolation work.