### PR TITLE
Bump whisper.cpp to upstream 6fc7c33b

### DIFF
--- a/llmedge/src/main/cpp/cmake/llmedge-whisper.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-whisper.cmake
@@ -25,6 +25,7 @@ set(WHISPER_GGML_SOURCES
         ${WHISPER_GGML_DIR}/src/ggml-alloc.c
         ${WHISPER_GGML_DIR}/src/ggml-backend.cpp
         ${WHISPER_GGML_DIR}/src/ggml-backend-reg.cpp
+        ${WHISPER_GGML_DIR}/src/ggml-backend-meta.cpp
         ${WHISPER_GGML_DIR}/src/ggml-opt.cpp
         ${WHISPER_GGML_DIR}/src/ggml-quants.c
         ${WHISPER_GGML_DIR}/src/ggml-threading.cpp
@@ -38,8 +39,21 @@ set(WHISPER_GGML_SOURCES
         ${WHISPER_GGML_DIR}/src/ggml-cpu/unary-ops.cpp
         ${WHISPER_GGML_DIR}/src/ggml-cpu/binary-ops.cpp
         ${WHISPER_GGML_DIR}/src/ggml-cpu/repack.cpp
-        ${WHISPER_GGML_DIR}/src/ggml-cpu/arch/arm/quants.c
 )
+
+if (ANDROID_ABI MATCHES "^(arm64-v8a|armeabi-v7a)$")
+        list(APPEND WHISPER_GGML_SOURCES
+                ${WHISPER_GGML_DIR}/src/ggml-cpu/arch/arm/quants.c
+                ${WHISPER_GGML_DIR}/src/ggml-cpu/arch/arm/repack.cpp
+                ${WHISPER_GGML_DIR}/src/ggml-cpu/arch/arm/cpu-feats.cpp
+        )
+elseif (ANDROID_ABI MATCHES "^(x86_64|x86)$")
+        list(APPEND WHISPER_GGML_SOURCES
+                ${WHISPER_GGML_DIR}/src/ggml-cpu/arch/x86/quants.c
+                ${WHISPER_GGML_DIR}/src/ggml-cpu/arch/x86/repack.cpp
+                ${WHISPER_GGML_DIR}/src/ggml-cpu/arch/x86/cpu-feats.cpp
+        )
+endif()
 
 set(WHISPER_SOURCES
         ${WHISPER_DIR}/src/whisper.cpp

--- a/mods/whisper.cpp/preferred-backend.patch
+++ b/mods/whisper.cpp/preferred-backend.patch
@@ -1,13 +1,8 @@
 diff --git a/src/whisper.cpp b/src/whisper.cpp
-index 796bccfb..1fc0940f 100644
+index 2a95bdb1..acf6f4dc 100644
 --- a/src/whisper.cpp
 +++ b/src/whisper.cpp
-@@ -1282,68 +1282,90 @@ static size_t aheads_masks_nbytes(struct whisper_aheads_masks & aheads_masks) {
-     size_t size = 0;
-     for (size_t i = 0; i < aheads_masks.m.size(); ++i) {
-         if (aheads_masks.m[i] != nullptr)
-             size += ggml_nbytes(aheads_masks.m[i]);
-     }
+@@ -1287,10 +1287,26 @@ static size_t aheads_masks_nbytes(struct whisper_aheads_masks & aheads_masks) {
      return size;
  }
  
@@ -25,6 +20,7 @@ index 796bccfb..1fc0940f 100644
 +    return reg_name && std::strcmp(reg_name, preferred_backend) == 0;
 +}
 +
++
  static ggml_backend_t whisper_backend_init_gpu(const whisper_context_params & params) {
      ggml_log_set(g_state.log_callback, g_state.log_callback_user_data);
  
@@ -33,8 +29,7 @@ index 796bccfb..1fc0940f 100644
  
      int cnt = 0;
      if (params.use_gpu) {
-         for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
-             ggml_backend_dev_t dev_cur = ggml_backend_dev_get(i);
+@@ -1299,7 +1315,8 @@ static ggml_backend_t whisper_backend_init_gpu(const whisper_context_params & pa
              enum ggml_backend_dev_type dev_type = ggml_backend_dev_type(dev_cur);
              const char * dev_name = ggml_backend_dev_name(dev_cur);
              WHISPER_LOG_INFO("%s: device %zu: %s (type: %d)\n", __func__, i, dev_name, dev_type);
@@ -44,13 +39,7 @@ index 796bccfb..1fc0940f 100644
                  WHISPER_LOG_INFO("%s: found GPU device %zu: %s (type: %d, cnt: %d)\n", __func__, i, dev_name, dev_type, cnt);
                  if (cnt == params.gpu_device) {
                      dev = dev_cur;
-                 }
- 
-                 if (++cnt > params.gpu_device) {
-                     break;
-                 }
-             }
-         }
+@@ -1313,7 +1330,11 @@ static ggml_backend_t whisper_backend_init_gpu(const whisper_context_params & pa
      }
  
      if (dev == nullptr) {
@@ -63,14 +52,7 @@ index 796bccfb..1fc0940f 100644
          return nullptr;
      }
  
-     WHISPER_LOG_INFO("%s: using %s backend\n", __func__, ggml_backend_dev_name(dev));
-     ggml_backend_t result = ggml_backend_dev_init(dev, nullptr);
-     if (!result) {
-         WHISPER_LOG_ERROR("%s: failed to initialize %s backend\n", __func__, ggml_backend_dev_name(dev));
-     }
- 
-     return result;
- }
+@@ -1328,6 +1349,7 @@ static ggml_backend_t whisper_backend_init_gpu(const whisper_context_params & pa
  
  static std::vector<ggml_backend_t> whisper_backend_init(const whisper_context_params & params) {
      std::vector<ggml_backend_t> result;
@@ -78,10 +60,7 @@ index 796bccfb..1fc0940f 100644
  
      ggml_backend_t backend_gpu = whisper_backend_init_gpu(params);
  
-     if (backend_gpu) {
-         result.push_back(backend_gpu);
-     }
- 
+@@ -1338,7 +1360,8 @@ static std::vector<ggml_backend_t> whisper_backend_init(const whisper_context_pa
      // ACCEL backends
      for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
          ggml_backend_dev_t dev = ggml_backend_dev_get(i);
@@ -91,17 +70,7 @@ index 796bccfb..1fc0940f 100644
              WHISPER_LOG_INFO("%s: using %s backend\n", __func__, ggml_backend_dev_name(dev));
              ggml_backend_t backend = ggml_backend_dev_init(dev, nullptr);
              if (!backend) {
-                 WHISPER_LOG_ERROR("%s: failed to initialize %s backend\n", __func__, ggml_backend_dev_name(dev));
-                 continue;
-             }
-             result.push_back(backend);
-         }
-@@ -1358,23 +1380,25 @@ static std::vector<ggml_backend_t> whisper_backend_init(const whisper_context_pa
-     return result;
- }
- 
- using buft_list_t = std::vector<std::pair<ggml_backend_dev_t, ggml_backend_buffer_type_t>>;
- 
+@@ -1363,13 +1386,15 @@ using buft_list_t = std::vector<std::pair<ggml_backend_dev_t, ggml_backend_buffe
  static buft_list_t make_buft_list(whisper_context_params & params) {
      // Prio order: GPU -> CPU Extra -> CPU
      buft_list_t buft_list;
@@ -118,8 +87,3 @@ index 796bccfb..1fc0940f 100644
                  if (cnt == params.gpu_device) {
                      auto * buft = ggml_backend_dev_buffer_type(dev);
                      if (buft) {
-                         buft_list.emplace_back(dev, buft);
-                     }
-                 }
- 
-                 if (++cnt > params.gpu_device) {

--- a/scripts/jni-desktop/CMakeLists.txt
+++ b/scripts/jni-desktop/CMakeLists.txt
@@ -262,6 +262,10 @@ if(WHISPER_DESKTOP_JNI)
             ${JNI_LIBRARIES}
         )
 
+        if(APPLE)
+            set_target_properties(${LLMEDGE_TARGET_WHISPER_JNI} PROPERTIES SUFFIX ".so")
+        endif()
+
         message(STATUS "Whisper desktop JNI configured")
     else()
         message(WARNING "whisper.cpp not found at ${WHISPER_ROOT}, skipping whisper_jni")


### PR DESCRIPTION
Advances the vendored whisper.cpp submodule ~714 commits to origin/master (6fc7c33b).

Changes:
- Refreshes mods/whisper.cpp/preferred-backend.patch against the refactored upstream backend-init code; the preferred-backend selection is preserved across whisper_backend_init_gpu, whisper_backend_init, and make_buft_list. The build FATAL_ERRORs if the patch fails to apply, so a green build confirms it applies.
- llmedge-whisper.cmake: adds the new ggml-backend-meta.cpp source and selects arch-specific quants.c/repack.cpp/cpu-feats.cpp per ANDROID_ABI (the desktop build uses upstream's own cmake via add_subdirectory and is unaffected).
- jni-desktop: forces a .so suffix for the desktop whisper JNI on macOS so the host E2E test can load it (APPLE-guarded, no effect on Linux or Android).

Verified on device: whisper STT on the S22 (arm64) transcribes the JFK sample correctly. CI covers the Linux-x86_64 native build (patch apply + x86 arch sources), WhisperLinuxE2ETest, and the full unit suite.