### PR TITLE
Opt-in isolated worker process and hang watchdog for image/video generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,16 @@ Troubleshooting
 - If you see "Vulkan 1.2 required" or linker errors for Vulkan symbols, confirm `minSdk` is set to 30 or higher in `llmedge/build.gradle.kts` and that your NDK provides the expected Vulkan headers.
 - If experimental OpenCL is not available, or if a GPU backend fails to initialize or execute, llmedge falls back to Vulkan or CPU automatically. For text, Whisper, and image/video, a failing backend is blacklisted per subsystem for the rest of the process and the next backend is retried once.
 - If your device lacks both usable OpenCL and Vulkan support, the native code falls back to the CPU backend.
-- If the Vulkan driver initializes but the first generate hangs forever at the first compute dispatch (observed on PowerVR DXT-48 / Pixel 10 Tensor G5), the automatic fallback cannot trigger — load succeeds, so no failure is observed. Force the CPU backend for image/video generation with `LLMEdgeConfig(image = ImageRuntimeConfig(useVulkan = false))`.
+- If the Vulkan driver initializes but the first generate hangs forever at the first compute dispatch (observed on PowerVR DXT-48 / Pixel 10 Tensor G5), the automatic fallback cannot trigger — load succeeds, so no failure is observed. Force the CPU backend for image/video generation with `LLMEdgeConfig(image = ImageRuntimeConfig(useVulkan = false))`, or enable process isolation (below) so the library detects and recovers from the hang automatically.
+
+Process isolation for image/video generation (opt-in)
+
+`LLMEdgeConfig(image = ImageRuntimeConfig(workerMode = DiffusionWorkerMode.ISOLATED_PROCESS))` runs the diffusion stack in a library-owned `:llmedge_sd` worker process:
+
+- A native crash in the diffusion stack surfaces as a typed `WorkerCrashedException` (with one automatic CPU retry) instead of killing the app.
+- A GPU driver that hangs at dispatch is detected by a watchdog — no progress heartbeat while the worker's CPU time stays flat (a legitimate cold shader compile pegs a core and is never killed) — the worker is killed, and per `hangRecoveryPolicy` the request is transparently retried on CPU (default) or failed with `GenerationHangException`.
+- Hang verdicts persist across sessions (keyed to the OS build fingerprint, so a system/driver update re-enables the GPU automatically). `ImageClient.resetBackendVerdicts(context)` clears them manually.
+- The public `ImageClient` API is unchanged; `DiffusionWorkerMode.IN_PROCESS` remains the default for now. Apps that already host llmedge in their own service process should stay in-process to avoid a redundant extra process.
 
 #### Notes:
 

--- a/llmedge/build.gradle.kts
+++ b/llmedge/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
+    id("org.jetbrains.kotlin.plugin.parcelize")
     id("jacoco")
     id("com.vanniktech.maven.publish") version "0.34.0"
 }
@@ -137,6 +138,9 @@ android {
             path = file("src/main/cpp/CMakeLists.txt")
             version = "3.22.1"
         }
+    }
+    buildFeatures {
+        aidl = true
     }
     packaging {
         jniLibs {

--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/image/ipc/IsolatedGenerationParityTest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/image/ipc/IsolatedGenerationParityTest.kt
@@ -1,0 +1,117 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.aatricks.llmedge.DiffusionWorkerMode
+import io.aatricks.llmedge.ImageRuntimeConfig
+import io.aatricks.llmedge.LLMEdgeConfig
+import io.aatricks.llmedge.core.LLMEdgeScope
+import io.aatricks.llmedge.image.ImageGenerationRequest
+import io.aatricks.llmedge.model.DefaultModelRepository
+import io.aatricks.llmedge.model.ModelSpec
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Real-generation parity between the in-process and isolated engines, CPU backend (the path a
+ * device with a broken Vulkan driver lands on). Opt-in: needs a local SD model, e.g.
+ *   -Pandroid.testInstrumentationRunnerArguments.sdModelPath=/data/local/tmp/sdturbo.gguf
+ */
+@RunWith(AndroidJUnit4::class)
+class IsolatedGenerationParityTest {
+    @Test
+    fun isolatedCpuGenerateMatchesInProcess() {
+        val modelPath = InstrumentationRegistry.getArguments().getString("sdModelPath").orEmpty()
+        assumeTrue(
+            "Provide -Pandroid.testInstrumentationRunnerArguments.sdModelPath=<device path>",
+            modelPath.isNotBlank() && File(modelPath).exists(),
+        )
+        val request =
+            ImageGenerationRequest(
+                prompt = "a red apple on a wooden table",
+                width = 128,
+                height = 128,
+                steps = 2,
+                cfgScale = 1.0f,
+                seed = 7L,
+                model = ModelSpec.localFile(modelPath),
+            )
+
+        val inProcess = generateWith(DiffusionWorkerMode.IN_PROCESS, request)
+        val isolated = generateWith(DiffusionWorkerMode.ISOLATED_PROCESS, request)
+
+        assertEquals(128, isolated.width)
+        assertEquals(128, isolated.height)
+        assertTrue("isolated output must not be uniform", isNotUniform(isolated))
+        assertTrue("in-process output must not be uniform", isNotUniform(inProcess))
+
+        // Same seed, same backend, same thread planning: outputs should match near-exactly.
+        val total = 128 * 128
+        var matching = 0
+        for (y in 0 until 128) {
+            for (x in 0 until 128) {
+                if (inProcess.getPixel(x, y) == isolated.getPixel(x, y)) matching++
+            }
+        }
+        assertTrue(
+            "outputs diverged: only $matching/$total pixels identical",
+            matching >= (total * 0.98).toInt(),
+        )
+    }
+
+    private fun generateWith(
+        mode: DiffusionWorkerMode,
+        request: ImageGenerationRequest,
+    ): Bitmap {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val parentScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val edgeScope = LLMEdgeScope(parentScope, 4)
+        val config =
+            LLMEdgeConfig(
+                image =
+                    ImageRuntimeConfig(
+                        useVulkan = false,
+                        workerMode = mode,
+                    ),
+            )
+        val engine: DiffusionEngine =
+            when (mode) {
+                DiffusionWorkerMode.IN_PROCESS ->
+                    InProcessDiffusionEngine(context, edgeScope, config, DefaultModelRepository())
+                DiffusionWorkerMode.ISOLATED_PROCESS ->
+                    IsolatedDiffusionEngine(context, edgeScope, config)
+            }
+        return try {
+            runBlocking {
+                withTimeout(15 * 60_000) { engine.generate(request) }
+            }
+        } finally {
+            engine.close()
+            edgeScope.close()
+            parentScope.cancel()
+        }
+    }
+
+    private fun isNotUniform(bitmap: Bitmap): Boolean {
+        val first = bitmap.getPixel(0, 0)
+        for (y in 0 until bitmap.height step 8) {
+            for (x in 0 until bitmap.width step 8) {
+                if (bitmap.getPixel(x, y) != first) return true
+            }
+        }
+        return false
+    }
+}

--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/image/ipc/IsolatedWorkerTest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/image/ipc/IsolatedWorkerTest.kt
@@ -1,0 +1,161 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.os.Bundle
+import android.os.IBinder
+import android.os.Process
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.aatricks.llmedge.DiffusionWorkerMode
+import io.aatricks.llmedge.HangRecoveryPolicy
+import io.aatricks.llmedge.ImageRuntimeConfig
+import io.aatricks.llmedge.LLMEdgeConfig
+import io.aatricks.llmedge.WorkerWatchdogConfig
+import io.aatricks.llmedge.core.GenerationHangException
+import io.aatricks.llmedge.core.LLMEdgeScope
+import io.aatricks.llmedge.image.ImageGenerationRequest
+import io.aatricks.llmedge.runtime.ComputeBackend
+import io.aatricks.llmedge.runtime.ComputeSubsystem
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class IsolatedWorkerTest {
+    private lateinit var context: Context
+    private lateinit var parentScope: CoroutineScope
+    private lateinit var edgeScope: LLMEdgeScope
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        parentScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        edgeScope = LLMEdgeScope(parentScope, 2)
+        BackendVerdictStore(context).reset()
+    }
+
+    @After
+    fun tearDown() {
+        BackendVerdictStore(context).reset()
+        edgeScope.close()
+        parentScope.cancel()
+    }
+
+    @Test
+    fun sharedMemoryPixelCodecRoundTrips() {
+        val bitmap = Bitmap.createBitmap(16, 8, Bitmap.Config.ARGB_8888)
+        for (x in 0 until 16) for (y in 0 until 8) {
+            bitmap.setPixel(x, y, Color.rgb(x * 16, y * 32, (x + y) * 8))
+        }
+        val decoded = PixelCodec.decodeBitmap(PixelCodec.encodeBitmap(bitmap, "test_frame"))
+        assertEquals(bitmap.width, decoded.width)
+        assertEquals(bitmap.height, decoded.height)
+        assertEquals(bitmap.getPixel(3, 5), decoded.getPixel(3, 5))
+        assertEquals(bitmap.getPixel(15, 7), decoded.getPixel(15, 7))
+    }
+
+    @Test
+    fun workerServiceBindsInSeparateProcess() {
+        val latch = CountDownLatch(1)
+        var binder: IBinder? = null
+        val connection =
+            object : ServiceConnection {
+                override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                    binder = service
+                    latch.countDown()
+                }
+
+                override fun onServiceDisconnected(name: ComponentName?) = Unit
+            }
+        try {
+            assertTrue(
+                context.bindService(
+                    Intent(context, DiffusionWorkerService::class.java),
+                    connection,
+                    Context.BIND_AUTO_CREATE,
+                ),
+            )
+            assertTrue("service did not connect", latch.await(20, TimeUnit.SECONDS))
+            val worker = IDiffusionWorker.Stub.asInterface(binder)
+            val workerPid = worker.pid
+            assertNotEquals("worker must run in its own process", Process.myPid(), workerPid)
+            // initialize is idempotent
+            val config =
+                WorkerInitConfig(
+                    cacheMaxEntries = 1,
+                    cacheMaxMemoryMb = 1024,
+                    preferPerformanceMode = false,
+                    useVulkan = false,
+                    blacklistSeed = emptyList(),
+                )
+            worker.initialize(config)
+            worker.initialize(config)
+        } finally {
+            runCatching { context.unbindService(connection) }
+        }
+    }
+
+    @Test
+    fun watchdogKillsHungWorkerAndPersistsVerdict() {
+        val config =
+            LLMEdgeConfig(
+                image =
+                    ImageRuntimeConfig(
+                        workerMode = DiffusionWorkerMode.ISOLATED_PROCESS,
+                        hangRecoveryPolicy = HangRecoveryPolicy.FAIL_FAST,
+                        watchdog =
+                            WorkerWatchdogConfig(
+                                cpuSampleIntervalMs = 500,
+                                loadingStallTimeoutMs = 4_000,
+                                generatingStallTimeoutMs = 4_000,
+                                stepStallTimeoutMs = 4_000,
+                                hardWallTimeoutMs = 120_000,
+                            ),
+                    ),
+            )
+        val engine = IsolatedDiffusionEngine(context, edgeScope, config)
+        try {
+            runBlocking {
+                withTimeout(60_000) {
+                    engine.installFaultInjectionForTests(
+                        Bundle().apply {
+                            putString(DiffusionWorkerService.FAULT_MODE, DiffusionWorkerService.FAULT_HANG_AFTER_PHASE)
+                            putString(DiffusionWorkerService.FAULT_BACKEND, "VULKAN")
+                        },
+                    )
+                    try {
+                        engine.generate(ImageGenerationRequest(prompt = "hang test"))
+                        fail("expected GenerationHangException")
+                    } catch (hang: GenerationHangException) {
+                        assertEquals("VULKAN", hang.backend)
+                        assertEquals(DiffusionPhases.LOADING, hang.phase)
+                    }
+                }
+            }
+            assertTrue(
+                "hang verdict must be persisted",
+                BackendVerdictStore(context).load().contains(ComputeSubsystem.IMAGE to ComputeBackend.VULKAN),
+            )
+        } finally {
+            engine.close()
+        }
+    }
+}

--- a/llmedge/src/main/AndroidManifest.xml
+++ b/llmedge/src/main/AndroidManifest.xml
@@ -17,4 +17,16 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <application>
+        <!--
+          Optional worker process for image/video generation (DiffusionWorkerMode.ISOLATED_PROCESS).
+          Inert until bound: the :llmedge_sd process only spawns when a client binds the service.
+          Not android:isolatedProcess - the worker needs the app's storage to read model files.
+        -->
+        <service
+            android:name="io.aatricks.llmedge.image.ipc.DiffusionWorkerService"
+            android:process=":llmedge_sd"
+            android:exported="false" />
+    </application>
+
 </manifest>

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IDiffusionResultCallback.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IDiffusionResultCallback.aidl
@@ -1,0 +1,11 @@
+package io.aatricks.llmedge.image.ipc;
+
+import io.aatricks.llmedge.image.ipc.PhaseUpdate;
+import io.aatricks.llmedge.image.ipc.IpcImageResult;
+import io.aatricks.llmedge.image.ipc.IpcFailure;
+
+oneway interface IDiffusionResultCallback {
+    void onPhase(in PhaseUpdate update);
+    void onCompleted(in IpcImageResult result);
+    void onFailed(in IpcFailure failure);
+}

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IDiffusionVideoCallback.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IDiffusionVideoCallback.aidl
@@ -1,0 +1,12 @@
+package io.aatricks.llmedge.image.ipc;
+
+import io.aatricks.llmedge.image.ipc.PhaseUpdate;
+import io.aatricks.llmedge.image.ipc.IpcVideoResult;
+import io.aatricks.llmedge.image.ipc.IpcFailure;
+
+oneway interface IDiffusionVideoCallback {
+    void onPhase(in PhaseUpdate update);
+    void onProgress(String message, int current, int total);
+    void onCompleted(in IpcVideoResult result);
+    void onFailed(in IpcFailure failure);
+}

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IDiffusionWorker.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IDiffusionWorker.aidl
@@ -1,0 +1,19 @@
+package io.aatricks.llmedge.image.ipc;
+
+import android.os.Bundle;
+import io.aatricks.llmedge.image.ipc.WorkerInitConfig;
+import io.aatricks.llmedge.image.ipc.IpcImageRequest;
+import io.aatricks.llmedge.image.ipc.IpcVideoRequest;
+import io.aatricks.llmedge.image.ipc.IDiffusionResultCallback;
+import io.aatricks.llmedge.image.ipc.IDiffusionVideoCallback;
+
+interface IDiffusionWorker {
+    int getPid();
+    // Idempotent; re-sent after every (re)connect. Rebuilds the worker engine when config changes.
+    void initialize(in WorkerInitConfig config);
+    oneway void generateImage(in IpcImageRequest request, IDiffusionResultCallback callback);
+    oneway void generateVideo(in IpcVideoRequest request, IDiffusionVideoCallback callback);
+    oneway void cancelGeneration();
+    // Debug builds only (FLAG_DEBUGGABLE); throws SecurityException otherwise.
+    void installFaultInjection(in Bundle args);
+}

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcFailure.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcFailure.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable IpcFailure;

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcFrameBuffer.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcFrameBuffer.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable IpcFrameBuffer;

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcGenerationMetrics.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcGenerationMetrics.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable IpcGenerationMetrics;

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcImageRequest.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcImageRequest.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable IpcImageRequest;

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcImageResult.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcImageResult.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable IpcImageResult;

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcModelSpec.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcModelSpec.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable IpcModelSpec;

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcVideoRequest.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcVideoRequest.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable IpcVideoRequest;

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcVideoResult.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcVideoResult.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable IpcVideoResult;

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/PhaseUpdate.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/PhaseUpdate.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable PhaseUpdate;

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/WorkerInitConfig.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/WorkerInitConfig.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable WorkerInitConfig;

