### PR TITLE
Bump sd.cpp nested ggml to upstream 0ce7ad3 + wire SPIRV-Headers

### DIFF
--- a/llmedge/src/main/cpp/cmake/llmedge-spirv-headers.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-spirv-headers.cmake
@@ -1,0 +1,28 @@
+# ------------------------------------------------------------
+# SPIRV-Headers (shared by the Android and desktop/CI builds)
+# ------------------------------------------------------------
+# Newer ggml-vulkan.cpp patches SPIR-V bytecode at runtime (adds RoundingModeRTE)
+# and needs the Khronos `namespace spv` definitions, which it probes for via
+# <spirv/unified1/spirv.hpp>. The Android NDK sysroot and the Linux CI toolchain
+# do not ship those headers, so fetch them once here and attach to ggml-vulkan
+# from both build entry points. Using a single pinned source keeps both
+# toolchains compiling against identical definitions.
+include_guard(GLOBAL)
+include(FetchContent)
+
+FetchContent_Declare(
+    spirv_headers
+    GIT_REPOSITORY https://github.com/KhronosGroup/SPIRV-Headers.git
+    GIT_TAG        vulkan-sdk-1.3.275.0  # aligned with the Vulkan-Hpp tag used elsewhere
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(spirv_headers)
+
+set(LLMEDGE_SPIRV_INCLUDE_DIR "${spirv_headers_SOURCE_DIR}/include" CACHE INTERNAL "SPIRV-Headers include dir")
+
+# Attach the SPIRV-Headers include dir to a Vulkan-enabled ggml target, if present.
+function(llmedge_attach_spirv_headers _target)
+    if (TARGET ${_target})
+        target_include_directories(${_target} PRIVATE "${LLMEDGE_SPIRV_INCLUDE_DIR}")
+    endif()
+endfunction()

--- a/llmedge/src/main/cpp/cmake/llmedge-stable-diffusion.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-stable-diffusion.cmake
@@ -191,6 +191,10 @@ add_subdirectory(${SD_DIR} ${CMAKE_CURRENT_BINARY_DIR}/stable-diffusion.cpp)
 if (TARGET ggml-vulkan AND vulkan_hpp_SOURCE_DIR)
     target_include_directories(ggml-vulkan PRIVATE ${vulkan_hpp_SOURCE_DIR})
 endif()
+if (SD_VULKAN)
+    include("${LLMEDGE_CPP_ROOT}/cmake/llmedge-spirv-headers.cmake")
+    llmedge_attach_spirv_headers(ggml-vulkan)
+endif()
 
 add_library(${LLMEDGE_TARGET_SDCPP} SHARED
         ${LLMEDGE_CPP_ROOT}/sdcpp_jni_common.cpp

--- a/scripts/jni-desktop/CMakeLists.txt
+++ b/scripts/jni-desktop/CMakeLists.txt
@@ -42,6 +42,13 @@ if(BUILD_SDCPP)
     # Add stable-diffusion.cpp
     add_subdirectory(${SD_ROOT} stable-diffusion)
 
+    # Newer ggml-vulkan.cpp needs SPIRV-Headers (namespace spv); provide them from the
+    # same pinned source the Android build uses.
+    if(SD_VULKAN)
+        include("${LLMEDGE_CPP_ROOT}/cmake/llmedge-spirv-headers.cmake")
+        llmedge_attach_spirv_headers(ggml-vulkan)
+    endif()
+
     # Build sdcpp shared library. Compile the full split JNI source set (matching the Android
     # build in cmake/llmedge-stable-diffusion.cmake) so the desktop library actually exports the
     # JNI entry points (nativeCreate, txt2img, ...) and host image/video E2E tests can load it.


### PR DESCRIPTION
Aligns stable-diffusion.cpp's nested ggml with the upstream leejet/master merge (a8db410 -> 0ce7ad3), reverting the temporary CI pin from #34.

The newer ggml-vulkan.cpp patches SPIR-V bytecode at runtime (RoundingModeRTE) and needs the Khronos namespace spv definitions, probed via <spirv/unified1/spirv.hpp>. Neither the Android NDK sysroot nor the Linux CI toolchain ship those headers, which is what broke the build after the original merge. This adds llmedge-spirv-headers.cmake: one pinned FetchContent of SPIRV-Headers (vulkan-sdk-1.3.275.0, aligned with the Vulkan-Hpp tag), attached to the ggml-vulkan target from both build entry points (Android llmedge-stable-diffusion.cmake and desktop/CI jni-desktop). Both toolchains compile against identical SPIRV-Headers content.

CI validates the build (native + AAR). Image generation itself is not covered by CI, so this also needs an on-device check (S22: standard, sequential, FLUX) before merge.