### PR TITLE
Optimize isolated diffusion worker loading with direct mmap

### DIFF
--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/image/ipc/IsolatedGenerationParityTest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/image/ipc/IsolatedGenerationParityTest.kt
@@ -11,6 +11,9 @@ import io.aatricks.llmedge.LLMEdgeConfig
 import io.aatricks.llmedge.core.LLMEdgeScope
 import io.aatricks.llmedge.image.ImageGenerationRequest
 import io.aatricks.llmedge.model.DefaultModelRepository
+import io.aatricks.llmedge.model.ModelArtifactKind
+import io.aatricks.llmedge.model.ModelCapability
+import io.aatricks.llmedge.model.ModelHints
 import io.aatricks.llmedge.model.ModelSpec
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
@@ -70,6 +73,59 @@ class IsolatedGenerationParityTest {
             "outputs diverged: only $matching/$total pixels identical",
             matching >= (total * 0.98).toInt(),
         )
+    }
+
+    @Test
+    fun isolatedFlux2SequentialGenerate() {
+        val ditPath = "/data/local/tmp/bonsai-flux2-klein-ternary-q2_k.gguf"
+        val encoderPath = "/data/local/tmp/Qwen_3_4b-Q3_K_M.gguf"
+        val vaePath = "/data/local/tmp/flux2-vae.safetensors"
+
+        assumeTrue(
+            "Model files missing on device",
+            File(ditPath).exists() && File(encoderPath).exists() && File(vaePath).exists(),
+        )
+
+        val request =
+            ImageGenerationRequest(
+                prompt = "a red fox in snow",
+                width = 256,
+                height = 256,
+                steps = 2,
+                cfgScale = 1.0f,
+                seed = 42L,
+                model =
+                    ModelSpec.localFile(
+                        ditPath,
+                        ModelHints(
+                            artifactKind = ModelArtifactKind.DIFFUSION_MODEL,
+                            capabilities = setOf(ModelCapability.IMAGE),
+                        ),
+                    ),
+                vae =
+                    ModelSpec.localFile(
+                        vaePath,
+                        ModelHints(
+                            artifactKind = ModelArtifactKind.VAE,
+                            capabilities = setOf(ModelCapability.IMAGE),
+                        ),
+                    ),
+                textEncoder =
+                    ModelSpec.localFile(
+                        encoderPath,
+                        ModelHints(
+                            artifactKind = ModelArtifactKind.TEXT_ENCODER,
+                            capabilities = setOf(ModelCapability.TEXT, ModelCapability.IMAGE),
+                        ),
+                    ),
+                splitDiffusionModel = true,
+                sequential = true,
+            )
+
+        val isolated = generateWith(DiffusionWorkerMode.ISOLATED_PROCESS, request)
+        assertEquals(256, isolated.width)
+        assertEquals(256, isolated.height)
+        assertTrue("isolated output must not be uniform", isNotUniform(isolated))
     }
 
     private fun generateWith(

--- a/llmedge/src/main/cpp/sd_jni_internal.h
+++ b/llmedge/src/main/cpp/sd_jni_internal.h
@@ -3,6 +3,8 @@
 #include <jni.h>
 #include <atomic>
 #include <string>
+#include <vector>
+#include "model.h"
 
 struct sd_ctx_t;
 
@@ -11,6 +13,7 @@ struct SdHandle {
     void* t5_ctx = nullptr; // Pointer to T5CLIPEmbedder for T5-only mode
     void* llm_ctx = nullptr; // Pointer to LLMEmbedder for Qwen3-only mode (FLUX.2 sequential)
     void* backend = nullptr; // Pointer to ggml_backend_t for encoder-only handles
+    std::vector<MmapTensorStore> mmap_stores;
     float flowShift = 0.0f;
     std::string loraModelDir;
     int last_width = 0;

--- a/llmedge/src/main/cpp/sdcpp_jni.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni.cpp
@@ -15,5 +15,7 @@ extern "C" SD_API sd_image_t* sd_generate_video_with_precomputed_condition(
         const sd_condition_raw_t*,
         const sd_condition_raw_t*,
         int* num_frames_out) {
-    return generate_video(sd_ctx, params, num_frames_out);
+    sd_image_t* frames = nullptr;
+    generate_video(sd_ctx, params, &frames, num_frames_out, nullptr);
+    return frames;
 }

--- a/llmedge/src/main/cpp/sdcpp_jni_condition.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_condition.cpp
@@ -44,6 +44,8 @@ static sd_condition_raw_t* reconstruct_condition(JNIEnv* env, jobjectArray condA
                 raw.ne[i] = dims[i];
                 expected_len *= dims[i];
             }
+            ALOGI("Reconstructed raw tensor: ndims=%d, ne=[%lld, %lld, %lld, %lld]",
+                  raw.ndims, (long long)raw.ne[0], (long long)raw.ne[1], (long long)raw.ne[2], (long long)raw.ne[3]);
             env->ReleaseIntArrayElements(dimsArr, dims, JNI_ABORT);
 
             if (expected_len != dataLen) {
@@ -126,17 +128,6 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativePrecomputeConditi
         } else if (handle->t5_ctx) {
             auto* t5 = static_cast<T5CLIPEmbedder*>(handle->t5_ctx);
             try {
-                struct ggml_init_params params;
-                params.mem_size = 128 * 1024 * 1024;
-                params.mem_buffer = nullptr;
-                params.no_alloc = false;
-                struct ggml_context* work_ctx = ggml_init(params);
-                if (!work_ctx) {
-                    releaseStrings();
-                    throwJavaException(env, "java/lang/RuntimeException", "Failed to initialize ggml_context");
-                    return nullptr;
-                }
-
                 ConditionerParams cparams;
                 cparams.text = resolved.prompt.c_str();
                 cparams.clip_skip = clipSkip;
@@ -145,42 +136,32 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativePrecomputeConditi
                 cparams.zero_out_masked = (jIsVideo == JNI_TRUE);
 
                 SDCondition sd_cond =
-                        t5->get_learned_condition(work_ctx, sd_get_num_physical_cores_safe(), cparams);
+                        t5->get_learned_condition(sd_get_num_physical_cores_safe(), cparams);
 
                 cond = static_cast<sd_condition_raw_t*>(calloc(1, sizeof(sd_condition_raw_t)));
                 if (!cond) {
-                    ggml_free(work_ctx);
                     throw std::runtime_error("Out of memory allocating condition");
                 }
 
-                auto tensor_to_raw_f32 = [](struct ggml_tensor* t, sd_tensor_raw_t& raw) {
-                    if (!t) {
-                        return;
-                    }
-                    raw.ndims = ggml_n_dims(t);
-                    for (int i = 0; i < 4; ++i) {
-                        raw.ne[i] = t->ne[i];
-                    }
-                    const size_t n = static_cast<size_t>(ggml_nelements(t));
+                auto tensor_to_raw_f32 = [](const sd::Tensor<float>& t, sd_tensor_raw_t& raw) {
+                    if (t.empty()) return;
+                    raw.ndims = (int)t.dim();
+                    for (int i = 0; i < t.dim(); ++i) raw.ne[i] = t.shape()[i];
+                    ALOGI("Precomputed condition tensor to raw (T5): ndims=%d, shape=[%lld, %lld, %lld, %lld]",
+                          raw.ndims, (long long)raw.ne[0], (long long)raw.ne[1], (long long)raw.ne[2], (long long)raw.ne[3]);
+                    const size_t n = static_cast<size_t>(t.numel());
                     raw.data = static_cast<float*>(malloc(sizeof(float) * n));
                     if (!raw.data) {
                         raw.ndims = 0;
                         return;
                     }
-                    if (ggml_is_contiguous(t) && t->type == GGML_TYPE_F32) {
-                        memcpy(raw.data, t->data, sizeof(float) * n);
-                    } else {
-                        for (size_t i = 0; i < n; ++i) {
-                            raw.data[i] = ggml_get_f32_1d(t, static_cast<int>(i));
-                        }
-                    }
+                    memcpy(raw.data, t.data(), sizeof(float) * n);
                 };
 
-                if (sd_cond.c_crossattn) tensor_to_raw_f32(sd_cond.c_crossattn, cond->c_crossattn);
-                if (sd_cond.c_vector) tensor_to_raw_f32(sd_cond.c_vector, cond->c_vector);
-                if (sd_cond.c_concat) tensor_to_raw_f32(sd_cond.c_concat, cond->c_concat);
+                if (!sd_cond.c_crossattn.empty()) tensor_to_raw_f32(sd_cond.c_crossattn, cond->c_crossattn);
+                if (!sd_cond.c_vector.empty()) tensor_to_raw_f32(sd_cond.c_vector, cond->c_vector);
+                if (!sd_cond.c_concat.empty()) tensor_to_raw_f32(sd_cond.c_concat, cond->c_concat);
 
-                ggml_free(work_ctx);
             } catch (const std::exception& e) {
                 releaseStrings();
                 throwJavaException(env, "java/lang/RuntimeException", e.what());
@@ -190,17 +171,6 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativePrecomputeConditi
             // FLUX.2 sequential mode: encoder-only (Qwen3) handle precomputes the conditioning.
             auto* llm = static_cast<LLMEmbedder*>(handle->llm_ctx);
             try {
-                struct ggml_init_params params;
-                params.mem_size = 128 * 1024 * 1024;
-                params.mem_buffer = nullptr;
-                params.no_alloc = false;
-                struct ggml_context* work_ctx = ggml_init(params);
-                if (!work_ctx) {
-                    releaseStrings();
-                    throwJavaException(env, "java/lang/RuntimeException", "Failed to initialize ggml_context");
-                    return nullptr;
-                }
-
                 ConditionerParams cparams;
                 cparams.text      = resolved.prompt.c_str();
                 cparams.clip_skip = clipSkip;
@@ -209,36 +179,32 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativePrecomputeConditi
                 cparams.zero_out_masked = (jIsVideo == JNI_TRUE);
 
                 SDCondition sd_cond =
-                        llm->get_learned_condition(work_ctx, sd_get_num_physical_cores_safe(), cparams);
+                        llm->get_learned_condition(sd_get_num_physical_cores_safe(), cparams);
 
                 cond = static_cast<sd_condition_raw_t*>(calloc(1, sizeof(sd_condition_raw_t)));
                 if (!cond) {
-                    ggml_free(work_ctx);
                     throw std::runtime_error("Out of memory allocating condition");
                 }
 
-                auto tensor_to_raw_f32 = [](struct ggml_tensor* t, sd_tensor_raw_t& raw) {
-                    if (!t) return;
-                    raw.ndims = ggml_n_dims(t);
-                    for (int i = 0; i < 4; ++i) raw.ne[i] = t->ne[i];
-                    const size_t n = static_cast<size_t>(ggml_nelements(t));
+                auto tensor_to_raw_f32 = [](const sd::Tensor<float>& t, sd_tensor_raw_t& raw) {
+                    if (t.empty()) return;
+                    raw.ndims = (int)t.dim();
+                    for (int i = 0; i < t.dim(); ++i) raw.ne[i] = t.shape()[i];
+                    ALOGI("Precomputed condition tensor to raw (LLM): ndims=%d, shape=[%lld, %lld, %lld, %lld]",
+                          raw.ndims, (long long)raw.ne[0], (long long)raw.ne[1], (long long)raw.ne[2], (long long)raw.ne[3]);
+                    const size_t n = static_cast<size_t>(t.numel());
                     raw.data = static_cast<float*>(malloc(sizeof(float) * n));
                     if (!raw.data) {
                         raw.ndims = 0;
                         return;
                     }
-                    if (ggml_is_contiguous(t) && t->type == GGML_TYPE_F32) {
-                        memcpy(raw.data, t->data, sizeof(float) * n);
-                    } else {
-                        for (size_t i = 0; i < n; ++i) raw.data[i] = ggml_get_f32_1d(t, static_cast<int>(i));
-                    }
+                    memcpy(raw.data, t.data(), sizeof(float) * n);
                 };
 
-                if (sd_cond.c_crossattn) tensor_to_raw_f32(sd_cond.c_crossattn, cond->c_crossattn);
-                if (sd_cond.c_vector) tensor_to_raw_f32(sd_cond.c_vector, cond->c_vector);
-                if (sd_cond.c_concat) tensor_to_raw_f32(sd_cond.c_concat, cond->c_concat);
+                if (!sd_cond.c_crossattn.empty()) tensor_to_raw_f32(sd_cond.c_crossattn, cond->c_crossattn);
+                if (!sd_cond.c_vector.empty()) tensor_to_raw_f32(sd_cond.c_vector, cond->c_vector);
+                if (!sd_cond.c_concat.empty()) tensor_to_raw_f32(sd_cond.c_concat, cond->c_concat);
 
-                ggml_free(work_ctx);
             } catch (const std::exception& e) {
                 releaseStrings();
                 throwJavaException(env, "java/lang/RuntimeException", e.what());

--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -18,6 +18,7 @@
 #include "ggml-vulkan.h"
 #endif
 #include "conditioner.hpp"
+#include "ggml_extend_backend.h"
 #include "ggml-backend.h"
 #include "model.h"
 
@@ -73,7 +74,7 @@ static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, b
     (void)useVulkan;
 #endif
     if (!backend) {
-        backend = ggml_backend_cpu_init();
+        backend = sd_backend_cpu_init();
     }
     if (!backend) {
         ALOGE("Unable to initialize backend for T5-only context");
@@ -81,21 +82,30 @@ static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, b
     }
 
     bool is_umt5 = std::string(modelPath).find("umt5") != std::string::npos;
+    ggml_backend_t params_backend = offloadToCpu ? sd_backend_cpu_init() : backend;
     auto* t5 = new T5CLIPEmbedder(
         backend,
-        offloadToCpu,
+        params_backend,
         model_loader.get_tensor_storage_map(),
-        false,
+        offloadToCpu,
         0,
         is_umt5);
-    // alloc_params_buffer() returns void in this fork; load_tensors below is the
-    // checkable failure point.
-    t5->alloc_params_buffer();
-
     std::map<std::string, struct ggml_tensor*> tensors;
     t5->get_param_tensors(tensors);
-    std::set<std::string> ignore_tensors;
-    if (!model_loader.load_tensors(tensors, ignore_tensors, sd_get_num_physical_cores_safe())) {
+
+    std::vector<MmapTensorStore> mmap_stores = model_loader.mmap_tensors(tensors, {}, false);
+    bool load_ok = true;
+    if (mmap_stores.empty()) {
+        ALOGW("mmap failed or disabled for T5, falling back to loading into allocated memory buffer");
+        t5->alloc_params_buffer();
+        std::set<std::string> ignore_tensors;
+        load_ok = model_loader.load_tensors(tensors, ignore_tensors, sd_get_num_physical_cores_safe(), false);
+    } else {
+        ALOGI("Successfully memory-mapped T5 tensors directly (skipped separate buffer allocation)");
+        t5->alloc_params_buffer();
+    }
+
+    if (!load_ok) {
         ALOGE("Failed to load tensors for T5 context");
         t5->free_params_buffer();
         delete t5;
@@ -107,6 +117,7 @@ static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, b
     handle->ctx = nullptr;
     handle->t5_ctx = t5;
     handle->backend = backend;
+    handle->mmap_stores = std::move(mmap_stores);
     if (env) {
         env->GetJavaVM(&handle->jvm);
         jni_thread_cache_init(handle->jvm);
@@ -141,26 +152,35 @@ static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bo
     (void)useVulkan;
 #endif
     if (!backend) {
-        backend = ggml_backend_cpu_init();
+        backend = sd_backend_cpu_init();
     }
     if (!backend) {
         ALOGE("Unable to initialize backend for LLM-only context");
         return nullptr;
     }
 
+    ggml_backend_t params_backend = offloadToCpu ? sd_backend_cpu_init() : backend;
     auto* llm = new LLMEmbedder(
         backend,
-        offloadToCpu,
+        params_backend,
         model_loader.get_tensor_storage_map(),
         VERSION_FLUX2_KLEIN);
-    // alloc_params_buffer() returns void in this fork; load_tensors below is the
-    // checkable failure point.
-    llm->alloc_params_buffer();
-
     std::map<std::string, struct ggml_tensor*> tensors;
     llm->get_param_tensors(tensors);
-    std::set<std::string> ignore_tensors;
-    if (!model_loader.load_tensors(tensors, ignore_tensors, sd_get_num_physical_cores_safe())) {
+
+    std::vector<MmapTensorStore> mmap_stores = model_loader.mmap_tensors(tensors, {}, false);
+    bool load_ok = true;
+    if (mmap_stores.empty()) {
+        ALOGW("mmap failed or disabled for LLM, falling back to loading into allocated memory buffer");
+        llm->alloc_params_buffer();
+        std::set<std::string> ignore_tensors;
+        load_ok = model_loader.load_tensors(tensors, ignore_tensors, sd_get_num_physical_cores_safe(), false);
+    } else {
+        ALOGI("Successfully memory-mapped LLM tensors directly (skipped separate buffer allocation)");
+        llm->alloc_params_buffer();
+    }
+
+    if (!load_ok) {
         ALOGE("Failed to load tensors for LLM context");
         llm->free_params_buffer();
         delete llm;
@@ -172,6 +192,7 @@ static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bo
     handle->ctx     = nullptr;
     handle->llm_ctx = llm;
     handle->backend = backend;
+    handle->mmap_stores = std::move(mmap_stores);
     if (env) {
         env->GetJavaVM(&handle->jvm);
         jni_thread_cache_init(handle->jvm);
@@ -402,6 +423,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
 
     sd_ctx_params_t p{};
     sd_ctx_params_init(&p);
+    p.enable_mmap = true;
     p.model_path = modelPath ? modelPath : "";
     p.vae_path = vaePath ? vaePath : "";
     p.t5xxl_path = t5xxlPath;

--- a/llmedge/src/main/cpp/sdcpp_jni_video.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_video.cpp
@@ -111,7 +111,11 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Vid(
     sd_image_t* frames = nullptr;
     int numFrames = 0;
     try {
-        frames = generate_video(handle->ctx, &gen, &numFrames);
+        bool ok = generate_video(handle->ctx, &gen, &frames, &numFrames, nullptr);
+        if (!ok) {
+            frames = nullptr;
+            numFrames = 0;
+        }
     } catch (const std::exception& e) {
         releaseStrings();
         const char* clazz = handle->cancellationRequested.load()


### PR DESCRIPTION
Reorders JNI loaders to call mmap_tensors before alloc_params_buffer. Adds mmap_stores to SdHandle to prevent early unmapping of memory. Enables direct mmap for T5 and LLM loaders. Updates test to run with Qwen3 3.4B model.