--- a/llmedge/src/main/java/io/aatricks/llmedge/LLMEdgeConfig.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/LLMEdgeConfig.kt
@@ -69,6 +69,53 @@ data class SpeechRuntimeConfig(
     val cache: RuntimeCacheConfig = RuntimeCacheConfig(maxEntries = 1, maxMemoryMb = 1024),
 )
 
+/** Where the diffusion (image/video) stack runs. */
+enum class DiffusionWorkerMode {
+    /** Historical behavior: native generation runs inside the app process. */
+    IN_PROCESS,
+
+    /**
+     * Generation runs in the library-owned `:llmedge_sd` process. Native crashes and GPU-driver
+     * hangs are contained there: the host observes a typed failure (or a transparent retry)
+     * instead of an app crash or a permanent freeze.
+     */
+    ISOLATED_PROCESS,
+}
+
+/** What to do when the watchdog kills a hung worker mid-request. */
+enum class HangRecoveryPolicy {
+    /** Transparently reissue the request on the CPU backend in a fresh worker; fail if that also dies. */
+    RETRY_CPU_THEN_FAIL,
+
+    /** Fail the request with [io.aatricks.llmedge.core.GenerationHangException]; the persisted verdict makes the NEXT request use CPU. */
+    FAIL_FAST,
+}
+
+/**
+ * Watchdog tuning for [DiffusionWorkerMode.ISOLATED_PROCESS]. A hang verdict requires BOTH no
+ * phase/step heartbeat for the phase's stall window AND a flat worker CPU delta over that window —
+ * a legitimate cold shader compile pegs a core (observed ~310s on Pixel 8), while a driver
+ * dispatch deadlock sits at 0% (observed on PowerVR DXT-48 / Pixel 10). RESOLVING (model
+ * download) is exempt from the flat-CPU rule.
+ */
+data class WorkerWatchdogConfig(
+    val enabled: Boolean = true,
+    val cpuSampleIntervalMs: Long = 2_000,
+    val resolvingStallTimeoutMs: Long = 30 * 60_000,
+    val loadingStallTimeoutMs: Long = 90_000,
+    val generatingStallTimeoutMs: Long = 90_000,
+    val stepStallTimeoutMs: Long = 300_000,
+    val hardWallTimeoutMs: Long = 30 * 60_000,
+    val cancelKillGraceMs: Long = 5_000,
+    /** CPU busy fraction (of one core) below which the worker counts as idle. */
+    val flatCpuThreshold: Double = 0.02,
+) {
+    init {
+        require(cpuSampleIntervalMs > 0) { "cpuSampleIntervalMs must be positive." }
+        require(flatCpuThreshold in 0.0..1.0) { "flatCpuThreshold must be within [0,1]." }
+    }
+}
+
 data class ImageRuntimeConfig(
     val cache: RuntimeCacheConfig = RuntimeCacheConfig(maxEntries = 1, maxMemoryMb = 4096),
     val preferPerformanceMode: Boolean = false,
@@ -80,6 +127,16 @@ data class ImageRuntimeConfig(
      * (observed on PowerVR DXT-48, Pixel 10 / Tensor G5), where no automatic fallback can trigger.
      */
     val useVulkan: Boolean = true,
+    /**
+     * Opt-in for now: [DiffusionWorkerMode.ISOLATED_PROCESS] runs image/video generation in a
+     * library-owned worker process so native crashes and driver hangs cannot take the app down.
+     * The default flips to ISOLATED_PROCESS in a future minor release.
+     */
+    val workerMode: DiffusionWorkerMode = DiffusionWorkerMode.IN_PROCESS,
+    val watchdog: WorkerWatchdogConfig = WorkerWatchdogConfig(),
+    val hangRecoveryPolicy: HangRecoveryPolicy = HangRecoveryPolicy.RETRY_CPU_THEN_FAIL,
+    /** Persist watchdog hang verdicts (keyed by Build.FINGERPRINT) so later sessions skip the broken backend. */
+    val persistBackendVerdicts: Boolean = true,
 )
 
 data class VisionRuntimeConfig(

--- a/llmedge/src/main/java/io/aatricks/llmedge/core/LLMEdgeException.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/core/LLMEdgeException.kt
@@ -46,3 +46,34 @@ class ModelFileNotFoundException(
 ) : FileNotFoundException("$modelKind file not found: $modelPath")
 
 class UnsupportedModelException(detail: String) : UnsupportedOperationException(detail)
+
+/** Failures of the isolated diffusion worker process (DiffusionWorkerMode.ISOLATED_PROCESS). */
+open class WorkerProcessException(message: String, cause: Throwable? = null) :
+    LLMEdgeException(message, cause)
+
+class WorkerBindException(detail: String, cause: Throwable? = null) :
+    WorkerProcessException("Failed to bind the diffusion worker service: $detail", cause)
+
+class WorkerCrashedException(
+    val backend: String?,
+    val exitReason: Int?,
+) : WorkerProcessException(
+    "Diffusion worker process died during generation" +
+        (backend?.let { " (backend=$it)" } ?: "") +
+        (exitReason?.let { " (exitReason=$it)" } ?: ""),
+)
+
+class WorkerKilledByMemoryException : WorkerProcessException(
+    "Diffusion worker process was killed by the low-memory killer. " +
+        "Consider forceSequentialLoad, CPU offload options, or a smaller model.",
+)
+
+class GenerationHangException(
+    val backend: String?,
+    val phase: String,
+    val stallMs: Long,
+) : WorkerProcessException(
+    "Generation hung in phase $phase for ${stallMs}ms with an idle worker" +
+        (backend?.let { " (backend=$it)" } ?: "") +
+        "; the worker process was killed. This usually indicates a broken GPU driver.",
+)

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/DiffusionPhaseListener.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/DiffusionPhaseListener.kt
@@ -1,0 +1,19 @@
+package io.aatricks.llmedge.image
+
+/**
+ * Coarse lifecycle heartbeats for a diffusion request, consumed by the worker-process watchdog.
+ * Phases are the [io.aatricks.llmedge.image.ipc.DiffusionPhases] constants. Implementations must
+ * be cheap and non-blocking: callbacks fire on the generation path (steps come from the native
+ * per-denoise-step progress callback).
+ */
+internal interface DiffusionPhaseListener {
+    fun onPhase(
+        phase: String,
+        backend: String? = null,
+    )
+
+    fun onStep(
+        step: Int,
+        totalSteps: Int,
+    )
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
@@ -2,6 +2,7 @@ package io.aatricks.llmedge.image
 
 import android.content.Context
 import android.graphics.Bitmap
+import io.aatricks.llmedge.DiffusionWorkerMode
 import io.aatricks.llmedge.LLMEdgeConfig
 import io.aatricks.llmedge.core.ClientBootstrapContext
 import io.aatricks.llmedge.core.FeatureContext
@@ -14,14 +15,15 @@ import io.aatricks.llmedge.image.diffusion.ImageGenerationTraceEvent
 import io.aatricks.llmedge.image.diffusion.LoraApplyMode
 import io.aatricks.llmedge.image.diffusion.SampleMethod
 import io.aatricks.llmedge.image.diffusion.Scheduler
+import io.aatricks.llmedge.image.ipc.DiffusionEngine
+import io.aatricks.llmedge.image.ipc.InProcessDiffusionEngine
+import io.aatricks.llmedge.image.ipc.IsolatedDiffusionEngine
 import io.aatricks.llmedge.model.DefaultModelRepository
 import io.aatricks.llmedge.model.ModelRepository
 import io.aatricks.llmedge.model.ModelSpec
 import io.aatricks.llmedge.runtime.BackendRuntimePolicy
-import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.sync.Mutex
 
 data class ImageGenerationRequest(
     val prompt: String,
@@ -109,30 +111,34 @@ class ImageClient internal constructor(
         internal fun resetVideoVulkanBlacklistForTests() {
             BackendRuntimePolicy.resetForTests()
         }
+
+        /**
+         * Clears persisted backend hang verdicts (recorded by the isolated-worker watchdog) and
+         * the in-memory blacklist, re-enabling GPU backends on the next load. Verdicts also clear
+         * automatically when the OS fingerprint changes (system/driver update).
+         */
+        @JvmStatic
+        fun resetBackendVerdicts(context: Context) {
+            io.aatricks.llmedge.image.ipc.BackendVerdictStore(context).reset()
+            BackendRuntimePolicy.resetForTests()
+        }
     }
 
-    private val runtimePool = createDiffusionRuntimePool(appContext, edgeScope, config, modelRepository)
-    private val generationMutex = Mutex()
-    private val imageRequestIds = AtomicLong(0L)
-    private val state = ImageClientState()
-    private val requestExecutor = DiffusionRequestExecutor(runtimePool, state, LOG_TAG)
-    private val imageGenerationExecutor =
-        ImageGenerationExecutor(
-            config = config,
-            generationMutex = generationMutex,
-            imageRequestIds = imageRequestIds,
-            state = state,
-            requestExecutor = requestExecutor,
-            logTag = LOG_TAG,
-        )
-    private val videoGenerationExecutor =
-        VideoGenerationExecutor(
-            scope = edgeScope,
-            config = config,
-            generationMutex = generationMutex,
-            state = state,
-            requestExecutor = requestExecutor,
-        )
+    init {
+        // Seed persisted hang verdicts into the in-memory blacklist for BOTH modes, so an
+        // in-process client on a device with a recorded GPU hang also avoids the broken backend.
+        if (config.image.persistBackendVerdicts) {
+            BackendRuntimePolicy.seed(io.aatricks.llmedge.image.ipc.BackendVerdictStore(appContext).load())
+        }
+    }
+
+    private val engine: DiffusionEngine =
+        when (config.image.workerMode) {
+            DiffusionWorkerMode.IN_PROCESS ->
+                InProcessDiffusionEngine(appContext, edgeScope, config, modelRepository, LOG_TAG)
+            DiffusionWorkerMode.ISOLATED_PROCESS ->
+                IsolatedDiffusionEngine(appContext, edgeScope, config)
+        }
 
     /**
      * Generate a single bitmap from text.
@@ -145,7 +151,7 @@ class ImageClient internal constructor(
      */
     suspend fun generate(
         params: ImageGenerationRequest,
-    ): Bitmap = imageGenerationExecutor.generate(params)
+    ): Bitmap = engine.generate(params)
 
     /**
      * Stream progress and final frames for text-to-video generation.
@@ -157,22 +163,20 @@ class ImageClient internal constructor(
      */
     fun generateVideo(
         params: VideoGenerationRequest,
-    ): Flow<GenerationStreamEvent> = videoGenerationExecutor.generate(params)
+    ): Flow<GenerationStreamEvent> = engine.generateVideo(params)
 
     /** Request cancellation for the active generation, if any. */
     fun cancelGeneration() {
-        state.activeModel?.cancelGeneration()
+        engine.cancelGeneration()
     }
 
-    fun getLastGenerationMetrics(): GenerationMetrics? = state.lastGenerationMetrics
+    fun getLastGenerationMetrics(): GenerationMetrics? = engine.lastGenerationMetrics()
 
-    internal fun getLastImageRequestTraceForTests(): List<ImageGenerationTraceEvent> = state.lastImageRequestTrace
+    internal fun getLastImageRequestTraceForTests(): List<ImageGenerationTraceEvent> = engine.lastImageRequestTraceForTests()
 
     override fun close() {
         closeOwned {
-            cancelGeneration()
-            state.activeModel = null
-            runtimePool.close()
+            engine.close()
         }
     }
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageGenerationExecutor.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageGenerationExecutor.kt
@@ -22,6 +22,7 @@ internal class ImageGenerationExecutor(
     private val state: ImageClientState,
     private val requestExecutor: DiffusionRequestExecutor,
     private val logTag: String,
+    private val phaseListener: DiffusionPhaseListener? = null,
 ) {
     suspend fun generate(params: ImageGenerationRequest): Bitmap {
         if (params.sequential && params.splitDiffusionModel && params.textEncoder != null) {
@@ -47,7 +48,8 @@ internal class ImageGenerationExecutor(
                     spec = plan.conditioningRequest.spec,
                     options = plan.conditioningRequest.options,
                     retryMessage = "Retrying FLUX.2 sequential conditioning on the next backend for",
-                ) { model, _, _ ->
+                ) { model, _, acquire ->
+                    phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.GENERATING, acquire.backend.name)
                     model.precomputeCondition(params.prompt, "", params.width, params.height, -1)
                 }
 
@@ -64,7 +66,13 @@ internal class ImageGenerationExecutor(
                 spec = plan.diffusionRequest.spec,
                 options = plan.diffusionRequest.options,
                 retryMessage = "Retrying FLUX.2 sequential diffusion on the next backend for",
-            ) { model, _, _ ->
+            ) { model, _, acquire ->
+                phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.GENERATING, acquire.backend.name)
+                phaseListener?.let { listener ->
+                    model.setProgressCallback { step, totalSteps, _, _, _ ->
+                        listener.onStep(step, totalSteps)
+                    }
+                }
                 val rgb =
                     model.txt2ImgWithPrecomputedCondition(
                         prompt = params.prompt,
@@ -146,20 +154,30 @@ internal class ImageGenerationExecutor(
                         ImageGenerationPhase.TXT2IMG_ENTER,
                         "ImageClient dispatching to StableDiffusion.txt2img",
                     )
+                    phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.GENERATING, acquire.backend.name)
+                    phaseListener?.let { listener ->
+                        model.setProgressCallback { step, totalSteps, _, _, _ ->
+                            listener.onStep(step, totalSteps)
+                        }
+                    }
                     val generationStartNanos = System.nanoTime()
                     val bitmap =
-                        model.txt2img(
-                            GenerateParams(
-                                prompt = params.prompt,
-                                negative = params.negative,
-                                width = params.width,
-                                height = params.height,
-                                steps = params.steps,
-                                cfgScale = params.cfgScale,
-                                seed = params.seed,
-                                easyCacheParams = easyCache,
-                            ),
-                        )
+                        try {
+                            model.txt2img(
+                                GenerateParams(
+                                    prompt = params.prompt,
+                                    negative = params.negative,
+                                    width = params.width,
+                                    height = params.height,
+                                    steps = params.steps,
+                                    cfgScale = params.cfgScale,
+                                    seed = params.seed,
+                                    easyCacheParams = easyCache,
+                                ),
+                            )
+                        } finally {
+                            if (phaseListener != null) model.setProgressCallback(null)
+                        }
                     val generateMs = elapsedMillis(generationStartNanos)
                     val requestMetrics =
                         ImageRequestMetrics(

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
@@ -71,6 +71,7 @@ internal class ManagedDiffusionModel(
 internal class DiffusionRuntimeLoader(
     private val context: Context,
     private val resolver: ModelRepository,
+    private val phaseListener: DiffusionPhaseListener? = null,
 ) {
     companion object {
         private const val LOG_TAG = "DiffusionRuntimeLoader"
@@ -81,6 +82,9 @@ internal class DiffusionRuntimeLoader(
         options: DiffusionLoadOptions,
         backend: ComputeBackend,
     ): ManagedDiffusionModel {
+        // RESOLVING may legitimately sit CPU-flat for minutes (network download); the watchdog
+        // exempts it from the flat-CPU hang rule, so it must be distinguishable from LOADING.
+        phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.RESOLVING_MODEL, backend.name)
         val resolvedModel = resolver.resolve(context, spec.model)
         val resolvedVae = spec.vae?.let { resolver.resolve(context, it) }
         val resolvedTextEncoder = spec.textEncoder?.let { resolver.resolve(context, it) }
@@ -173,6 +177,7 @@ internal class DiffusionRuntimeLoader(
             LOG_TAG,
             "Creating managed ${backend.name} runtime for ${resolvedModel.name} flash=$flashAttn sequential=${options.sequentialLoad}",
         )
+        phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.LOADING, backend.name)
         val model =
             StableDiffusion.loadWithRuntimeBackend(
                 context = context,
@@ -227,6 +232,7 @@ internal fun createDiffusionRuntimePool(
     scope: LLMEdgeScope,
     config: LLMEdgeConfig,
     resolver: ModelRepository,
+    phaseListener: DiffusionPhaseListener? = null,
 ): RuntimePool<DiffusionRuntimeSpec, DiffusionLoadOptions, ManagedDiffusionModel> =
     createCachedRuntimePool(
         context = context,
@@ -255,7 +261,7 @@ internal fun createDiffusionRuntimePool(
                         "loraMode=${options.loraApplyMode.id}",
                     )
                 },
-                loadRuntime = DiffusionRuntimeLoader(context, resolver)::load,
+                loadRuntime = DiffusionRuntimeLoader(context, resolver, phaseListener)::load,
                 activeBackend = { it.backend },
                 candidateRequest = { options ->
                     BackendCandidateResolver.Request(

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/VideoGenerationExecutor.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/VideoGenerationExecutor.kt
@@ -21,6 +21,7 @@ internal class VideoGenerationExecutor(
     private val generationMutex: Mutex,
     private val state: ImageClientState,
     private val requestExecutor: DiffusionRequestExecutor,
+    private val phaseListener: DiffusionPhaseListener? = null,
 ) {
     fun generate(params: VideoGenerationRequest): Flow<GenerationStreamEvent> =
         callbackFlow {
@@ -83,7 +84,8 @@ internal class VideoGenerationExecutor(
             spec = request.spec,
             options = request.options,
             retryMessage = "Retrying video generation on the next backend after a backend-specific failure for",
-        ) { model, _, _ ->
+        ) { model, _, acquire ->
+            phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.GENERATING, acquire.backend.name)
             val easyCache = model.resolveEasyCacheParams(params.easyCache)
             model.txt2vid(
                 params =
@@ -93,6 +95,7 @@ internal class VideoGenerationExecutor(
                     ),
                 onProgress =
                     VideoProgressCallback { step, totalSteps, currentFrame, totalFrames, _ ->
+                        phaseListener?.onStep(step, totalSteps)
                         onProgress?.invoke(
                             "Generating frame $currentFrame/$totalFrames",
                             step,
@@ -143,8 +146,9 @@ internal class VideoGenerationExecutor(
             spec = diffusionRequest.spec,
             options = diffusionRequest.options,
             retryMessage = "Retrying sequential video diffusion on the next backend after a backend-specific failure for",
-        ) { model, _, _ ->
+        ) { model, _, acquire ->
             onProgress?.invoke("Loading diffusion model", 0, params.steps)
+            phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.GENERATING, acquire.backend.name)
             val easyCache = model.resolveEasyCacheParams(params.easyCache)
             model.txt2VidWithPrecomputedCondition(
                 params =
@@ -156,6 +160,7 @@ internal class VideoGenerationExecutor(
                 uncond = conditioning.second,
                 onProgress =
                     VideoProgressCallback { step, totalSteps, currentFrame, totalFrames, _ ->
+                        phaseListener?.onStep(step, totalSteps)
                         onProgress?.invoke(
                             "Generating frame $currentFrame/$totalFrames",
                             step,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/BackendVerdictStore.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/BackendVerdictStore.kt
@@ -1,0 +1,59 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.content.Context
+import android.os.Build
+import io.aatricks.llmedge.runtime.ComputeBackend
+import io.aatricks.llmedge.runtime.ComputeSubsystem
+
+/**
+ * Persisted backend hang verdicts, host process only (the worker receives a seed over IPC).
+ * Keyed by [Build.FINGERPRINT]: an OS/driver update clears all verdicts, so a fixed GPU driver
+ * (e.g. the Pixel 10 QPR3 PowerVR bump) automatically re-enables Vulkan.
+ */
+internal class BackendVerdictStore(context: Context) {
+    private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun recordHang(
+        subsystem: ComputeSubsystem,
+        backend: ComputeBackend,
+    ) {
+        if (backend == ComputeBackend.CPU) return
+        prefs.edit()
+            .putString(KEY_FINGERPRINT, Build.FINGERPRINT)
+            .putLong(verdictKey(subsystem, backend), System.currentTimeMillis())
+            .apply()
+    }
+
+    /** Verdicts for the current OS fingerprint; clears stale ones from before an OS update. */
+    fun load(): List<Pair<ComputeSubsystem, ComputeBackend>> {
+        val stored = prefs.getString(KEY_FINGERPRINT, null) ?: return emptyList()
+        if (stored != Build.FINGERPRINT) {
+            reset()
+            return emptyList()
+        }
+        return prefs.all.keys
+            .filter { it.startsWith(VERDICT_PREFIX) }
+            .mapNotNull { key ->
+                val parts = key.removePrefix(VERDICT_PREFIX).split('.')
+                if (parts.size != 2) return@mapNotNull null
+                val subsystem = ComputeSubsystem.entries.firstOrNull { it.name == parts[0] } ?: return@mapNotNull null
+                val backend = ComputeBackend.entries.firstOrNull { it.name == parts[1] } ?: return@mapNotNull null
+                subsystem to backend
+            }
+    }
+
+    fun reset() {
+        prefs.edit().clear().apply()
+    }
+
+    private fun verdictKey(
+        subsystem: ComputeSubsystem,
+        backend: ComputeBackend,
+    ): String = "$VERDICT_PREFIX${subsystem.name}.${backend.name}"
+
+    companion object {
+        private const val PREFS_NAME = "llmedge_backend_verdicts"
+        private const val KEY_FINGERPRINT = "fingerprint"
+        private const val VERDICT_PREFIX = "verdict."
+    }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionEngine.kt
@@ -1,0 +1,26 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.graphics.Bitmap
+import io.aatricks.llmedge.image.GenerationStreamEvent
+import io.aatricks.llmedge.image.ImageGenerationRequest
+import io.aatricks.llmedge.image.VideoGenerationRequest
+import io.aatricks.llmedge.image.diffusion.GenerationMetrics
+import io.aatricks.llmedge.image.diffusion.ImageGenerationTraceEvent
+
+/**
+ * Seam between [io.aatricks.llmedge.image.ImageClient]'s public API and the diffusion stack.
+ * [InProcessDiffusionEngine] runs the stack in the caller's process (historical behavior);
+ * [IsolatedDiffusionEngine] proxies it to the `:llmedge_sd` worker process so that native
+ * crashes and GPU-driver hangs cannot take the host app down.
+ */
+internal interface DiffusionEngine : AutoCloseable {
+    suspend fun generate(params: ImageGenerationRequest): Bitmap
+
+    fun generateVideo(params: VideoGenerationRequest): kotlinx.coroutines.flow.Flow<GenerationStreamEvent>
+
+    fun cancelGeneration()
+
+    fun lastGenerationMetrics(): GenerationMetrics?
+
+    fun lastImageRequestTraceForTests(): List<ImageGenerationTraceEvent>
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
@@ -1,0 +1,255 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.os.Bundle
+import android.os.IBinder
+import android.os.Process
+import android.os.SystemClock
+import io.aatricks.llmedge.ImageRuntimeConfig
+import io.aatricks.llmedge.LLMEdgeConfig
+import io.aatricks.llmedge.RuntimeCacheConfig
+import io.aatricks.llmedge.core.AndroidLogAdapter
+import io.aatricks.llmedge.core.ClientBootstrapContext
+import io.aatricks.llmedge.image.DiffusionPhaseListener
+import io.aatricks.llmedge.image.GenerationStreamEvent
+import io.aatricks.llmedge.model.DefaultModelRepository
+import io.aatricks.llmedge.runtime.BackendRuntimePolicy
+import io.aatricks.llmedge.runtime.ComputeBackend
+import io.aatricks.llmedge.runtime.ComputeSubsystem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+/**
+ * Bound service hosting the diffusion stack in the `:llmedge_sd` process. It simply runs an
+ * [InProcessDiffusionEngine] here — same code, different process — and forwards phase heartbeats
+ * so the host-side watchdog can tell a hung worker from a busy one. Dying (crash, LMK, watchdog
+ * kill) is part of its contract: the host observes binderDied and recovers.
+ */
+internal class DiffusionWorkerService : Service() {
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private var bootstrap: ClientBootstrapContext? = null
+    private var engine: InProcessDiffusionEngine? = null
+    private var engineConfig: WorkerInitConfig? = null
+
+    /** Phase sink for the request currently generating (single in-flight). */
+    @Volatile private var phaseSink: ((PhaseUpdate) -> Unit)? = null
+
+    @Volatile private var faultInjection: Bundle? = null
+
+    private val phaseRelay =
+        object : DiffusionPhaseListener {
+            override fun onPhase(
+                phase: String,
+                backend: String?,
+            ) {
+                phaseSink?.invoke(PhaseUpdate(phase, backend, 0, 0, SystemClock.uptimeMillis()))
+            }
+
+            override fun onStep(
+                step: Int,
+                totalSteps: Int,
+            ) {
+                phaseSink?.invoke(PhaseUpdate(DiffusionPhases.STEP, null, step, totalSteps, SystemClock.uptimeMillis()))
+            }
+        }
+
+    private val binder =
+        object : IDiffusionWorker.Stub() {
+            override fun getPid(): Int = Process.myPid()
+
+            override fun initialize(config: WorkerInitConfig) {
+                synchronized(this@DiffusionWorkerService) {
+                    if (config == engineConfig && engine != null) return
+                    engine?.close()
+                    bootstrap?.close()
+                    val newBootstrap =
+                        ClientBootstrapContext.create(
+                            context = applicationContext,
+                            scope = serviceScope,
+                            inferenceThreads = Runtime.getRuntime().availableProcessors().coerceAtLeast(1),
+                        )
+                    BackendRuntimePolicy.seed(
+                        config.blacklistSeed.mapNotNull { entry ->
+                            val parts = entry.split(':')
+                            if (parts.size != 2) return@mapNotNull null
+                            val subsystem = ComputeSubsystem.entries.firstOrNull { it.name == parts[0] } ?: return@mapNotNull null
+                            val backend = ComputeBackend.entries.firstOrNull { it.name == parts[1] } ?: return@mapNotNull null
+                            subsystem to backend
+                        },
+                    )
+                    bootstrap = newBootstrap
+                    engine =
+                        InProcessDiffusionEngine(
+                            appContext = applicationContext,
+                            edgeScope = newBootstrap.edgeScope,
+                            config =
+                                LLMEdgeConfig(
+                                    image =
+                                        ImageRuntimeConfig(
+                                            cache =
+                                                RuntimeCacheConfig(
+                                                    maxEntries = config.cacheMaxEntries,
+                                                    maxMemoryMb = config.cacheMaxMemoryMb,
+                                                ),
+                                            preferPerformanceMode = config.preferPerformanceMode,
+                                            useVulkan = config.useVulkan,
+                                        ),
+                                ),
+                            modelRepository = DefaultModelRepository(),
+                            logTag = LOG_TAG,
+                            phaseListener = phaseRelay,
+                        )
+                    engineConfig = config
+                    AndroidLogAdapter.i(LOG_TAG, "Worker engine initialized (useVulkan=${config.useVulkan}, seed=${config.blacklistSeed})")
+                }
+            }
+
+            override fun generateImage(
+                request: IpcImageRequest,
+                callback: IDiffusionResultCallback,
+            ) {
+                val activeEngine = engine
+                serviceScope.launch {
+                    phaseSink = { update -> runCatching { callback.onPhase(update) } }
+                    if (simulateFaultIfRequested()) return@launch
+                    if (activeEngine == null) {
+                        runCatching { callback.onFailed(failure(IllegalStateException("worker not initialized"))) }
+                        phaseSink = null
+                        return@launch
+                    }
+                    try {
+                        val bitmap = activeEngine.generate(IpcCodecs.fromIpc(request))
+                        val metrics = activeEngine.lastGenerationMetrics()?.let(IpcCodecs::toIpc)
+                        val frame = PixelCodec.encodeBitmap(bitmap, "llmedge_image_result")
+                        try {
+                            callback.onCompleted(IpcImageResult(frame = frame, metrics = metrics))
+                        } finally {
+                            // Binder dups the fd during the call; our SharedMemory object is done.
+                            frame.memory.close()
+                        }
+                    } catch (t: Throwable) {
+                        runCatching { callback.onFailed(failure(t)) }
+                    } finally {
+                        phaseSink = null
+                    }
+                }
+            }
+
+            override fun generateVideo(
+                request: IpcVideoRequest,
+                callback: IDiffusionVideoCallback,
+            ) {
+                val activeEngine = engine
+                serviceScope.launch {
+                    phaseSink = { update -> runCatching { callback.onPhase(update) } }
+                    if (simulateFaultIfRequested()) return@launch
+                    if (activeEngine == null) {
+                        runCatching { callback.onFailed(failure(IllegalStateException("worker not initialized"))) }
+                        phaseSink = null
+                        return@launch
+                    }
+                    try {
+                        var completed = false
+                        activeEngine.generateVideo(IpcCodecs.fromIpc(request)).collect { event ->
+                            when (event) {
+                                is GenerationStreamEvent.Progress ->
+                                    runCatching {
+                                        callback.onProgress(event.update.message, event.update.current, event.update.total)
+                                    }
+                                is GenerationStreamEvent.Completed -> {
+                                    completed = true
+                                    val metrics = activeEngine.lastGenerationMetrics()?.let(IpcCodecs::toIpc)
+                                    val frames = PixelCodec.encodeFrames(event.frames, "llmedge_video_result")
+                                    try {
+                                        callback.onCompleted(IpcVideoResult(frames = frames, metrics = metrics))
+                                    } finally {
+                                        frames.memory.close()
+                                    }
+                                }
+                            }
+                        }
+                        if (!completed) {
+                            runCatching { callback.onFailed(failure(IllegalStateException("video flow ended without frames"))) }
+                        }
+                    } catch (t: Throwable) {
+                        runCatching { callback.onFailed(failure(t)) }
+                    } finally {
+                        phaseSink = null
+                    }
+                }
+            }
+
+            override fun cancelGeneration() {
+                engine?.cancelGeneration()
+            }
+
+            override fun installFaultInjection(args: Bundle) {
+                val debuggable = (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+                if (!debuggable) throw SecurityException("Fault injection requires a debuggable build")
+                faultInjection = args
+                AndroidLogAdapter.w(LOG_TAG, "Fault injection installed: ${args.getString(FAULT_MODE)}")
+            }
+        }
+
+    /** Returns true when a fault was simulated instead of generating. */
+    private fun simulateFaultIfRequested(): Boolean {
+        val args = faultInjection ?: return false
+        when (args.getString(FAULT_MODE)) {
+            FAULT_HANG -> {
+                // Reproduce the driver-deadlock signature: no callbacks, thread parked, 0% CPU.
+                AndroidLogAdapter.w(LOG_TAG, "Simulating dispatch hang")
+                java.util.concurrent.CountDownLatch(1).await()
+            }
+            FAULT_HANG_AFTER_PHASE -> {
+                phaseSink?.invoke(
+                    PhaseUpdate(DiffusionPhases.LOADING, args.getString(FAULT_BACKEND) ?: "VULKAN", 0, 0, SystemClock.uptimeMillis()),
+                )
+                AndroidLogAdapter.w(LOG_TAG, "Simulating dispatch hang after LOADING phase")
+                java.util.concurrent.CountDownLatch(1).await()
+            }
+            FAULT_CRASH -> {
+                AndroidLogAdapter.w(LOG_TAG, "Simulating native crash")
+                Process.killProcess(Process.myPid())
+            }
+            else -> return false
+        }
+        return true
+    }
+
+    private fun failure(t: Throwable): IpcFailure =
+        IpcFailure(
+            code =
+                if (t is kotlinx.coroutines.CancellationException) {
+                    IpcFailure.CODE_CANCELLED
+                } else {
+                    IpcFailure.CODE_GENERIC
+                },
+            exceptionClass = t.javaClass.name,
+            message = t.message,
+            backend = null,
+        )
+
+    override fun onBind(intent: Intent?): IBinder = binder
+
+    override fun onDestroy() {
+        engine?.close()
+        bootstrap?.close()
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val LOG_TAG = "DiffusionWorker"
+        const val FAULT_MODE = "mode"
+        const val FAULT_BACKEND = "backend"
+        const val FAULT_HANG = "hang"
+        const val FAULT_HANG_AFTER_PHASE = "hang-after-phase"
+        const val FAULT_CRASH = "crash"
+    }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/GenerationWatchdog.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/GenerationWatchdog.kt
@@ -1,0 +1,108 @@
+package io.aatricks.llmedge.image.ipc
+
+import io.aatricks.llmedge.WorkerWatchdogConfig
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Pure hang detector for one generation request. Driven from outside: phase/step heartbeats via
+ * [onPhase]/[onStep], periodic [sample] ticks (every [WorkerWatchdogConfig.cpuSampleIntervalMs]).
+ *
+ * Hang verdict = no heartbeat for the current phase's stall window AND the worker's CPU delta over
+ * that window is flat. Flat CPU is the discriminator: a cold shader compile pegs a core for
+ * minutes and must never be killed; a driver dispatch deadlock sits at 0% with all threads
+ * sleeping. RESOLVING_MODEL (network download) is legitimately CPU-flat and only the hard wall
+ * applies there. If CPU time is unreadable the stall rule is skipped entirely (hard wall only).
+ */
+internal class GenerationWatchdog(
+    private val config: WorkerWatchdogConfig,
+    private val clock: () -> Long,
+    private val cpuTimeMsReader: () -> Long?,
+    private val onHangVerdict: (phase: String, backend: String?, stallMs: Long) -> Unit,
+) {
+    private val fired = AtomicBoolean(false)
+    private val stopped = AtomicBoolean(false)
+
+    private val startMs = clock()
+
+    @Volatile private var phase: String = DiffusionPhases.REQUESTED
+
+    @Volatile private var backend: String? = null
+
+    @Volatile private var windowStartMs: Long = startMs
+
+    @Volatile private var cpuAtWindowStartMs: Long? = null
+
+    @Synchronized
+    fun onPhase(
+        newPhase: String,
+        newBackend: String?,
+    ) {
+        phase = newPhase
+        if (newBackend != null) backend = newBackend
+        resetWindow()
+    }
+
+    fun onStep(
+        step: Int,
+        totalSteps: Int,
+    ) = onPhase(DiffusionPhases.STEP, null)
+
+    @Synchronized
+    fun sample() {
+        if (fired.get() || stopped.get()) return
+        val now = clock()
+        if (now - startMs >= config.hardWallTimeoutMs) {
+            fire(now)
+            return
+        }
+        val stallMs = now - windowStartMs
+        if (stallMs < stallTimeoutFor(phase)) return
+        if (phase == DiffusionPhases.RESOLVING_MODEL) return // downloads are CPU-flat; hard wall only
+
+        val cpuNow = cpuTimeMsReader() ?: return // unreadable: never kill on the stall rule
+        val cpuAtStart = cpuAtWindowStartMs
+        if (cpuAtStart == null) {
+            // First readable sample inside this window: anchor and re-measure from here.
+            cpuAtWindowStartMs = cpuNow
+            windowStartMs = now
+            return
+        }
+        val busyFraction = (cpuNow - cpuAtStart).toDouble() / stallMs.toDouble()
+        if (busyFraction < config.flatCpuThreshold) {
+            fire(now)
+        } else {
+            // Worker is computing (e.g. shader compile). Slide the window so flatness is always
+            // judged over the most recent stall period.
+            cpuAtWindowStartMs = cpuNow
+            windowStartMs = now
+        }
+    }
+
+    fun stop() {
+        stopped.set(true)
+    }
+
+    fun lastPhase(): String = phase
+
+    fun lastBackend(): String? = backend
+
+    private fun fire(now: Long) {
+        if (fired.compareAndSet(false, true)) {
+            onHangVerdict(phase, backend, now - windowStartMs)
+        }
+    }
+
+    private fun resetWindow() {
+        windowStartMs = clock()
+        cpuAtWindowStartMs = cpuTimeMsReader()
+    }
+
+    private fun stallTimeoutFor(phase: String): Long =
+        when (phase) {
+            DiffusionPhases.RESOLVING_MODEL -> config.resolvingStallTimeoutMs
+            DiffusionPhases.LOADING -> config.loadingStallTimeoutMs
+            DiffusionPhases.GENERATING -> config.generatingStallTimeoutMs
+            DiffusionPhases.STEP -> config.stepStallTimeoutMs
+            else -> config.loadingStallTimeoutMs
+        }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/InProcessDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/InProcessDiffusionEngine.kt
@@ -1,0 +1,75 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.content.Context
+import android.graphics.Bitmap
+import io.aatricks.llmedge.LLMEdgeConfig
+import io.aatricks.llmedge.core.LLMEdgeScope
+import io.aatricks.llmedge.image.DiffusionPhaseListener
+import io.aatricks.llmedge.image.DiffusionRequestExecutor
+import io.aatricks.llmedge.image.GenerationStreamEvent
+import io.aatricks.llmedge.image.ImageClientState
+import io.aatricks.llmedge.image.ImageGenerationExecutor
+import io.aatricks.llmedge.image.ImageGenerationRequest
+import io.aatricks.llmedge.image.VideoGenerationExecutor
+import io.aatricks.llmedge.image.VideoGenerationRequest
+import io.aatricks.llmedge.image.createDiffusionRuntimePool
+import io.aatricks.llmedge.image.diffusion.GenerationMetrics
+import io.aatricks.llmedge.image.diffusion.ImageGenerationTraceEvent
+import io.aatricks.llmedge.model.ModelRepository
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+
+/** The historical in-process diffusion stack, extracted verbatim from ImageClient. */
+internal class InProcessDiffusionEngine(
+    appContext: Context,
+    edgeScope: LLMEdgeScope,
+    config: LLMEdgeConfig,
+    modelRepository: ModelRepository,
+    logTag: String = "ImageClient",
+    phaseListener: DiffusionPhaseListener? = null,
+) : DiffusionEngine {
+    private val runtimePool = createDiffusionRuntimePool(appContext, edgeScope, config, modelRepository, phaseListener)
+    private val generationMutex = Mutex()
+    private val imageRequestIds = AtomicLong(0L)
+    private val state = ImageClientState()
+    private val requestExecutor = DiffusionRequestExecutor(runtimePool, state, logTag)
+    private val imageGenerationExecutor =
+        ImageGenerationExecutor(
+            config = config,
+            generationMutex = generationMutex,
+            imageRequestIds = imageRequestIds,
+            state = state,
+            requestExecutor = requestExecutor,
+            logTag = logTag,
+            phaseListener = phaseListener,
+        )
+    private val videoGenerationExecutor =
+        VideoGenerationExecutor(
+            scope = edgeScope,
+            config = config,
+            generationMutex = generationMutex,
+            state = state,
+            requestExecutor = requestExecutor,
+            phaseListener = phaseListener,
+        )
+
+    override suspend fun generate(params: ImageGenerationRequest): Bitmap = imageGenerationExecutor.generate(params)
+
+    override fun generateVideo(params: VideoGenerationRequest): Flow<GenerationStreamEvent> =
+        videoGenerationExecutor.generate(params)
+
+    override fun cancelGeneration() {
+        state.activeModel?.cancelGeneration()
+    }
+
+    override fun lastGenerationMetrics(): GenerationMetrics? = state.lastGenerationMetrics
+
+    override fun lastImageRequestTraceForTests(): List<ImageGenerationTraceEvent> = state.lastImageRequestTrace
+
+    override fun close() {
+        cancelGeneration()
+        state.activeModel = null
+        runtimePool.close()
+    }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcCodecs.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcCodecs.kt
@@ -1,0 +1,317 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.graphics.Bitmap
+import android.os.SharedMemory
+import io.aatricks.llmedge.image.ImageGenerationRequest
+import io.aatricks.llmedge.image.VideoGenerationRequest
+import io.aatricks.llmedge.image.diffusion.EasyCacheParams
+import io.aatricks.llmedge.image.diffusion.GenerationMetrics
+import io.aatricks.llmedge.image.diffusion.ImageRequestMetrics
+import io.aatricks.llmedge.image.diffusion.LoraApplyMode
+import io.aatricks.llmedge.image.diffusion.SampleMethod
+import io.aatricks.llmedge.image.diffusion.Scheduler
+import io.aatricks.llmedge.model.ModelArtifactKind
+import io.aatricks.llmedge.model.ModelCapability
+import io.aatricks.llmedge.model.ModelConversion
+import io.aatricks.llmedge.model.ModelHints
+import io.aatricks.llmedge.model.ModelSpec
+import io.aatricks.llmedge.model.ConversionAdapter
+import io.aatricks.llmedge.model.ConversionPrecision
+import java.io.File
+
+internal object IpcCodecs {
+    private const val TYPE_LOCAL = "local"
+    private const val TYPE_HF = "hf"
+
+    fun toIpc(spec: ModelSpec): IpcModelSpec =
+        when (spec) {
+            is ModelSpec.LocalFile ->
+                IpcModelSpec(
+                    type = TYPE_LOCAL,
+                    path = spec.file.absolutePath,
+                    repoId = null,
+                    filename = null,
+                    revision = null,
+                    preferredQuantizations = emptyList(),
+                    token = null,
+                    forceDownload = false,
+                    preferSystemDownloader = true,
+                    artifactKind = spec.hints.artifactKind.name,
+                    capabilities = spec.hints.capabilities.map(ModelCapability::name),
+                    chatTemplate = spec.hints.chatTemplate,
+                    conversionPrecision = spec.hints.conversion?.precision?.name,
+                    conversionAdapter = spec.hints.conversion?.adapter?.name,
+                    conversionTokenizerPre = spec.hints.conversion?.tokenizerPre,
+                )
+            is ModelSpec.HuggingFace ->
+                IpcModelSpec(
+                    type = TYPE_HF,
+                    path = null,
+                    repoId = spec.repoId,
+                    filename = spec.filename,
+                    revision = spec.revision,
+                    preferredQuantizations = spec.preferredQuantizations,
+                    token = spec.token,
+                    forceDownload = spec.forceDownload,
+                    preferSystemDownloader = spec.preferSystemDownloader,
+                    artifactKind = spec.hints.artifactKind.name,
+                    capabilities = spec.hints.capabilities.map(ModelCapability::name),
+                    chatTemplate = spec.hints.chatTemplate,
+                    conversionPrecision = spec.hints.conversion?.precision?.name,
+                    conversionAdapter = spec.hints.conversion?.adapter?.name,
+                    conversionTokenizerPre = spec.hints.conversion?.tokenizerPre,
+                )
+        }
+
+    fun fromIpc(spec: IpcModelSpec): ModelSpec {
+        val hints =
+            ModelHints(
+                artifactKind = ModelArtifactKind.valueOf(spec.artifactKind),
+                capabilities = spec.capabilities.map(ModelCapability::valueOf).toSet(),
+                chatTemplate = spec.chatTemplate,
+                conversion =
+                    spec.conversionPrecision?.let { precision ->
+                        ModelConversion(
+                            precision = ConversionPrecision.valueOf(precision),
+                            adapter = ConversionAdapter.valueOf(spec.conversionAdapter ?: ConversionAdapter.NONE.name),
+                            tokenizerPre = spec.conversionTokenizerPre,
+                        )
+                    },
+            )
+        return when (spec.type) {
+            TYPE_LOCAL -> ModelSpec.LocalFile(File(requireNotNull(spec.path) { "local spec without path" }), hints)
+            TYPE_HF ->
+                ModelSpec.HuggingFace(
+                    repoId = requireNotNull(spec.repoId) { "hf spec without repoId" },
+                    filename = spec.filename,
+                    revision = spec.revision ?: "main",
+                    preferredQuantizations = spec.preferredQuantizations,
+                    token = spec.token,
+                    forceDownload = spec.forceDownload,
+                    preferSystemDownloader = spec.preferSystemDownloader,
+                    hints = hints,
+                )
+            else -> throw IllegalArgumentException("Unknown IpcModelSpec type '${spec.type}'")
+        }
+    }
+
+    fun toIpc(request: ImageGenerationRequest): IpcImageRequest =
+        IpcImageRequest(
+            prompt = request.prompt,
+            negative = request.negative,
+            width = request.width,
+            height = request.height,
+            steps = request.steps,
+            cfgScale = request.cfgScale,
+            seed = request.seed,
+            flashAttention = request.flashAttention,
+            forceSequentialLoad = request.forceSequentialLoad,
+            easyCacheEnabled = request.easyCache.enabled,
+            easyCacheReuseThreshold = request.easyCache.reuseThreshold,
+            easyCacheStartPercent = request.easyCache.startPercent,
+            easyCacheEndPercent = request.easyCache.endPercent,
+            loraModelDir = request.loraModelDir,
+            loraApplyModeId = request.loraApplyMode.id,
+            model = request.model?.let(::toIpc),
+            vae = request.vae?.let(::toIpc),
+            textEncoder = request.textEncoder?.let(::toIpc),
+            splitDiffusionModel = request.splitDiffusionModel,
+            sequential = request.sequential,
+        )
+
+    fun fromIpc(request: IpcImageRequest): ImageGenerationRequest =
+        ImageGenerationRequest(
+            prompt = request.prompt,
+            negative = request.negative,
+            width = request.width,
+            height = request.height,
+            steps = request.steps,
+            cfgScale = request.cfgScale,
+            seed = request.seed,
+            flashAttention = request.flashAttention,
+            forceSequentialLoad = request.forceSequentialLoad,
+            easyCache =
+                EasyCacheParams(
+                    enabled = request.easyCacheEnabled,
+                    reuseThreshold = request.easyCacheReuseThreshold,
+                    startPercent = request.easyCacheStartPercent,
+                    endPercent = request.easyCacheEndPercent,
+                ),
+            loraModelDir = request.loraModelDir,
+            loraApplyMode = LoraApplyMode.fromId(request.loraApplyModeId),
+            model = request.model?.let(::fromIpc),
+            vae = request.vae?.let(::fromIpc),
+            textEncoder = request.textEncoder?.let(::fromIpc),
+            splitDiffusionModel = request.splitDiffusionModel,
+            sequential = request.sequential,
+        )
+
+    fun toIpc(request: VideoGenerationRequest): IpcVideoRequest =
+        IpcVideoRequest(
+            prompt = request.prompt,
+            negative = request.negative,
+            width = request.width,
+            height = request.height,
+            videoFrames = request.videoFrames,
+            steps = request.steps,
+            cfgScale = request.cfgScale,
+            seed = request.seed,
+            flowShift = request.flowShift,
+            flashAttention = request.flashAttention,
+            forceSequentialLoad = request.forceSequentialLoad,
+            initImage = request.initImage?.let { PixelCodec.encodeBitmap(it, "llmedge_init_image") },
+            strength = request.strength,
+            sampleMethodId = request.sampleMethod.id,
+            schedulerId = request.scheduler.id,
+            easyCacheEnabled = request.easyCache.enabled,
+            easyCacheReuseThreshold = request.easyCache.reuseThreshold,
+            easyCacheStartPercent = request.easyCache.startPercent,
+            easyCacheEndPercent = request.easyCache.endPercent,
+            loraModelDir = request.loraModelDir,
+            loraApplyModeId = request.loraApplyMode.id,
+            taehv = request.taehv?.let(::toIpc),
+            model = request.model?.let(::toIpc),
+            vae = request.vae?.let(::toIpc),
+            textEncoder = request.textEncoder?.let(::toIpc),
+        )
+
+    fun fromIpc(request: IpcVideoRequest): VideoGenerationRequest =
+        VideoGenerationRequest(
+            prompt = request.prompt,
+            negative = request.negative,
+            width = request.width,
+            height = request.height,
+            videoFrames = request.videoFrames,
+            steps = request.steps,
+            cfgScale = request.cfgScale,
+            seed = request.seed,
+            flowShift = request.flowShift,
+            flashAttention = request.flashAttention,
+            forceSequentialLoad = request.forceSequentialLoad,
+            initImage = request.initImage?.let { PixelCodec.decodeBitmap(it) },
+            strength = request.strength,
+            sampleMethod = SampleMethod.fromId(request.sampleMethodId),
+            scheduler = Scheduler.fromId(request.schedulerId),
+            easyCache =
+                EasyCacheParams(
+                    enabled = request.easyCacheEnabled,
+                    reuseThreshold = request.easyCacheReuseThreshold,
+                    startPercent = request.easyCacheStartPercent,
+                    endPercent = request.easyCacheEndPercent,
+                ),
+            loraModelDir = request.loraModelDir,
+            loraApplyMode = LoraApplyMode.fromId(request.loraApplyModeId),
+            taehv = request.taehv?.let(::fromIpc),
+            model = request.model?.let(::fromIpc),
+            vae = request.vae?.let(::fromIpc),
+            textEncoder = request.textEncoder?.let(::fromIpc),
+        )
+
+    fun toIpc(metrics: GenerationMetrics): IpcGenerationMetrics {
+        val request = metrics.imageRequestMetrics
+        return IpcGenerationMetrics(
+            totalTimeSeconds = metrics.totalTimeSeconds,
+            framesPerSecond = metrics.framesPerSecond,
+            timePerStep = metrics.timePerStep,
+            peakMemoryUsageMb = metrics.peakMemoryUsageMb,
+            vulkanEnabled = metrics.vulkanEnabled,
+            frameConversionTimeSeconds = metrics.frameConversionTimeSeconds,
+            hasRequestMetrics = request != null,
+            runtimeAcquireMs = request?.runtimeAcquireMs ?: 0L,
+            modelLoadMs = request?.modelLoadMs ?: 0L,
+            generateMs = request?.generateMs ?: 0L,
+            cacheHit = request?.cacheHit ?: false,
+            backend = request?.backend ?: "",
+            flashAttentionEnabled = request?.flashAttentionEnabled ?: false,
+            easyCacheEnabled = request?.easyCacheEnabled ?: false,
+            width = request?.width ?: 0,
+            height = request?.height ?: 0,
+            steps = request?.steps ?: 0,
+        )
+    }
+
+    fun fromIpc(metrics: IpcGenerationMetrics): GenerationMetrics {
+        val base =
+            GenerationMetrics(
+                totalTimeSeconds = metrics.totalTimeSeconds,
+                framesPerSecond = metrics.framesPerSecond,
+                timePerStep = metrics.timePerStep,
+                peakMemoryUsageMb = metrics.peakMemoryUsageMb,
+                vulkanEnabled = metrics.vulkanEnabled,
+                frameConversionTimeSeconds = metrics.frameConversionTimeSeconds,
+            )
+        if (!metrics.hasRequestMetrics) return base
+        return base.withImageRequestMetrics(
+            ImageRequestMetrics(
+                runtimeAcquireMs = metrics.runtimeAcquireMs,
+                modelLoadMs = metrics.modelLoadMs,
+                generateMs = metrics.generateMs,
+                cacheHit = metrics.cacheHit,
+                backend = metrics.backend,
+                flashAttentionEnabled = metrics.flashAttentionEnabled,
+                easyCacheEnabled = metrics.easyCacheEnabled,
+                width = metrics.width,
+                height = metrics.height,
+                steps = metrics.steps,
+            ),
+        )
+    }
+}
+
+/** ARGB_8888 pixels packed into ashmem. One frame per [encodeBitmap]; N frames per [encodeFrames]. */
+internal object PixelCodec {
+    private const val BYTES_PER_PIXEL = 4
+
+    fun encodeBitmap(bitmap: Bitmap, name: String): IpcFrameBuffer = encodeFrames(listOf(bitmap), name)
+
+    fun decodeBitmap(buffer: IpcFrameBuffer): Bitmap = decodeFrames(buffer).single()
+
+    fun encodeFrames(frames: List<Bitmap>, name: String): IpcFrameBuffer {
+        require(frames.isNotEmpty()) { "no frames to encode" }
+        val width = frames.first().width
+        val height = frames.first().height
+        frames.forEach { frame ->
+            require(frame.width == width && frame.height == height) { "frames must share dimensions" }
+        }
+        val frameBytes = width * height * BYTES_PER_PIXEL
+        val memory = SharedMemory.create(name, frameBytes * frames.size)
+        try {
+            val mapped = memory.mapReadWrite()
+            try {
+                frames.forEach { frame ->
+                    val argb = if (frame.config == Bitmap.Config.ARGB_8888) frame else frame.copy(Bitmap.Config.ARGB_8888, false)
+                    argb.copyPixelsToBuffer(mapped)
+                    if (argb !== frame) argb.recycle()
+                }
+            } finally {
+                SharedMemory.unmap(mapped)
+            }
+        } catch (error: Throwable) {
+            memory.close()
+            throw error
+        }
+        return IpcFrameBuffer(memory = memory, width = width, height = height, frameCount = frames.size)
+    }
+
+    fun decodeFrames(buffer: IpcFrameBuffer): List<Bitmap> {
+        val frameBytes = buffer.width * buffer.height * BYTES_PER_PIXEL
+        val expected = frameBytes * buffer.frameCount
+        check(buffer.memory.size >= expected) {
+            "frame buffer too small: ${buffer.memory.size} < $expected"
+        }
+        buffer.memory.use { memory ->
+            val mapped = memory.mapReadOnly()
+            try {
+                return (0 until buffer.frameCount).map { index ->
+                    mapped.position(index * frameBytes)
+                    mapped.limit(index * frameBytes + frameBytes)
+                    val bitmap = Bitmap.createBitmap(buffer.width, buffer.height, Bitmap.Config.ARGB_8888)
+                    bitmap.copyPixelsFromBuffer(mapped.slice())
+                    bitmap
+                }
+            } finally {
+                SharedMemory.unmap(mapped)
+            }
+        }
+    }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcTypes.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcTypes.kt
@@ -1,0 +1,172 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.os.Parcelable
+import android.os.SharedMemory
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Parcelable mirrors of the public request/result types for the diffusion worker process.
+ * Pixel payloads never cross Binder inline (512x512 ARGB is ~1 MB, at the transaction limit);
+ * they ride in ashmem via [IpcFrameBuffer].
+ */
+
+@Parcelize
+internal data class WorkerInitConfig(
+    val cacheMaxEntries: Int,
+    val cacheMaxMemoryMb: Long,
+    val preferPerformanceMode: Boolean,
+    val useVulkan: Boolean,
+    /** Entries "SUBSYSTEM:BACKEND" seeded into the worker's in-process backend blacklist. */
+    val blacklistSeed: List<String>,
+) : Parcelable
+
+@Parcelize
+internal data class IpcModelSpec(
+    /** "local" or "hf". */
+    val type: String,
+    val path: String?,
+    val repoId: String?,
+    val filename: String?,
+    val revision: String?,
+    val preferredQuantizations: List<String>,
+    val token: String?,
+    val forceDownload: Boolean,
+    val preferSystemDownloader: Boolean,
+    // ModelHints, flattened
+    val artifactKind: String,
+    val capabilities: List<String>,
+    val chatTemplate: String?,
+    val conversionPrecision: String?,
+    val conversionAdapter: String?,
+    val conversionTokenizerPre: String?,
+) : Parcelable
+
+@Parcelize
+internal data class IpcImageRequest(
+    val prompt: String,
+    val negative: String,
+    val width: Int,
+    val height: Int,
+    val steps: Int,
+    val cfgScale: Float,
+    val seed: Long,
+    val flashAttention: Boolean,
+    val forceSequentialLoad: Boolean,
+    val easyCacheEnabled: Boolean,
+    val easyCacheReuseThreshold: Float,
+    val easyCacheStartPercent: Float,
+    val easyCacheEndPercent: Float,
+    val loraModelDir: String?,
+    val loraApplyModeId: Int,
+    val model: IpcModelSpec?,
+    val vae: IpcModelSpec?,
+    val textEncoder: IpcModelSpec?,
+    val splitDiffusionModel: Boolean,
+    val sequential: Boolean,
+) : Parcelable
+
+@Parcelize
+internal data class IpcVideoRequest(
+    val prompt: String,
+    val negative: String,
+    val width: Int,
+    val height: Int,
+    val videoFrames: Int,
+    val steps: Int,
+    val cfgScale: Float,
+    val seed: Long,
+    val flowShift: Float,
+    val flashAttention: Boolean,
+    val forceSequentialLoad: Boolean,
+    val initImage: IpcFrameBuffer?,
+    val strength: Float,
+    val sampleMethodId: Int,
+    val schedulerId: Int,
+    val easyCacheEnabled: Boolean,
+    val easyCacheReuseThreshold: Float,
+    val easyCacheStartPercent: Float,
+    val easyCacheEndPercent: Float,
+    val loraModelDir: String?,
+    val loraApplyModeId: Int,
+    val taehv: IpcModelSpec?,
+    val model: IpcModelSpec?,
+    val vae: IpcModelSpec?,
+    val textEncoder: IpcModelSpec?,
+) : Parcelable
+
+/** ARGB_8888 pixel frames packed contiguously into one ashmem region. */
+@Parcelize
+internal data class IpcFrameBuffer(
+    val memory: SharedMemory,
+    val width: Int,
+    val height: Int,
+    val frameCount: Int,
+) : Parcelable
+
+@Parcelize
+internal data class IpcGenerationMetrics(
+    val totalTimeSeconds: Float,
+    val framesPerSecond: Float,
+    val timePerStep: Float,
+    val peakMemoryUsageMb: Long,
+    val vulkanEnabled: Boolean,
+    val frameConversionTimeSeconds: Float,
+    val hasRequestMetrics: Boolean,
+    val runtimeAcquireMs: Long,
+    val modelLoadMs: Long,
+    val generateMs: Long,
+    val cacheHit: Boolean,
+    val backend: String,
+    val flashAttentionEnabled: Boolean,
+    val easyCacheEnabled: Boolean,
+    val width: Int,
+    val height: Int,
+    val steps: Int,
+) : Parcelable
+
+@Parcelize
+internal data class IpcImageResult(
+    val frame: IpcFrameBuffer,
+    val metrics: IpcGenerationMetrics?,
+) : Parcelable
+
+@Parcelize
+internal data class IpcVideoResult(
+    val frames: IpcFrameBuffer,
+    val metrics: IpcGenerationMetrics?,
+) : Parcelable
+
+@Parcelize
+internal data class PhaseUpdate(
+    /** One of [DiffusionPhases]. */
+    val phase: String,
+    val backend: String?,
+    val step: Int,
+    val totalSteps: Int,
+    val uptimeMillis: Long,
+) : Parcelable
+
+@Parcelize
+internal data class IpcFailure(
+    val code: Int,
+    val exceptionClass: String,
+    val message: String?,
+    /** Backend the worker was using when it failed, if known. */
+    val backend: String?,
+) : Parcelable {
+    companion object {
+        const val CODE_GENERIC = 0
+        const val CODE_CANCELLED = 1
+        const val CODE_BUSY = 2
+    }
+}
+
+internal object DiffusionPhases {
+    const val REQUESTED = "REQUESTED"
+    const val RESOLVING_MODEL = "RESOLVING_MODEL"
+    const val LOADING = "LOADING"
+    const val GENERATING = "GENERATING"
+    const val STEP = "STEP"
+    const val COMPLETED = "COMPLETED"
+    const val FAILED = "FAILED"
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
@@ -1,0 +1,384 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.SystemClock
+import io.aatricks.llmedge.HangRecoveryPolicy
+import io.aatricks.llmedge.LLMEdgeConfig
+import io.aatricks.llmedge.core.AndroidLogAdapter
+import io.aatricks.llmedge.core.GenerationHangException
+import io.aatricks.llmedge.core.InferenceFailedException
+import io.aatricks.llmedge.core.LLMEdgeScope
+import io.aatricks.llmedge.core.ProgressEvent
+import io.aatricks.llmedge.core.WorkerCrashedException
+import io.aatricks.llmedge.image.GenerationStreamEvent
+import io.aatricks.llmedge.image.ImageGenerationRequest
+import io.aatricks.llmedge.image.VideoGenerationRequest
+import io.aatricks.llmedge.image.diffusion.GenerationMetrics
+import io.aatricks.llmedge.image.diffusion.ImageGenerationTraceEvent
+import io.aatricks.llmedge.runtime.BackendRuntimePolicy
+import io.aatricks.llmedge.runtime.ComputeBackend
+import io.aatricks.llmedge.runtime.ComputeSubsystem
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * Binder proxy to the `:llmedge_sd` worker process. Public semantics match
+ * [InProcessDiffusionEngine] (single in-flight request, same exceptions for ordinary failures),
+ * plus containment: a native crash surfaces as [WorkerCrashedException] (with one automatic CPU
+ * retry), and a GPU-driver hang is detected by the [GenerationWatchdog], the worker killed, the
+ * verdict persisted, and the request retried on CPU or failed per [HangRecoveryPolicy].
+ */
+internal class IsolatedDiffusionEngine(
+    private val context: Context,
+    private val edgeScope: LLMEdgeScope,
+    private val config: LLMEdgeConfig,
+    private val connectionManager: WorkerConnectionManager = WorkerConnectionManager(context),
+    private val verdictStore: BackendVerdictStore = BackendVerdictStore(context),
+    private val cpuReaderFor: (Int) -> (() -> Long?) = { pid -> { ProcCpuReader.readCpuTimeMs(pid) } },
+    private val clock: () -> Long = { SystemClock.elapsedRealtime() },
+) : DiffusionEngine {
+    private val generationMutex = Mutex()
+
+    @Volatile private var lastMetrics: GenerationMetrics? = null
+
+    @Volatile private var activeRequest: ActiveRequest? = null
+
+    /** Blacklist entries shipped to every worker (persisted verdicts + session discoveries). */
+    private val seedEntries = CopyOnWriteArraySet<Pair<ComputeSubsystem, ComputeBackend>>()
+
+    init {
+        if (config.image.persistBackendVerdicts) {
+            val persisted = verdictStore.load()
+            seedEntries.addAll(persisted)
+            BackendRuntimePolicy.seed(persisted)
+            if (persisted.isNotEmpty()) {
+                AndroidLogAdapter.w(LOG_TAG, "Seeded persisted backend verdicts: $persisted")
+            }
+        }
+    }
+
+    private class ActiveRequest(
+        val connection: WorkerConnectionManager.Connection,
+        val isCompleted: () -> Boolean,
+    )
+
+    override suspend fun generate(params: ImageGenerationRequest): Bitmap =
+        generationMutex.withLock {
+            val result =
+                runWithRecovery(ComputeSubsystem.IMAGE) { forceCpu ->
+                    issueImageRequest(params, forceCpu)
+                }
+            lastMetrics = result.metrics?.let(IpcCodecs::fromIpc)
+            PixelCodec.decodeBitmap(result.frame)
+        }
+
+    override fun generateVideo(params: VideoGenerationRequest): Flow<GenerationStreamEvent> =
+        callbackFlow {
+            val producer = this
+            val job =
+                edgeScope.coroutineScope.launch {
+                    try {
+                        val result =
+                            generationMutex.withLock {
+                                runWithRecovery(ComputeSubsystem.VIDEO) { forceCpu ->
+                                    issueVideoRequest(params, forceCpu) { message, current, total ->
+                                        producer.trySend(
+                                            GenerationStreamEvent.Progress(ProgressEvent.Step(message, current, total)),
+                                        )
+                                    }
+                                }
+                            }
+                        lastMetrics = result.metrics?.let(IpcCodecs::fromIpc)
+                        trySend(GenerationStreamEvent.Completed(PixelCodec.decodeFrames(result.frames)))
+                        close()
+                    } catch (t: Throwable) {
+                        close(t)
+                    }
+                }
+            awaitClose {
+                job.cancel()
+                cancelGeneration()
+            }
+        }
+
+    override fun cancelGeneration() {
+        val request = activeRequest ?: return
+        runCatching { request.connection.worker.cancelGeneration() }
+        // Native cancel is cooperative (polled between denoise steps); a worker stuck inside a
+        // dispatch never observes it. Escalate to SIGKILL after a grace window.
+        edgeScope.coroutineScope.launch {
+            delay(config.image.watchdog.cancelKillGraceMs)
+            if (!request.isCompleted() && !request.connection.dead) {
+                connectionManager.killWorker(request.connection)
+            }
+        }
+    }
+
+    override fun lastGenerationMetrics(): GenerationMetrics? = lastMetrics
+
+    /** Trace events stay inside the worker process; not available in isolated mode. */
+    override fun lastImageRequestTraceForTests(): List<ImageGenerationTraceEvent> = emptyList()
+
+    override fun close() {
+        val request = activeRequest
+        if (request != null && !request.connection.dead) {
+            runCatching { request.connection.worker.cancelGeneration() }
+        }
+        // Synchronous like ManagedRuntimeBase.closeOnce: the owning scope tears down right after.
+        kotlinx.coroutines.runBlocking { connectionManager.close() }
+    }
+
+    /** Debug/test hook: forwards fault-injection args to the (freshly connected) worker. */
+    internal suspend fun installFaultInjectionForTests(args: android.os.Bundle) {
+        val connection = connectionManager.connect(buildInitConfig(forceCpu = false))
+        connection.worker.installFaultInjection(args)
+    }
+
+    private suspend fun <T> runWithRecovery(
+        subsystem: ComputeSubsystem,
+        issue: suspend (forceCpu: Boolean) -> T,
+    ): T =
+        try {
+            issue(false)
+        } catch (hang: GenerationHangException) {
+            recordHangVerdict(subsystem, hang.backend)
+            when (config.image.hangRecoveryPolicy) {
+                HangRecoveryPolicy.FAIL_FAST -> throw hang
+                HangRecoveryPolicy.RETRY_CPU_THEN_FAIL -> {
+                    AndroidLogAdapter.w(LOG_TAG, "Worker hang (${hang.message}); retrying on CPU")
+                    issue(true)
+                }
+            }
+        } catch (crash: WorkerCrashedException) {
+            if (crash.backend == ComputeBackend.CPU.name) throw crash
+            markSessionBlacklist(subsystem, crash.backend)
+            AndroidLogAdapter.w(LOG_TAG, "Worker crashed (${crash.message}); retrying on CPU")
+            issue(true)
+        }
+
+    private suspend fun issueImageRequest(
+        params: ImageGenerationRequest,
+        forceCpu: Boolean,
+    ): IpcImageResult {
+        val deferred = CompletableDeferred<IpcImageResult>()
+        return runRequest(deferred, forceCpu) { connection, watchdog ->
+            val callback =
+                object : IDiffusionResultCallback.Stub() {
+                    override fun onPhase(update: PhaseUpdate) = dispatchPhase(watchdog, update)
+
+                    override fun onCompleted(result: IpcImageResult) {
+                        deferred.complete(result)
+                    }
+
+                    override fun onFailed(failure: IpcFailure) {
+                        deferred.completeExceptionally(mapFailure("image generation", failure))
+                    }
+                }
+            connection.worker.generateImage(IpcCodecs.toIpc(params), callback)
+        }
+    }
+
+    private suspend fun issueVideoRequest(
+        params: VideoGenerationRequest,
+        forceCpu: Boolean,
+        onProgress: (String, Int, Int) -> Unit,
+    ): IpcVideoResult {
+        val deferred = CompletableDeferred<IpcVideoResult>()
+        val ipcRequest = IpcCodecs.toIpc(params)
+        try {
+            return runRequest(deferred, forceCpu) { connection, watchdog ->
+                val callback =
+                    object : IDiffusionVideoCallback.Stub() {
+                        override fun onPhase(update: PhaseUpdate) = dispatchPhase(watchdog, update)
+
+                        override fun onProgress(
+                            message: String,
+                            current: Int,
+                            total: Int,
+                        ) {
+                            watchdog?.onStep(current, total)
+                            onProgress(message, current, total)
+                        }
+
+                        override fun onCompleted(result: IpcVideoResult) {
+                            deferred.complete(result)
+                        }
+
+                        override fun onFailed(failure: IpcFailure) {
+                            deferred.completeExceptionally(mapFailure("video generation", failure))
+                        }
+                    }
+                connection.worker.generateVideo(ipcRequest, callback)
+            }
+        } finally {
+            // Binder dups the fd on send; the host-side initImage buffer is done either way.
+            ipcRequest.initImage?.memory?.close()
+        }
+    }
+
+    /**
+     * Shared request lifecycle: connect, arm death handling + watchdog, send the request via
+     * [send], await the result, and tear everything down inline. Coroutine cancellation sends a
+     * cooperative cancel to the worker and escalates to a kill after the grace window.
+     */
+    private suspend fun <T> runRequest(
+        deferred: CompletableDeferred<T>,
+        forceCpu: Boolean,
+        send: (WorkerConnectionManager.Connection, GenerationWatchdog?) -> Unit,
+    ): T {
+        val connection = connectionManager.connect(buildInitConfig(forceCpu))
+        val killedByWatchdog = AtomicBoolean(false)
+        val verdictStallMs = AtomicLong(0L)
+
+        var watchdog: GenerationWatchdog? = null
+        if (config.image.watchdog.enabled) {
+            watchdog =
+                GenerationWatchdog(
+                    config = config.image.watchdog,
+                    clock = clock,
+                    cpuTimeMsReader = cpuReaderFor(connection.pid),
+                ) { _, _, stallMs ->
+                    killedByWatchdog.set(true)
+                    verdictStallMs.set(stallMs)
+                    connectionManager.killWorker(connection)
+                }
+        }
+        val watchdogRef = watchdog
+
+        connection.onDeath = {
+            deferred.completeExceptionally(
+                WorkerFailureClassifier.classify(
+                    context = context,
+                    pid = connection.pid,
+                    lastPhase = watchdogRef?.lastPhase() ?: DiffusionPhases.REQUESTED,
+                    lastBackend = watchdogRef?.lastBackend(),
+                    killedByWatchdog = killedByWatchdog.get(),
+                    stallMs = verdictStallMs.get(),
+                ),
+            )
+        }
+        if (connection.dead) {
+            // Died between connect and arming the handler; classify immediately.
+            connection.onDeath?.invoke()
+        }
+
+        activeRequest = ActiveRequest(connection) { deferred.isCompleted }
+
+        val ticker =
+            watchdog?.let { armed ->
+                edgeScope.coroutineScope.launch {
+                    while (isActive && !deferred.isCompleted) {
+                        delay(config.image.watchdog.cpuSampleIntervalMs)
+                        armed.sample()
+                    }
+                }
+            }
+
+        try {
+            if (!deferred.isCompleted) {
+                try {
+                    send(connection, watchdog)
+                } catch (remote: Throwable) {
+                    // The oneway send itself failed (e.g. DeadObjectException between connect and send).
+                    if (!deferred.isCompleted) {
+                        deferred.completeExceptionally(WorkerCrashedException(backend = null, exitReason = null))
+                    }
+                }
+            }
+            return deferred.await()
+        } catch (cancelled: CancellationException) {
+            runCatching { connection.worker.cancelGeneration() }
+            edgeScope.coroutineScope.launch {
+                delay(config.image.watchdog.cancelKillGraceMs)
+                if (!deferred.isCompleted && !connection.dead) {
+                    connectionManager.killWorker(connection)
+                }
+            }
+            throw cancelled
+        } finally {
+            withContext(NonCancellable) {
+                ticker?.cancel()
+                watchdog?.stop()
+                connection.onDeath = null
+                activeRequest = null
+            }
+        }
+    }
+
+    private fun dispatchPhase(
+        watchdog: GenerationWatchdog?,
+        update: PhaseUpdate,
+    ) {
+        if (update.phase == DiffusionPhases.STEP) {
+            watchdog?.onStep(update.step, update.totalSteps)
+        } else {
+            watchdog?.onPhase(update.phase, update.backend)
+        }
+    }
+
+    private fun buildInitConfig(forceCpu: Boolean): WorkerInitConfig =
+        WorkerInitConfig(
+            cacheMaxEntries = config.image.cache.maxEntries,
+            cacheMaxMemoryMb = config.image.cache.maxMemoryMb,
+            preferPerformanceMode = config.image.preferPerformanceMode,
+            useVulkan = config.image.useVulkan && !forceCpu,
+            blacklistSeed = seedEntries.map { (subsystem, backend) -> "${subsystem.name}:${backend.name}" },
+        )
+
+    private fun recordHangVerdict(
+        subsystem: ComputeSubsystem,
+        backendName: String?,
+    ) {
+        val backend = backendName?.let { name -> ComputeBackend.entries.firstOrNull { it.name == name } }
+        // An unknown backend means the hang happened before any phase heartbeat (load or
+        // conditioner dispatch). GPU is the only credible culprit for that signature.
+        val verdictBackend = backend ?: ComputeBackend.VULKAN
+        if (verdictBackend == ComputeBackend.CPU) return
+        seedEntries.add(subsystem to verdictBackend)
+        BackendRuntimePolicy.seed(listOf(subsystem to verdictBackend))
+        if (config.image.persistBackendVerdicts) {
+            verdictStore.recordHang(subsystem, verdictBackend)
+        }
+    }
+
+    private fun markSessionBlacklist(
+        subsystem: ComputeSubsystem,
+        backendName: String?,
+    ) {
+        val backend = backendName?.let { name -> ComputeBackend.entries.firstOrNull { it.name == name } } ?: return
+        if (backend == ComputeBackend.CPU) return
+        seedEntries.add(subsystem to backend)
+        BackendRuntimePolicy.seed(listOf(subsystem to backend))
+    }
+
+    private fun mapFailure(
+        operation: String,
+        failure: IpcFailure,
+    ): Throwable =
+        when (failure.code) {
+            IpcFailure.CODE_CANCELLED -> CancellationException("Generation cancelled in worker")
+            else ->
+                InferenceFailedException(
+                    operation,
+                    "${failure.exceptionClass}: ${failure.message ?: "no message"} (worker process)",
+                )
+        }
+
+    companion object {
+        private const val LOG_TAG = "IsolatedDiffusion"
+    }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/ProcCpuReader.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/ProcCpuReader.kt
@@ -1,0 +1,34 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.system.Os
+import android.system.OsConstants
+import java.io.File
+
+/**
+ * Reads a same-UID process's cumulative CPU time from /proc/<pid>/stat (utime + stime).
+ * Used by the watchdog to tell a driver deadlock (flat CPU) from a long-but-live workload
+ * such as a cold Vulkan shader compile (pegs a core).
+ */
+internal object ProcCpuReader {
+    /** Cumulative user+system CPU time in ms, or null when /proc is unreadable. */
+    fun readCpuTimeMs(pid: Int): Long? = parseStat(runCatching { File("/proc/$pid/stat").readText() }.getOrNull())
+
+    fun parseStat(
+        stat: String?,
+        clockTicksPerSecond: Long = clkTck,
+    ): Long? {
+        if (stat.isNullOrBlank()) return null
+        // The comm field (2nd, in parens) may contain spaces; fields resume after the last ')'.
+        val afterComm = stat.substringAfterLast(')').trim()
+        val fields = afterComm.split(' ')
+        // afterComm starts at field 3 ("state"); utime/stime are fields 14/15 of the full line.
+        val utime = fields.getOrNull(11)?.toLongOrNull() ?: return null
+        val stime = fields.getOrNull(12)?.toLongOrNull() ?: return null
+        if (clockTicksPerSecond <= 0) return null
+        return (utime + stime) * 1000L / clockTicksPerSecond
+    }
+
+    private val clkTck: Long by lazy {
+        runCatching { Os.sysconf(OsConstants._SC_CLK_TCK) }.getOrDefault(100L).takeIf { it > 0 } ?: 100L
+    }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerConnectionManager.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerConnectionManager.kt
@@ -1,0 +1,130 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import android.os.Process
+import io.aatricks.llmedge.core.AndroidLogAdapter
+import io.aatricks.llmedge.core.WorkerBindException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Owns the Binder connection to [DiffusionWorkerService]: bind on demand, death notification,
+ * lazy reconnect (every (re)connect re-sends [WorkerInitConfig]), and the kill escalation the
+ * watchdog and cancellation paths rely on.
+ */
+internal class WorkerConnectionManager(private val context: Context) {
+    internal class Connection(
+        val worker: IDiffusionWorker,
+        val binder: IBinder,
+        val pid: Int,
+    ) {
+        @Volatile var dead: Boolean = false
+
+        /** Death listener for the request currently in flight on this connection. */
+        @Volatile var onDeath: (() -> Unit)? = null
+    }
+
+    private val mutex = Mutex()
+    private var current: Connection? = null
+    private var serviceConnection: ServiceConnection? = null
+
+    /** Binds (or reuses the live connection) and (re)initializes the worker with [initConfig]. */
+    suspend fun connect(initConfig: WorkerInitConfig): Connection =
+        mutex.withLock {
+            current?.takeIf { !it.dead && it.binder.isBinderAlive }?.let { live ->
+                live.worker.initialize(initConfig)
+                return live
+            }
+            unbindLocked()
+
+            val binder = bindAndAwait()
+            val worker = IDiffusionWorker.Stub.asInterface(binder)
+            val connection = Connection(worker = worker, binder = binder, pid = worker.pid)
+            binder.linkToDeath(
+                {
+                    connection.dead = true
+                    AndroidLogAdapter.w(LOG_TAG, "Diffusion worker process died (pid=${connection.pid})")
+                    connection.onDeath?.invoke()
+                },
+                0,
+            )
+            worker.initialize(initConfig)
+            current = connection
+            return connection
+        }
+
+    private suspend fun bindAndAwait(): IBinder =
+        suspendCancellableCoroutine { continuation ->
+            val intent = Intent(context, DiffusionWorkerService::class.java)
+            val serviceConn =
+                object : ServiceConnection {
+                    override fun onServiceConnected(
+                        name: ComponentName?,
+                        service: IBinder?,
+                    ) {
+                        if (continuation.isActive) {
+                            if (service != null) {
+                                continuation.resume(service)
+                            } else {
+                                continuation.resumeWithException(WorkerBindException("null binder"))
+                            }
+                        }
+                    }
+
+                    override fun onServiceDisconnected(name: ComponentName?) {
+                        // Death is handled via linkToDeath on the binder.
+                    }
+
+                    override fun onBindingDied(name: ComponentName?) {
+                        if (continuation.isActive) {
+                            continuation.resumeWithException(WorkerBindException("binding died"))
+                        }
+                    }
+
+                    override fun onNullBinding(name: ComponentName?) {
+                        if (continuation.isActive) {
+                            continuation.resumeWithException(WorkerBindException("null binding"))
+                        }
+                    }
+                }
+            serviceConnection = serviceConn
+            val bound = context.bindService(intent, serviceConn, Context.BIND_AUTO_CREATE)
+            if (!bound) {
+                serviceConnection = null
+                runCatching { context.unbindService(serviceConn) }
+                if (continuation.isActive) {
+                    continuation.resumeWithException(
+                        WorkerBindException("bindService returned false; is the service declared in the merged manifest?"),
+                    )
+                }
+            }
+            continuation.invokeOnCancellation { runCatching { context.unbindService(serviceConn) } }
+        }
+
+    /** SIGKILL the worker. Same UID, so this is permitted; linkToDeath delivers the notification. */
+    fun killWorker(connection: Connection) {
+        AndroidLogAdapter.w(LOG_TAG, "Killing diffusion worker pid=${connection.pid}")
+        Process.killProcess(connection.pid)
+    }
+
+    suspend fun close() {
+        mutex.withLock { unbindLocked() }
+    }
+
+    private fun unbindLocked() {
+        serviceConnection?.let { runCatching { context.unbindService(it) } }
+        serviceConnection = null
+        current = null
+    }
+
+    companion object {
+        private const val LOG_TAG = "WorkerConnection"
+    }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerFailureClassifier.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerFailureClassifier.kt
@@ -1,0 +1,41 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import android.content.Context
+import io.aatricks.llmedge.core.GenerationHangException
+import io.aatricks.llmedge.core.WorkerCrashedException
+import io.aatricks.llmedge.core.WorkerKilledByMemoryException
+import io.aatricks.llmedge.core.WorkerProcessException
+
+/** Maps a dead worker (binderDied) to a typed failure using ApplicationExitInfo (API 30+). */
+internal object WorkerFailureClassifier {
+    fun classify(
+        context: Context,
+        pid: Int,
+        lastPhase: String,
+        lastBackend: String?,
+        killedByWatchdog: Boolean,
+        stallMs: Long,
+    ): WorkerProcessException {
+        if (killedByWatchdog) {
+            return GenerationHangException(backend = lastBackend, phase = lastPhase, stallMs = stallMs)
+        }
+        val exitReason = exitReasonFor(context, pid)
+        return when (exitReason) {
+            ApplicationExitInfo.REASON_LOW_MEMORY -> WorkerKilledByMemoryException()
+            else -> WorkerCrashedException(backend = lastBackend, exitReason = exitReason)
+        }
+    }
+
+    private fun exitReasonFor(
+        context: Context,
+        pid: Int,
+    ): Int? =
+        runCatching {
+            val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            activityManager.getHistoricalProcessExitReasons(context.packageName, pid, 1)
+                .firstOrNull()
+                ?.reason
+        }.getOrNull()
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/runtime/ComputeBackend.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/runtime/ComputeBackend.kt
@@ -51,4 +51,9 @@ internal object BackendRuntimePolicy {
             openClAvailable = openClAvailable,
             vulkanAvailable = vulkanAvailable,
         )
+
+    /** Seed the in-memory blacklist from persisted verdicts (host) or a WorkerInitConfig (worker). */
+    fun seed(entries: Iterable<Pair<ComputeSubsystem, ComputeBackend>>) {
+        entries.forEach { (subsystem, backend) -> registry.blacklist(subsystem, backend) }
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/BackendVerdictStoreTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/BackendVerdictStoreTest.kt
@@ -1,0 +1,70 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.aatricks.llmedge.runtime.ComputeBackend
+import io.aatricks.llmedge.runtime.ComputeSubsystem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class BackendVerdictStoreTest {
+    private lateinit var context: Context
+    private lateinit var store: BackendVerdictStore
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        store = BackendVerdictStore(context)
+        store.reset()
+    }
+
+    @Test
+    fun `record and load round trip`() {
+        store.recordHang(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
+        store.recordHang(ComputeSubsystem.VIDEO, ComputeBackend.OPENCL)
+        val loaded = store.load()
+        assertEquals(
+            setOf(
+                ComputeSubsystem.IMAGE to ComputeBackend.VULKAN,
+                ComputeSubsystem.VIDEO to ComputeBackend.OPENCL,
+            ),
+            loaded.toSet(),
+        )
+    }
+
+    @Test
+    fun `cpu verdicts are never recorded`() {
+        store.recordHang(ComputeSubsystem.IMAGE, ComputeBackend.CPU)
+        assertTrue(store.load().isEmpty())
+    }
+
+    @Test
+    fun `fingerprint mismatch clears all verdicts`() {
+        store.recordHang(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
+        // Simulate an OS/driver update by rewriting the stored fingerprint.
+        context.getSharedPreferences("llmedge_backend_verdicts", Context.MODE_PRIVATE)
+            .edit()
+            .putString("fingerprint", "some/other/build:fingerprint")
+            .commit()
+        assertTrue(store.load().isEmpty())
+        // And the store was wiped, not just filtered.
+        assertTrue(
+            context.getSharedPreferences("llmedge_backend_verdicts", Context.MODE_PRIVATE)
+                .all.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `reset clears everything`() {
+        store.recordHang(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
+        store.reset()
+        assertTrue(store.load().isEmpty())
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/GenerationWatchdogTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/GenerationWatchdogTest.kt
@@ -1,0 +1,121 @@
+package io.aatricks.llmedge.image.ipc
+
+import io.aatricks.llmedge.WorkerWatchdogConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GenerationWatchdogTest {
+    private class Harness(
+        config: WorkerWatchdogConfig = WorkerWatchdogConfig(),
+    ) {
+        var nowMs = 0L
+        var cpuMs: Long? = 0L
+        var verdicts = mutableListOf<Triple<String, String?, Long>>()
+        val watchdog =
+            GenerationWatchdog(
+                config = config,
+                clock = { nowMs },
+                cpuTimeMsReader = { cpuMs },
+            ) { phase, backend, stallMs -> verdicts.add(Triple(phase, backend, stallMs)) }
+
+        /** Advance time in sample-interval ticks, optionally accruing CPU. */
+        fun run(
+            durationMs: Long,
+            cpuBusyFraction: Double,
+            stepMs: Long = 2_000,
+        ) {
+            var elapsed = 0L
+            while (elapsed < durationMs) {
+                nowMs += stepMs
+                cpuMs = cpuMs?.plus((stepMs * cpuBusyFraction).toLong())
+                elapsed += stepMs
+                watchdog.sample()
+            }
+        }
+    }
+
+    @Test
+    fun `flat cpu loading hang fires at the loading stall timeout`() {
+        val h = Harness()
+        h.watchdog.onPhase(DiffusionPhases.LOADING, "VULKAN")
+        h.run(durationMs = 95_000, cpuBusyFraction = 0.0)
+        assertEquals(1, h.verdicts.size)
+        val (phase, backend, _) = h.verdicts.single()
+        assertEquals(DiffusionPhases.LOADING, phase)
+        assertEquals("VULKAN", backend)
+    }
+
+    @Test
+    fun `busy cpu cold shader compile never fires`() {
+        val h = Harness()
+        h.watchdog.onPhase(DiffusionPhases.LOADING, "VULKAN")
+        // Pixel 8 signature: ~310s before the first step, one core pegged.
+        h.run(durationMs = 310_000, cpuBusyFraction = 1.0)
+        assertTrue(h.verdicts.isEmpty())
+    }
+
+    @Test
+    fun `step heartbeats keep resetting the window`() {
+        val h = Harness()
+        h.watchdog.onPhase(DiffusionPhases.GENERATING, "VULKAN")
+        repeat(10) {
+            h.run(durationMs = 60_000, cpuBusyFraction = 0.0)
+            h.watchdog.onStep(it, 10)
+        }
+        assertTrue(h.verdicts.isEmpty())
+        // Steps stop AND cpu is flat -> verdict after the step stall window.
+        h.run(durationMs = 310_000, cpuBusyFraction = 0.0)
+        assertEquals(1, h.verdicts.size)
+        assertEquals(DiffusionPhases.STEP, h.verdicts.single().first)
+    }
+
+    @Test
+    fun `resolving phase is exempt from the flat cpu rule`() {
+        val h = Harness()
+        h.watchdog.onPhase(DiffusionPhases.RESOLVING_MODEL, null)
+        // A model download: CPU-flat for 20 minutes. Must not fire (hard wall is 30 min).
+        h.run(durationMs = 20 * 60_000, cpuBusyFraction = 0.0)
+        assertTrue(h.verdicts.isEmpty())
+    }
+
+    @Test
+    fun `hard wall fires regardless of cpu activity`() {
+        val h = Harness()
+        h.watchdog.onPhase(DiffusionPhases.RESOLVING_MODEL, null)
+        h.run(durationMs = 31 * 60_000, cpuBusyFraction = 1.0)
+        assertEquals(1, h.verdicts.size)
+    }
+
+    @Test
+    fun `unreadable cpu never fires the stall rule`() {
+        val h = Harness()
+        h.cpuMs = null
+        h.watchdog.onPhase(DiffusionPhases.LOADING, "VULKAN")
+        h.run(durationMs = 10 * 60_000, cpuBusyFraction = 0.0)
+        assertTrue(h.verdicts.isEmpty())
+    }
+
+    @Test
+    fun `verdict fires exactly once and stop disarms`() {
+        val h = Harness()
+        h.watchdog.onPhase(DiffusionPhases.LOADING, "VULKAN")
+        h.run(durationMs = 200_000, cpuBusyFraction = 0.0)
+        assertEquals(1, h.verdicts.size)
+
+        val h2 = Harness()
+        h2.watchdog.onPhase(DiffusionPhases.LOADING, "VULKAN")
+        h2.watchdog.stop()
+        h2.run(durationMs = 200_000, cpuBusyFraction = 0.0)
+        assertTrue(h2.verdicts.isEmpty())
+    }
+
+    @Test
+    fun `low but nonzero cpu below threshold still counts as hung`() {
+        val h = Harness()
+        h.watchdog.onPhase(DiffusionPhases.GENERATING, "VULKAN")
+        h.run(durationMs = 100_000, cpuBusyFraction = 0.005)
+        assertFalse(h.verdicts.isEmpty())
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IpcMarshallingTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IpcMarshallingTest.kt
@@ -1,0 +1,120 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.os.Parcel
+import android.os.Parcelable
+import io.aatricks.llmedge.image.ImageGenerationRequest
+import io.aatricks.llmedge.image.diffusion.EasyCacheParams
+import io.aatricks.llmedge.image.diffusion.GenerationMetrics
+import io.aatricks.llmedge.image.diffusion.ImageRequestMetrics
+import io.aatricks.llmedge.image.diffusion.LoraApplyMode
+import io.aatricks.llmedge.model.ModelCapability
+import io.aatricks.llmedge.model.ModelConversion
+import io.aatricks.llmedge.model.ModelHints
+import io.aatricks.llmedge.model.ModelSpec
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class IpcMarshallingTest {
+    private inline fun <reified T : Parcelable> parcelRoundTrip(value: T): T {
+        val parcel = Parcel.obtain()
+        return try {
+            parcel.writeParcelable(value, 0)
+            parcel.setDataPosition(0)
+            @Suppress("DEPRECATION")
+            parcel.readParcelable(T::class.java.classLoader)!!
+        } finally {
+            parcel.recycle()
+        }
+    }
+
+    @Test
+    fun `local file model spec survives codec and parcel round trip`() {
+        val spec =
+            ModelSpec.LocalFile(
+                file = File("/data/local/tmp/model.gguf"),
+                hints =
+                    ModelHints(
+                        capabilities = setOf(ModelCapability.IMAGE),
+                        conversion = ModelConversion(tokenizerPre = "smollm"),
+                    ),
+            )
+        val decoded = IpcCodecs.fromIpc(parcelRoundTrip(IpcCodecs.toIpc(spec)))
+        assertEquals(spec, decoded)
+    }
+
+    @Test
+    fun `hugging face model spec survives codec and parcel round trip`() {
+        val spec =
+            ModelSpec.HuggingFace(
+                repoId = "Green-Sky/SD-Turbo-GGUF",
+                filename = "sd_turbo-f16-q8_0.gguf",
+                revision = "main",
+                preferredQuantizations = listOf("q8_0", "f16"),
+                token = "hf_secret",
+                forceDownload = true,
+                preferSystemDownloader = false,
+                hints = ModelHints(chatTemplate = "tmpl"),
+            )
+        val decoded = IpcCodecs.fromIpc(parcelRoundTrip(IpcCodecs.toIpc(spec)))
+        assertEquals(spec, decoded)
+    }
+
+    @Test
+    fun `image request survives codec and parcel round trip`() {
+        val request =
+            ImageGenerationRequest(
+                prompt = "a fox",
+                negative = "blurry",
+                width = 256,
+                height = 384,
+                steps = 4,
+                cfgScale = 1.5f,
+                seed = 42L,
+                flashAttention = false,
+                forceSequentialLoad = true,
+                easyCache = EasyCacheParams(enabled = true, reuseThreshold = 0.3f, startPercent = 0.1f, endPercent = 0.9f),
+                loraModelDir = "/lora",
+                loraApplyMode = LoraApplyMode.AT_RUNTIME,
+                model = ModelSpec.LocalFile(File("/m.gguf")),
+                splitDiffusionModel = true,
+                sequential = true,
+            )
+        val decoded = IpcCodecs.fromIpc(parcelRoundTrip(IpcCodecs.toIpc(request)))
+        assertEquals(request, decoded)
+    }
+
+    @Test
+    fun `metrics survive codec and parcel round trip including request metrics`() {
+        val metrics =
+            GenerationMetrics(
+                totalTimeSeconds = 12.5f,
+                framesPerSecond = 0.08f,
+                timePerStep = 3.1f,
+                peakMemoryUsageMb = 1234L,
+                vulkanEnabled = true,
+                frameConversionTimeSeconds = 0.2f,
+            ).withImageRequestMetrics(
+                ImageRequestMetrics(
+                    runtimeAcquireMs = 5000L,
+                    modelLoadMs = 4800L,
+                    generateMs = 12000L,
+                    cacheHit = false,
+                    backend = "VULKAN",
+                    flashAttentionEnabled = true,
+                    easyCacheEnabled = false,
+                    width = 512,
+                    height = 512,
+                    steps = 4,
+                ),
+            )
+        val decoded = IpcCodecs.fromIpc(parcelRoundTrip(IpcCodecs.toIpc(metrics)))
+        assertEquals(metrics, decoded)
+        assertEquals(metrics.imageRequestMetrics, decoded.imageRequestMetrics)
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/ProcCpuReaderTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/ProcCpuReaderTest.kt
@@ -1,0 +1,28 @@
+package io.aatricks.llmedge.image.ipc
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ProcCpuReaderTest {
+    @Test
+    fun `parses utime plus stime from a standard stat line`() {
+        // Fields 14 (utime) and 15 (stime) are 500 and 250 jiffies.
+        val stat = "1234 (llmedge_sd) S 1 1234 0 0 -1 4194560 100 0 0 0 500 250 0 0 20 0 30 0 12345 100000 200 18446744073709551615"
+        // 750 jiffies at 100 Hz = 7500 ms
+        assertEquals(7500L, ProcCpuReader.parseStat(stat, clockTicksPerSecond = 100))
+    }
+
+    @Test
+    fun `handles comm fields containing spaces and parens`() {
+        val stat = "42 (weird (name) x) R 1 42 0 0 -1 0 0 0 0 0 100 100 0 0 20 0 1 0 1 1 1 1"
+        assertEquals(2000L, ProcCpuReader.parseStat(stat, clockTicksPerSecond = 100))
+    }
+
+    @Test
+    fun `returns null for blank or malformed input`() {
+        assertNull(ProcCpuReader.parseStat(null))
+        assertNull(ProcCpuReader.parseStat(""))
+        assertNull(ProcCpuReader.parseStat("12 (x) S 1 2"))
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerFailureClassifierTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerFailureClassifierTest.kt
@@ -1,0 +1,48 @@
+package io.aatricks.llmedge.image.ipc
+
+import androidx.test.core.app.ApplicationProvider
+import io.aatricks.llmedge.core.GenerationHangException
+import io.aatricks.llmedge.core.WorkerCrashedException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class WorkerFailureClassifierTest {
+    @Test
+    fun `watchdog kill classifies as hang with phase and backend`() {
+        val result =
+            WorkerFailureClassifier.classify(
+                context = ApplicationProvider.getApplicationContext(),
+                pid = 12345,
+                lastPhase = DiffusionPhases.LOADING,
+                lastBackend = "VULKAN",
+                killedByWatchdog = true,
+                stallMs = 90_000L,
+            )
+        assertTrue(result is GenerationHangException)
+        result as GenerationHangException
+        assertEquals("VULKAN", result.backend)
+        assertEquals(DiffusionPhases.LOADING, result.phase)
+        assertEquals(90_000L, result.stallMs)
+    }
+
+    @Test
+    fun `unknown exit reason classifies as crash`() {
+        val result =
+            WorkerFailureClassifier.classify(
+                context = ApplicationProvider.getApplicationContext(),
+                pid = 12345,
+                lastPhase = DiffusionPhases.GENERATING,
+                lastBackend = "CPU",
+                killedByWatchdog = false,
+                stallMs = 0L,
+            )
+        assertTrue(result is WorkerCrashedException)
+        assertEquals("CPU", (result as WorkerCrashedException).backend)
+    }
+}


### PR DESCRIPTION
Follow-up to #31. With ImageRuntimeConfig.workerMode = ISOLATED_PROCESS the diffusion stack runs in a library-owned :llmedge_sd service process, so a native crash or a GPU driver that hangs at dispatch (the Pixel 10 case) ends as a typed exception or a transparent CPU retry instead of a frozen or dead app.

The public ImageClient API is unchanged. Internally it sits on a DiffusionEngine seam: the in-process implementation is the old code path verbatim and remains the default; the isolated implementation proxies over AIDL to DiffusionWorkerService, which hosts the same executors in the worker process. Pixels travel through ashmem SharedMemory because a single 512x512 frame already sits at the Binder transaction limit.

The watchdog only declares a worker hung when phase/step heartbeats stop AND the worker's CPU time stays flat over the same window. That conjunction is what separates a real driver deadlock (all threads sleeping at 0%) from a long cold shader compile (a core pegged for five minutes), and model downloads are exempt because they are legitimately CPU-flat. On a verdict the worker is killed and, per hangRecoveryPolicy, the request retries on CPU (default) or fails with GenerationHangException. Worker deaths classify through ApplicationExitInfo; a low-memory kill never blacklists a backend. Hang verdicts persist keyed to Build.FINGERPRINT so an OS or driver update re-enables the GPU on its own, and ImageClient.resetBackendVerdicts() clears them manually.

Tested: 319 unit tests, of which the 298 pre-existing ones pass untouched (that was the gate for the seam refactor), plus instrumented runs on a Pixel 6 managed device and a physical S22 covering cross-process binding, the ashmem codec, the injected hang to watchdog-kill to persisted-verdict flow, and a real SD-Turbo CPU generation whose output matches the in-process engine at 98%+ identical pixels.