### PR TITLE
Harden runtime coordination, JNI callback cache, and UTF-8 input paths

### DIFF
--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/RuntimeHardeningDeviceGateTest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/RuntimeHardeningDeviceGateTest.kt
@@ -1,0 +1,131 @@
+package io.aatricks.llmedge
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.aatricks.llmedge.image.diffusion.GenerateParams
+import io.aatricks.llmedge.image.diffusion.StableDiffusion
+import io.aatricks.llmedge.speech.stt.Whisper
+import io.aatricks.llmedge.text.runtime.SmolLM
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device regression gate for the runtime-hardening fixes that cannot be
+ * verified off-device: real native progress/segment callbacks (the JNI
+ * thread-cache state is per shared library and must work across translation
+ * units) and standard-UTF-8 prompt delivery to native tokenizers.
+ *
+ * Model files are read from /data/local/tmp (override via instrumentation args):
+ *   llmedge.gate.sd_model_path      (default /data/local/tmp/sdturbo.gguf)
+ *   llmedge.gate.whisper_model_path (default /data/local/tmp/ggml-base.en.bin)
+ *   llmedge.gate.wav_path           (default /data/local/tmp/jfk.wav)
+ *   llmedge.gate.text_model_path    (default /data/local/tmp/smollm135.gguf)
+ *
+ * Run:
+ *   ./gradlew :llmedge:connectedDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=io.aatricks.llmedge.RuntimeHardeningDeviceGateTest
+ */
+@RunWith(AndroidJUnit4::class)
+class RuntimeHardeningDeviceGateTest {
+
+    private fun requireFile(argKey: String, default: String): File {
+        val path = InstrumentationRegistry.getArguments().getString(argKey) ?: default
+        val file = File(path)
+        assumeTrue("Missing $argKey file: $path", file.exists())
+        return file
+    }
+
+    @Test
+    fun stableDiffusionProgressCallbackFiresDuringTxt2Img() = runBlocking {
+        val model = requireFile("llmedge.gate.sd_model_path", "/data/local/tmp/sdturbo.gguf")
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val progressCalls = AtomicInteger(0)
+
+        val sd = StableDiffusion.load(context = context, modelPath = model.absolutePath)
+        sd.use { engine ->
+            engine.setProgressCallback { _, _, _, _, _ -> progressCalls.incrementAndGet() }
+            val bitmap = engine.txt2img(
+                GenerateParams(
+                    prompt = "a red apple on a table",
+                    width = 256,
+                    height = 256,
+                    steps = 2,
+                    cfgScale = 1.0f,
+                    seed = 42L,
+                ),
+            )
+            assertTrue("txt2img returned empty bitmap", bitmap.width > 0 && bitmap.height > 0)
+        }
+        assertTrue(
+            "Native progress callback never fired (JNI thread-cache regression)",
+            progressCalls.get() > 0,
+        )
+    }
+
+    @Test
+    fun whisperSegmentAndProgressCallbacksFireDuringTranscribe() {
+        val model = requireFile("llmedge.gate.whisper_model_path", "/data/local/tmp/ggml-base.en.bin")
+        val wav = requireFile("llmedge.gate.wav_path", "/data/local/tmp/jfk.wav")
+        val segmentCalls = AtomicInteger(0)
+        val progressCalls = AtomicInteger(0)
+
+        val whisper = Whisper.load(modelPath = model.absolutePath, useGpu = false)
+        try {
+            whisper.setSegmentCallback { _, _, _, _ -> segmentCalls.incrementAndGet() }
+            whisper.setProgressCallback { progressCalls.incrementAndGet() }
+            val segments = whisper.transcribe(readWavMono16k(wav))
+            assertTrue("Transcription produced no segments", segments.isNotEmpty())
+            val text = segments.joinToString(" ") { it.text }.lowercase()
+            assertTrue("Unexpected transcript: $text", "country" in text)
+        } finally {
+            whisper.close()
+        }
+        assertTrue(
+            "Native segment callback never fired (JNI thread-cache regression)",
+            segmentCalls.get() > 0,
+        )
+    }
+
+    @Test
+    fun smolLmAcceptsSupplementaryUnicodePrompt() = runBlocking {
+        val model = requireFile("llmedge.gate.text_model_path", "/data/local/tmp/smollm135.gguf")
+        val smol = SmolLM()
+        try {
+            smol.load(model.absolutePath, SmolLM.InferenceParams(storeChats = false))
+            // U+1F600 crosses JNI as a surrogate pair; before the UTF-8 fix the
+            // tokenizer received invalid Modified-UTF-8 bytes for it.
+            val response = smol.getResponse("Repeat this exactly: hello 😀 world", maxTokens = 48)
+            assertTrue("Empty response to emoji prompt", response.isNotBlank())
+        } finally {
+            smol.close()
+        }
+    }
+
+    /** Minimal RIFF reader for 16 kHz mono PCM16 wav files (e.g. whisper.cpp samples). */
+    private fun readWavMono16k(file: File): FloatArray {
+        val bytes = file.readBytes()
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        require(bytes.size > 44 && bytes.decodeToString(0, 4) == "RIFF") { "Not a RIFF wav: $file" }
+        var pos = 12
+        while (pos + 8 <= bytes.size) {
+            val id = bytes.decodeToString(pos, pos + 4)
+            val size = buffer.getInt(pos + 4)
+            if (id == "data") {
+                val samples = FloatArray(size / 2)
+                for (i in samples.indices) {
+                    samples[i] = buffer.getShort(pos + 8 + i * 2) / 32768.0f
+                }
+                return samples
+            }
+            pos += 8 + size + (size and 1)
+        }
+        throw IllegalArgumentException("No data chunk in $file")
+    }
+}

--- a/llmedge/src/main/cpp/bark_jni.cpp
+++ b/llmedge/src/main/cpp/bark_jni.cpp
@@ -243,17 +243,19 @@ Java_io_aatricks_llmedge_speech_tts_BarkTTS_nativeGenerate(JNIEnv* env, jclass,
         return nullptr;
     }
 
-    const char* text = env->GetStringUTFChars(jText, nullptr);
-    if (!text) {
+    // Standard UTF-8 (not GetStringUTFChars' Modified UTF-8) so emoji and other
+    // supplementary characters reach the native tokenizer as valid bytes.
+    std::string textUtf8;
+    if (!llmedge_jstring_to_utf8(env, jText, &textUtf8)) {
         throwJavaException(env, "java/lang/RuntimeException", "Failed to get text string");
         return nullptr;
     }
+    const char* text = textUtf8.c_str();
 
     ALOGI("Generating audio for text: \"%s\", threads=%d", text, nThreads);
 
     // Generate audio
     bool success = bark_generate_audio(handle->ctx, text, nThreads);
-    env->ReleaseStringUTFChars(jText, text);
 
     if (!success) {
         ALOGE("Failed to generate audio");

--- a/llmedge/src/main/cpp/cmake/llmedge-bark.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-bark.cmake
@@ -35,6 +35,7 @@ set(BARK_JNI_ALL_SOURCES
         ${ENCODEC_SOURCES}
         ${BARK_SOURCES}
         ${LLMEDGE_CPP_ROOT}/bark_jni.cpp
+        ${LLMEDGE_CPP_ROOT}/jni_thread_cache.cpp
 )
 
 add_library(${LLMEDGE_TARGET_BARK_JNI} SHARED ${BARK_JNI_ALL_SOURCES})

--- a/llmedge/src/main/cpp/cmake/llmedge-stable-diffusion.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-stable-diffusion.cmake
@@ -203,6 +203,7 @@ add_library(${LLMEDGE_TARGET_SDCPP} SHARED
         ${LLMEDGE_CPP_ROOT}/sdcpp_jni.cpp
         ${LLMEDGE_CPP_ROOT}/sdcpp_jni_load.cpp
         ${LLMEDGE_CPP_ROOT}/sdcpp_jni_video.cpp
+        ${LLMEDGE_CPP_ROOT}/jni_thread_cache.cpp
 )
 
 target_include_directories(${LLMEDGE_TARGET_SDCPP}

--- a/llmedge/src/main/cpp/cmake/llmedge-whisper.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-whisper.cmake
@@ -59,6 +59,7 @@ set(WHISPER_SOURCES
         ${WHISPER_DIR}/src/whisper.cpp
         ${LLMEDGE_CPP_ROOT}/whisper_jni_common.cpp
         ${LLMEDGE_CPP_ROOT}/whisper_jni.cpp
+        ${LLMEDGE_CPP_ROOT}/jni_thread_cache.cpp
 )
 
 set(WHISPER_JNI_ALL_SOURCES

--- a/llmedge/src/main/cpp/jni_thread_cache.cpp
+++ b/llmedge/src/main/cpp/jni_thread_cache.cpp
@@ -1,0 +1,48 @@
+#include "jni_thread_cache.h"
+#include <pthread.h>
+
+static JavaVM* g_jvm = nullptr;
+static pthread_key_t g_jni_env_key;
+static pthread_once_t g_key_once = PTHREAD_ONCE_INIT;
+
+static void jni_thread_cache_detach(void* env) {
+    if (g_jvm && env) {
+        g_jvm->DetachCurrentThread();
+    }
+}
+
+static void jni_thread_cache_make_key() {
+    pthread_key_create(&g_jni_env_key, jni_thread_cache_detach);
+}
+
+void jni_thread_cache_init(JavaVM* jvm) {
+    g_jvm = jvm;
+    pthread_once(&g_key_once, jni_thread_cache_make_key);
+}
+
+JNIEnv* jni_thread_cache_get_env() {
+    pthread_once(&g_key_once, jni_thread_cache_make_key);
+    auto* env = static_cast<JNIEnv*>(pthread_getspecific(g_jni_env_key));
+    if (env) return env;
+
+    if (!g_jvm) return nullptr;
+
+    jint status = g_jvm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    if (status == JNI_OK) {
+        return env;
+    }
+
+    if (status == JNI_EDETACHED) {
+#if defined(__ANDROID__)
+        if (g_jvm->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+#else
+        if (g_jvm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr) != JNI_OK) {
+#endif
+            return nullptr;
+        }
+        pthread_setspecific(g_jni_env_key, env);
+        return env;
+    }
+
+    return nullptr;
+}

--- a/llmedge/src/main/cpp/jni_thread_cache.h
+++ b/llmedge/src/main/cpp/jni_thread_cache.h
@@ -1,78 +1,26 @@
-/**
- * Thread-local JNIEnv cache using pthread TLS.
+/*
+ * Shared JNI thread-attach cache.
  *
- * Each native thread attaches to the JVM once on first callback and is
- * automatically detached when the thread exits (via the pthread_key
- * destructor).  This avoids the overhead of AttachCurrentThread /
- * DetachCurrentThread on every callback invocation.
+ * Native callbacks (progress, segment, log) fire on internal worker threads
+ * that are not attached to the JVM. Attaching/detaching per callback is
+ * expensive and error-prone; this helper caches one JNIEnv per thread and
+ * auto-detaches on thread exit.
  *
  * Usage:
- *   1. Call jni_thread_cache_init(jvm) once (e.g. in JNI_OnLoad or when
+ *   1. Call jni_thread_cache_init(jvm) once per .so (e.g. in JNI_OnLoad or when
  *      the JavaVM* is first obtained).
  *   2. In callbacks, call jni_thread_cache_get_env() instead of the
  *      manual Attach/Detach dance.
  *
- * The helpers live in an unnamed namespace so each translation unit gets
- * its own copy — safe for separate .so files that are never linked together.
+ * The state lives in jni_thread_cache.cpp, compiled once into each shared
+ * library, so every translation unit of a given .so sees the same JavaVM*.
+ * (An earlier unnamed-namespace version gave each .cpp its own copy, which
+ * silently disabled callbacks initialized in a different translation unit.)
  */
 
 #pragma once
 
 #include <jni.h>
-#include <pthread.h>
 
-namespace {
-
-static JavaVM* g_jvm = nullptr;
-static pthread_key_t g_jni_env_key;
-static pthread_once_t g_key_once = PTHREAD_ONCE_INIT;
-
-static void jni_thread_cache_detach(void* env) {
-    if (g_jvm && env) {
-        g_jvm->DetachCurrentThread();
-    }
-}
-
-static void jni_thread_cache_make_key() {
-    pthread_key_create(&g_jni_env_key, jni_thread_cache_detach);
-}
-
-// Call once to store the JavaVM pointer used for attaching threads.
-static void jni_thread_cache_init(JavaVM* jvm) {
-    g_jvm = jvm;
-    pthread_once(&g_key_once, jni_thread_cache_make_key);
-}
-
-// Get JNIEnv for the current thread, attaching if needed.
-// The thread will be auto-detached when it exits.
-static JNIEnv* jni_thread_cache_get_env() {
-    pthread_once(&g_key_once, jni_thread_cache_make_key);
-    auto* env = static_cast<JNIEnv*>(pthread_getspecific(g_jni_env_key));
-    if (env) return env;
-
-    if (!g_jvm) return nullptr;
-
-    // Check if already attached (e.g. the JNI calling thread).
-    jint status = g_jvm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
-    if (status == JNI_OK) {
-        // Already attached — cache but do NOT register for auto-detach
-        // because this may be a JVM-owned thread (main / binder).
-        return env;
-    }
-
-    if (status == JNI_EDETACHED) {
-#if defined(__ANDROID__)
-        if (g_jvm->AttachCurrentThread(&env, nullptr) != JNI_OK) {
-#else
-        if (g_jvm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr) != JNI_OK) {
-#endif
-            return nullptr;
-        }
-        pthread_setspecific(g_jni_env_key, env);
-        return env;
-    }
-
-    return nullptr;
-}
-
-} // unnamed namespace
+void jni_thread_cache_init(JavaVM* jvm);
+JNIEnv* jni_thread_cache_get_env();

--- a/llmedge/src/main/cpp/jni_utils.h
+++ b/llmedge/src/main/cpp/jni_utils.h
@@ -2,8 +2,10 @@
 
 #include <jni.h>
 
+#include <cstdint>
 #include <cstring>
 #include <mutex>
+#include <string>
 
 // Single process-wide mutex for setenv/unsetenv/getenv around backend selection.
 // POSIX environment mutation is not thread-safe against concurrent getenv, and the
@@ -89,6 +91,62 @@ inline jstring llmedge_new_string_utf8(JNIEnv* env, const char* utf8) {
     env->DeleteLocalRef(string_class);
     env->DeleteLocalRef(bytes);
     return result;
+}
+
+// Convert a java.lang.String to *standard* UTF-8. GetStringUTFChars yields
+// Modified UTF-8 (supplementary characters such as emoji become 6-byte
+// surrogate sequences, U+0000 becomes 0xC0 0x80), which native tokenizers
+// reject as invalid bytes — so go through UTF-16 and encode real UTF-8.
+// Returns false only if the UTF-16 chars could not be obtained (a Java
+// exception is then pending). A null jstring converts to "" and returns true.
+inline bool llmedge_jstring_to_utf8(JNIEnv* env, jstring value, std::string* out) {
+    out->clear();
+    if (!value) {
+        return true;
+    }
+    const jsize len = env->GetStringLength(value);
+    const jchar* chars = env->GetStringChars(value, nullptr);
+    if (!chars) {
+        return false;
+    }
+    out->reserve(static_cast<size_t>(len) * 3);
+    for (jsize i = 0; i < len; ++i) {
+        uint32_t cp = chars[i];
+        if (cp >= 0xD800 && cp <= 0xDBFF && i + 1 < len) {
+            const uint32_t low = chars[i + 1];
+            if (low >= 0xDC00 && low <= 0xDFFF) {
+                cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
+                ++i;
+            }
+        }
+        if (cp >= 0xD800 && cp <= 0xDFFF) {
+            cp = 0xFFFD;  // unpaired surrogate -> replacement character
+        }
+        if (cp < 0x80) {
+            out->push_back(static_cast<char>(cp));
+        } else if (cp < 0x800) {
+            out->push_back(static_cast<char>(0xC0 | (cp >> 6)));
+            out->push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+        } else if (cp < 0x10000) {
+            out->push_back(static_cast<char>(0xE0 | (cp >> 12)));
+            out->push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+            out->push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+        } else {
+            out->push_back(static_cast<char>(0xF0 | (cp >> 18)));
+            out->push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+            out->push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+            out->push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+        }
+    }
+    env->ReleaseStringChars(value, chars);
+    return true;
+}
+
+// Convenience overload for call sites that treat conversion failure as "".
+inline std::string llmedge_jstring_to_utf8(JNIEnv* env, jstring value) {
+    std::string out;
+    llmedge_jstring_to_utf8(env, value, &out);
+    return out;
 }
 
 inline jobject llmedge_new_global_ref_or_throw(JNIEnv* env, jobject target, const char* oom_message) {

--- a/llmedge/src/main/cpp/sdcpp_jni_condition.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_condition.cpp
@@ -1,3 +1,4 @@
+#include "jni_utils.h"
 #include "sdcpp_jni_shared.h"
 
 #include <algorithm>
@@ -8,7 +9,11 @@
 #include <stdexcept>
 #include <vector>
 
+// conditioner.hpp drags in the full header-only sd.cpp model graph code, which the
+// host-native test harness cannot link (it stubs libstable-diffusion instead).
+#ifndef SD_JNI_TESTING
 #include "conditioner.hpp"
+#endif
 #include "ggml-backend.h"
 #include "model.h"
 
@@ -104,12 +109,14 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativePrecomputeConditi
         jboolean jIsVideo) {
     (void)thiz;
 
-    const char* prompt = jPrompt ? env->GetStringUTFChars(jPrompt, nullptr) : "";
-    const char* negative = jNegative ? env->GetStringUTFChars(jNegative, nullptr) : "";
+    // Standard UTF-8 (not GetStringUTFChars' Modified UTF-8) so emoji and other
+    // supplementary characters reach the native tokenizer as valid bytes.
+    const std::string promptUtf8 = llmedge_jstring_to_utf8(env, jPrompt);
+    const std::string negativeUtf8 = llmedge_jstring_to_utf8(env, jNegative);
+    const char* prompt = promptUtf8.c_str();
+    const char* negative = negativeUtf8.c_str();
 
     auto releaseStrings = [&]() {
-        if (jPrompt) env->ReleaseStringUTFChars(jPrompt, prompt);
-        if (jNegative) env->ReleaseStringUTFChars(jNegative, negative);
     };
 
     sd_condition_raw_t* cond = nullptr;
@@ -125,7 +132,9 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativePrecomputeConditi
                 throwJavaException(env, "java/lang/RuntimeException", e.what());
                 return nullptr;
             }
-        } else if (handle->t5_ctx) {
+        }
+#ifndef SD_JNI_TESTING
+        else if (handle->t5_ctx) {
             auto* t5 = static_cast<T5CLIPEmbedder*>(handle->t5_ctx);
             try {
                 ConditionerParams cparams;
@@ -210,7 +219,9 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativePrecomputeConditi
                 throwJavaException(env, "java/lang/RuntimeException", e.what());
                 return nullptr;
             }
-        } else {
+        }
+#endif
+        else {
             throwJavaException(env, "java/lang/IllegalStateException", "Invalid handle state");
             releaseStrings();
             return nullptr;
@@ -308,13 +319,15 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2ImgWithPrecom
     handle->cancellationRequested.store(false);
     SdProgressCallbackGuard callbackGuard(handle);
 
-    const char* prompt = jPrompt ? env->GetStringUTFChars(jPrompt, nullptr) : "";
-    const char* negative = jNegative ? env->GetStringUTFChars(jNegative, nullptr) : "";
+    // Standard UTF-8 (not GetStringUTFChars' Modified UTF-8) so emoji and other
+    // supplementary characters reach the native tokenizer as valid bytes.
+    const std::string promptUtf8 = llmedge_jstring_to_utf8(env, jPrompt);
+    const std::string negativeUtf8 = llmedge_jstring_to_utf8(env, jNegative);
+    const char* prompt = promptUtf8.c_str();
+    const char* negative = negativeUtf8.c_str();
     SdResolvedPromptLoras resolved = resolve_prompt_loras(prompt, negative, handle->loraModelDir);
 
     auto releaseStrings = [&]() {
-        if (jPrompt) env->ReleaseStringUTFChars(jPrompt, prompt);
-        if (jNegative) env->ReleaseStringUTFChars(jNegative, negative);
     };
 
     sd_condition_raw_t* cond = reconstruct_condition(env, condArr);
@@ -423,12 +436,14 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2VidWithPrecom
     handle->totalFrames = std::max(1, static_cast<int>(videoFrames));
     handle->currentFrame = 0;
 
-    const char* prompt = jPrompt ? env->GetStringUTFChars(jPrompt, nullptr) : "";
-    const char* negative = jNegative ? env->GetStringUTFChars(jNegative, nullptr) : "";
+    // Standard UTF-8 (not GetStringUTFChars' Modified UTF-8) so emoji and other
+    // supplementary characters reach the native tokenizer as valid bytes.
+    const std::string promptUtf8 = llmedge_jstring_to_utf8(env, jPrompt);
+    const std::string negativeUtf8 = llmedge_jstring_to_utf8(env, jNegative);
+    const char* prompt = promptUtf8.c_str();
+    const char* negative = negativeUtf8.c_str();
 
     auto releaseStrings = [&]() {
-        if (jPrompt) env->ReleaseStringUTFChars(jPrompt, prompt);
-        if (jNegative) env->ReleaseStringUTFChars(jNegative, negative);
     };
 
     sd_sample_params_t sample{};

--- a/llmedge/src/main/cpp/sdcpp_jni_image.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_image.cpp
@@ -1,3 +1,4 @@
+#include "jni_utils.h"
 #include "sdcpp_jni_shared.h"
 
 #include <cstddef>
@@ -26,8 +27,12 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Img(
     }
     handle->cancellationRequested.store(false);
     SdProgressCallbackGuard callbackGuard(handle);
-    const char* prompt = jPrompt ? env->GetStringUTFChars(jPrompt, nullptr) : "";
-    const char* negative = jNegative ? env->GetStringUTFChars(jNegative, nullptr) : "";
+    // Standard UTF-8 (not GetStringUTFChars' Modified UTF-8) so emoji and other
+    // supplementary characters reach the native tokenizer as valid bytes.
+    const std::string promptUtf8 = llmedge_jstring_to_utf8(env, jPrompt);
+    const std::string negativeUtf8 = llmedge_jstring_to_utf8(env, jNegative);
+    const char* prompt = promptUtf8.c_str();
+    const char* negative = negativeUtf8.c_str();
     SdResolvedPromptLoras resolved = resolve_prompt_loras(prompt, negative, handle->loraModelDir);
 
     sd_sample_params_t sample{};
@@ -60,17 +65,12 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Img(
     try {
         out = generate_image(handle->ctx, &gen);
     } catch (const std::exception& e) {
-        if (jPrompt) env->ReleaseStringUTFChars(jPrompt, prompt);
-        if (jNegative) env->ReleaseStringUTFChars(jNegative, negative);
         const char* clazz = handle->cancellationRequested.load()
                 ? "java/util/concurrent/CancellationException"
                 : "java/lang/RuntimeException";
         throwJavaException(env, clazz, e.what());
         return nullptr;
     }
-
-    if (jPrompt) env->ReleaseStringUTFChars(jPrompt, prompt);
-    if (jNegative) env->ReleaseStringUTFChars(jNegative, negative);
 
     if (!out || !out[0].data) {
         ALOGE("generate_image failed");
@@ -120,8 +120,12 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2ImgArgb(
     }
     handle->cancellationRequested.store(false);
     SdProgressCallbackGuard callbackGuard(handle);
-    const char* prompt = jPrompt ? env->GetStringUTFChars(jPrompt, nullptr) : "";
-    const char* negative = jNegative ? env->GetStringUTFChars(jNegative, nullptr) : "";
+    // Standard UTF-8 (not GetStringUTFChars' Modified UTF-8) so emoji and other
+    // supplementary characters reach the native tokenizer as valid bytes.
+    const std::string promptUtf8 = llmedge_jstring_to_utf8(env, jPrompt);
+    const std::string negativeUtf8 = llmedge_jstring_to_utf8(env, jNegative);
+    const char* prompt = promptUtf8.c_str();
+    const char* negative = negativeUtf8.c_str();
     SdResolvedPromptLoras resolved = resolve_prompt_loras(prompt, negative, handle->loraModelDir);
 
     sd_sample_params_t sample{};
@@ -154,17 +158,12 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2ImgArgb(
     try {
         out = generate_image(handle->ctx, &gen);
     } catch (const std::exception& e) {
-        if (jPrompt) env->ReleaseStringUTFChars(jPrompt, prompt);
-        if (jNegative) env->ReleaseStringUTFChars(jNegative, negative);
         const char* clazz = handle->cancellationRequested.load()
                 ? "java/util/concurrent/CancellationException"
                 : "java/lang/RuntimeException";
         throwJavaException(env, clazz, e.what());
         return nullptr;
     }
-
-    if (jPrompt) env->ReleaseStringUTFChars(jPrompt, prompt);
-    if (jNegative) env->ReleaseStringUTFChars(jNegative, negative);
 
     if (!out || !out[0].data) {
         ALOGE("generate_image failed");

--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -17,7 +17,11 @@
 #if defined(SD_USE_VULKAN)
 #include "ggml-vulkan.h"
 #endif
+// conditioner.hpp drags in the full header-only sd.cpp model graph code, which the
+// host-native test harness cannot link (it stubs libstable-diffusion instead).
+#ifndef SD_JNI_TESTING
 #include "conditioner.hpp"
+#endif
 #include "ggml_extend_backend.h"
 #include "ggml-backend.h"
 #include "model.h"
@@ -52,6 +56,10 @@ private:
 };
 
 static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, bool offloadToCpu, bool useVulkan) {
+#ifdef SD_JNI_TESTING
+    (void)env; (void)modelPath; (void)offloadToCpu; (void)useVulkan;
+    return nullptr;
+#else
     if (!modelPath) {
         return nullptr;
     }
@@ -125,12 +133,17 @@ static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, b
 
     ALOGI("Created T5-only context for sequential prompt conditioning");
     return handle;
+#endif
 }
 
 // Encoder-only handle for FLUX.2 sequential mode (llmedge Lever 1): loads ONLY the Qwen3 text
 // encoder (no diffusion transformer), so the precompute phase peaks at the encoder size instead of
 // encoder+DiT. Mirrors try_create_t5_only_handle but builds an LLMEmbedder.
 static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bool offloadToCpu, bool useVulkan) {
+#ifdef SD_JNI_TESTING
+    (void)env; (void)llmPath; (void)offloadToCpu; (void)useVulkan;
+    return nullptr;
+#else
     if (!llmPath) {
         return nullptr;
     }
@@ -199,6 +212,7 @@ static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bo
     }
     ALOGI("Created LLM-only (Qwen3) context for sequential FLUX.2 conditioning");
     return handle;
+#endif
 }
 
 void sd_android_log_cb(enum sd_log_level_t level, const char* text, void* data) {
@@ -521,6 +535,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(JNIEnv* e
         free_sd_ctx(handle->ctx);
         handle->ctx = nullptr;
     }
+#ifndef SD_JNI_TESTING
     if (handle->t5_ctx) {
         auto* t5 = static_cast<T5CLIPEmbedder*>(handle->t5_ctx);
         t5->free_params_buffer();
@@ -533,6 +548,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(JNIEnv* e
         delete llm;
         handle->llm_ctx = nullptr;
     }
+#endif
     if (handle->backend) {
         ggml_backend_free(static_cast<ggml_backend_t>(handle->backend));
         handle->backend = nullptr;

--- a/llmedge/src/main/cpp/sdcpp_jni_video.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_video.cpp
@@ -37,12 +37,14 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Vid(
     handle->totalFrames = std::max(1, static_cast<int>(videoFrames));
     handle->currentFrame = 0;
 
-    const char* prompt = jPrompt ? env->GetStringUTFChars(jPrompt, nullptr) : "";
-    const char* negative = jNegative ? env->GetStringUTFChars(jNegative, nullptr) : "";
+    // Standard UTF-8 (not GetStringUTFChars' Modified UTF-8) so emoji and other
+    // supplementary characters reach the native tokenizer as valid bytes.
+    const std::string promptUtf8 = llmedge_jstring_to_utf8(env, jPrompt);
+    const std::string negativeUtf8 = llmedge_jstring_to_utf8(env, jNegative);
+    const char* prompt = promptUtf8.c_str();
+    const char* negative = negativeUtf8.c_str();
 
     auto releaseStrings = [&]() {
-        if (jPrompt) env->ReleaseStringUTFChars(jPrompt, prompt);
-        if (jNegative) env->ReleaseStringUTFChars(jNegative, negative);
     };
 
     sd_sample_params_t sample{};

--- a/llmedge/src/main/cpp/smollm_jni_shared.h
+++ b/llmedge/src/main/cpp/smollm_jni_shared.h
@@ -19,28 +19,29 @@ inline void throwInvalidHandle(JNIEnv* env, const char* owner) {
     throwJavaException(env, "java/lang/IllegalStateException", owner);
 }
 
+// Converts through llmedge_jstring_to_utf8 so user text (prompts, chat
+// messages) reaches native tokenizers as standard UTF-8, not the Modified
+// UTF-8 that GetStringUTFChars produces for supplementary characters.
 class ScopedUtfChars {
   public:
-    ScopedUtfChars(JNIEnv* env, jstring value) : env_(env), value_(value) {
-        chars_ = value_ ? env_->GetStringUTFChars(value_, nullptr) : nullptr;
-    }
-
-    ~ScopedUtfChars() {
-        if (chars_) {
-            env_->ReleaseStringUTFChars(value_, chars_);
+    ScopedUtfChars(JNIEnv* env, jstring value) {
+        if (!value) {
+            return;
         }
+        has_value_ = true;
+        converted_ = llmedge_jstring_to_utf8(env, value, &utf8_);
     }
 
     ScopedUtfChars(const ScopedUtfChars&) = delete;
     ScopedUtfChars& operator=(const ScopedUtfChars&) = delete;
 
-    const char* get() const { return chars_; }
-    bool ok() const { return value_ == nullptr || chars_ != nullptr; }
+    const char* get() const { return has_value_ && converted_ ? utf8_.c_str() : nullptr; }
+    bool ok() const { return !has_value_ || converted_; }
 
   private:
-    JNIEnv* env_;
-    jstring value_;
-    const char* chars_ = nullptr;
+    bool has_value_ = false;
+    bool converted_ = false;
+    std::string utf8_;
 };
 
 inline LLMInference* requireInference(JNIEnv* env, jlong modelPtr, const char* operation) {

--- a/llmedge/src/main/java/io/aatricks/llmedge/core/runtime/RuntimeCoordinator.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/core/runtime/RuntimeCoordinator.kt
@@ -159,7 +159,9 @@ internal class RuntimeCoordinator<TSpec, TOptions, TRuntime : ManagedRuntime>(
                 if (backendCandidate == ComputeBackend.CPU) {
                     throw error
                 }
-                RuntimeLoadPolicy.recordBackendFailureIfNeeded(request, backendCandidate)
+                if (BackendFailureClassifier.isBackendFailure(error)) {
+                    RuntimeLoadPolicy.recordBackendFailureIfNeeded(request, backendCandidate)
+                }
             }
         }
         throw lastError ?: IllegalStateException("Runtime load failed without a reported cause")

--- a/llmedge/src/main/java/io/aatricks/llmedge/core/runtime/RuntimePool.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/core/runtime/RuntimePool.kt
@@ -31,7 +31,7 @@ internal class RuntimeLease<TRuntime : ManagedRuntime>(
 }
 
 internal class RuntimePool<TSpec, TOptions, TRuntime : ManagedRuntime>(
-    private val cache: ModelCache<TRuntime>,
+    internal val cache: ModelCache<TRuntime>,
     private val cacheKeyPrefix: (TSpec, TOptions) -> String,
     private val loadRuntime: suspend (TSpec, TOptions, ComputeBackend) -> TRuntime,
     private val activeBackend: (TRuntime) -> ComputeBackend,
@@ -81,7 +81,7 @@ internal class RuntimePool<TSpec, TOptions, TRuntime : ManagedRuntime>(
         repeat(2) {
             val result = coordinator.acquireDetailed(spec, options)
             val key = RuntimeCacheKeyBuilder.withBackend(result.keyPrefix, result.backend)
-            if (cache.pin(key)) {
+            if (cache.pin(key, result.runtime)) {
                 return RuntimeLease(result.runtime) { cache.unpin(key) }
             }
         }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/internal/StableDiffusionExecutor.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/internal/StableDiffusionExecutor.kt
@@ -122,6 +122,9 @@ internal object StableDiffusionExecutor {
                                     ImageGenerationPhase.JNI_ARGB_ENTER,
                                     "calling native ARGB image generation",
                                 )
+                                if (instance.state.closed.get()) {
+                                    throw IllegalStateException("StableDiffusion is closed")
+                                }
                                 instance.bridge.txt2imgArgb(
                                     instance.state.handle,
                                     params.prompt,
@@ -216,6 +219,9 @@ internal object StableDiffusionExecutor {
                                     ImageGenerationPhase.JNI_RGB_ENTER,
                                     "calling native RGB image generation",
                                 )
+                                if (instance.state.closed.get()) {
+                                    throw IllegalStateException("StableDiffusion is closed")
+                                }
                                 instance.bridge.txt2img(
                                     instance.state.handle,
                                     params.prompt,

--- a/llmedge/src/main/java/io/aatricks/llmedge/runtime/ModelCache.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/runtime/ModelCache.kt
@@ -197,6 +197,19 @@ class ModelCache<T : AutoCloseable>(
         true
     }
 
+    /**
+     * Pin an entry conditional on the exact instance.
+     * @return true if the entry was present, matches expectedModel exactly, and is now pinned
+     */
+    fun pin(key: String, expectedModel: T): Boolean = lock.write {
+        val entry = cache[key] ?: return@write false
+        if (entry.model !== expectedModel) {
+            return@write false
+        }
+        entry.pinCount++
+        true
+    }
+
     /** Release one pin taken with [pin]. Safe to call for absent keys. */
     fun unpin(key: String) {
         lock.write {

--- a/llmedge/src/main/java/io/aatricks/llmedge/vision/VisionRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/vision/VisionRuntimeSupport.kt
@@ -89,37 +89,56 @@ internal fun createVisionRuntimePool(
                         VisionPromptSupport.unsupportedReason(spec.model, spec.projector)
                     }
                     val smol = smolLmFactory(backend == ComputeBackend.VULKAN)
-                    smol.load(
-                        modelPath = modelFile.absolutePath,
-                        params =
-                            SmolLM.InferenceParams(
-                                numThreads = options.promptThreads.coerceAtLeast(1),
-                                generationThreads = options.generationThreads.coerceAtLeast(1),
-                                contextSize = null,
-                                storeChats = false,
-                                temperature = 0.0f,
-                                useFlashAttn = config.vision.useFlashAttention,
-                                thinkingMode = SmolLM.ThinkingMode.DEFAULT,
-                                // Non-causal projectors (Gemma3-family) require the whole
-                                // image chunk in a single micro-batch: llama_decode asserts
-                                // n_ubatch >= n_tokens when causal_attn is off. 1024 covers
-                                // every current projector's per-image token count.
-                                nUbatch = VISION_UBATCH,
-                            ),
-                        preferredBackend = backend,
-                    )
+                    var loadedSmol: SmolLM? = null
+                    var initializedProjector: Projector? = null
+                    try {
+                        smol.load(
+                            modelPath = modelFile.absolutePath,
+                            params =
+                                SmolLM.InferenceParams(
+                                    numThreads = options.promptThreads.coerceAtLeast(1),
+                                    generationThreads = options.generationThreads.coerceAtLeast(1),
+                                    contextSize = null,
+                                    storeChats = false,
+                                    temperature = 0.0f,
+                                    useFlashAttn = config.vision.useFlashAttention,
+                                    thinkingMode = SmolLM.ThinkingMode.DEFAULT,
+                                    // Non-causal projectors (Gemma3-family) require the whole
+                                    // image chunk in a single micro-batch: llama_decode asserts
+                                    // n_ubatch >= n_tokens when causal_attn is off. 1024 covers
+                                    // every current projector's per-image token count.
+                                    nUbatch = VISION_UBATCH,
+                                ),
+                            preferredBackend = backend,
+                        )
+                        loadedSmol = smol
 
-                    val projector = projectorFactory()
-                    projector.init(projectorFile.absolutePath, smol.getNativeModelPointer())
-                    check(projector.isReady()) {
-                        "Native projector initialization failed for ${projectorFile.name}. Ensure the mmproj file matches the selected model and that projector bindings are available."
+                        val projector = projectorFactory()
+                        initializedProjector = projector
+                        projector.init(projectorFile.absolutePath, smol.getNativeModelPointer())
+                        check(projector.isReady()) {
+                            "Native projector initialization failed for ${projectorFile.name}. Ensure the mmproj file matches the selected model and that projector bindings are available."
+                        }
+
+                        val runtime = ManagedVisionRuntime(
+                            fileSizeBytes = modelFile.length() + projectorFile.length(),
+                            smol = smol,
+                            projector = projector,
+                        )
+                        loadedSmol = null
+                        initializedProjector = null
+                        runtime
+                    } catch (t: Throwable) {
+                        try {
+                            initializedProjector?.close()
+                        } catch (e: Exception) {
+                        }
+                        try {
+                            loadedSmol?.close()
+                        } catch (e: Exception) {
+                        }
+                        throw t
                     }
-
-                    ManagedVisionRuntime(
-                        fileSizeBytes = modelFile.length() + projectorFile.length(),
-                        smol = smol,
-                        projector = projector,
-                    )
                 },
                 activeBackend = { it.smol.getActiveBackend() },
                 candidateRequest = {

--- a/llmedge/src/test/cpp/CMakeLists.txt
+++ b/llmedge/src/test/cpp/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(sd_jni_under_test STATIC
     ../../main/cpp/sdcpp_jni.cpp
     ../../main/cpp/sdcpp_jni_load.cpp
     ../../main/cpp/sdcpp_jni_video.cpp
+    ../../main/cpp/jni_thread_cache.cpp
     sd_test_stubs.cpp
 )
 

--- a/llmedge/src/test/cpp/sd_test_stubs.cpp
+++ b/llmedge/src/test/cpp/sd_test_stubs.cpp
@@ -31,7 +31,7 @@ void sd_set_preview_callback(sd_preview_cb_t, enum preview_t, int, bool, bool, v
     // Not used in tests.
 }
 
-int32_t get_num_physical_cores() {
+int32_t sd_get_num_physical_cores() {
     return 4;
 }
 
@@ -119,7 +119,8 @@ sd_image_t* generate_image(sd_ctx_t*, const sd_img_gen_params_t* params) {
     return images;
 }
 
-sd_image_t* generate_video(sd_ctx_t*, const sd_vid_gen_params_t* params, int* num_frames_out) {
+bool generate_video(sd_ctx_t*, const sd_vid_gen_params_t* params,
+                    sd_image_t** frames_out, int* num_frames_out, sd_audio_t** audio_out) {
     const int frames = params->video_frames > 0 ? params->video_frames : 4;
     *num_frames_out = frames;
     auto* images = static_cast<sd_image_t*>(std::malloc(sizeof(sd_image_t) * frames));
@@ -136,10 +137,16 @@ sd_image_t* generate_video(sd_ctx_t*, const sd_vid_gen_params_t* params, int* nu
             }
         }
     }
-    return images;
+    *frames_out = images;
+    if (audio_out) {
+        *audio_out = nullptr;
+    }
+    return true;
 }
 
-upscaler_ctx_t* new_upscaler_ctx(const char*, bool, bool, int, int) { return nullptr; }
+void free_sd_audio(sd_audio_t*) {}
+
+upscaler_ctx_t* new_upscaler_ctx(const char*, bool, bool, int, int, const char*, const char*) { return nullptr; }
 void free_upscaler_ctx(upscaler_ctx_t*) {}
 sd_image_t upscale(upscaler_ctx_t*, sd_image_t input_image, uint32_t) { return input_image; }
 int get_upscale_factor(upscaler_ctx_t*) { return 1; }
@@ -234,15 +241,16 @@ void sd_free_condition(sd_condition_raw_t* cond) {
     free(cond);
 }
 
-sd_image_t* sd_generate_video_with_precomputed_condition(sd_ctx_t* sd_ctx,
-                                                        const sd_vid_gen_params_t* sd_vid_gen_params,
-                                                        const sd_condition_raw_t* cond,
-                                                        const sd_condition_raw_t* uncond,
-                                                        int* num_frames_out) {
+// sd_generate_video_with_precomputed_condition is provided by sdcpp_jni.cpp
+// (compatibility shim) and forwards to the generate_video stub above.
+
+sd_image_t* sd_generate_image_with_precomputed_condition(sd_ctx_t* sd_ctx,
+                                                         const sd_img_gen_params_t* sd_img_gen_params,
+                                                         const sd_condition_raw_t* cond,
+                                                         const sd_condition_raw_t* uncond) {
     (void)cond;
     (void)uncond;
-    // For test purposes: forward to the standard generate_video stub
-    return generate_video(sd_ctx, sd_vid_gen_params, num_frames_out);
+    return generate_image(sd_ctx, sd_img_gen_params);
 }
 
 }  // extern "C"

--- a/llmedge/src/test/cpp/test_video_jni.cpp
+++ b/llmedge/src/test/cpp/test_video_jni.cpp
@@ -1,4 +1,5 @@
 #include "sd_jni_internal.h"
+#include "jni_utils.h"
 
 #include <jni.h>
 
@@ -36,33 +37,28 @@ static void save_frame_as_ppm(const uint8_t* data, int width, int height, int fr
 #endif
 
 extern "C" {
-JNIEXPORT jlong JNICALL Java_io_aatricks_llmedge_StableDiffusion_nativeCreate(
+JNIEXPORT jlong JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     JNIEnv* env, jclass clazz, jstring jModelPath, jstring jVaePath, jstring jT5xxlPath,
-    jint nThreads, jboolean offloadToCpu, jboolean keepClipOnCpu, jboolean keepVaeOnCpu,
-    jboolean flashAttn, jfloat flowShift, jstring jLoraModelDir, jint jLoraApplyMode);
-JNIEXPORT void JNICALL Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(JNIEnv* env, jobject thiz, jlong handlePtr);
-JNIEXPORT jobjectArray JNICALL Java_io_aatricks_llmedge_StableDiffusion_nativeTxt2Vid(
+    jstring jTaesdPath, jstring jDiffusionModelPath, jstring jLlmPath,
+    jint nThreads, jboolean enableOpenCl, jboolean useVulkan, jboolean offloadToCpu,
+    jboolean keepClipOnCpu, jboolean keepVaeOnCpu, jboolean flashAttn, jboolean jvaeDecodeOnly,
+    jfloat flowShift, jstring jLoraModelDir, jint jLoraApplyMode);
+JNIEXPORT void JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(JNIEnv* env, jobject thiz, jlong handlePtr);
+JNIEXPORT jobjectArray JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Vid(
     JNIEnv* env, jobject thiz, jlong handlePtr,
     jstring jPrompt, jstring jNegative,
     jint width, jint height,
     jint videoFrames, jint steps, jfloat cfg, jlong seed,
-    jint jScheduler, jfloat jStrength,
+    jint jSampleMethod, jint jScheduler, jfloat jStrength,
     jbyteArray jInitImage, jint initWidth, jint initHeight,
+    jfloat jVaceStrength,
     jboolean jEasyCacheEnabled, jfloat jEasyCacheReuseThreshold, jfloat jEasyCacheStartPercent, jfloat jEasyCacheEndPercent);
-JNIEXPORT void JNICALL Java_io_aatricks_llmedge_StableDiffusion_nativeSetProgressCallback(
+JNIEXPORT void JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeSetProgressCallback(
         JNIEnv* env, jobject thiz, jlong handlePtr, jobject progressCallback);
-JNIEXPORT jobjectArray JNICALL Java_io_aatricks_llmedge_StableDiffusion_nativeTxt2VidWithPrecomputedCondition(
-        JNIEnv* env, jobject thiz, jlong handlePtr,
-        jstring jPrompt, jstring jNegative,
-        jint width, jint height,
-        jint videoFrames, jint steps, jfloat cfg, jlong seed,
-        jint jScheduler, jfloat jStrength,
-        jbyteArray jInitImage, jint initWidth, jint initHeight,
-        jobjectArray condArr, jobjectArray uncondArr,
-        jboolean jEasyCacheEnabled, jfloat jEasyCacheReuseThreshold, jfloat jEasyCacheStartPercent, jfloat jEasyCacheEndPercent);
-JNIEXPORT void JNICALL Java_io_aatricks_llmedge_StableDiffusion_nativeCancelGeneration(
+JNIEXPORT void JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCancelGeneration(
         JNIEnv* env, jobject thiz, jlong handlePtr);
 }
+
 
 static std::atomic<int> g_frameBufferFrees{0};
 static std::atomic<int> g_frameArrayFrees{0};
@@ -128,9 +124,9 @@ private:
 static bool test_nativeTxt2Vid_memory(JNIEnv* env) {
     reset_free_counters();
     jstring modelPath = env->NewStringUTF("stub-model.gguf");
-        jlong handle = Java_io_aatricks_llmedge_StableDiffusion_nativeCreate(
-            env, nullptr, modelPath, nullptr, nullptr, 4,
-            JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
+        jlong handle = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
+            env, nullptr, modelPath, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
+            JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
             std::numeric_limits<float>::infinity(), nullptr, 0);
     env->DeleteLocalRef(modelPath);
     if (handle == 0) {
@@ -139,10 +135,12 @@ static bool test_nativeTxt2Vid_memory(JNIEnv* env) {
     }
 
     jstring prompt = env->NewStringUTF("a cat playing with yarn");
-        jobjectArray frames = Java_io_aatricks_llmedge_StableDiffusion_nativeTxt2Vid(
+        jobjectArray frames = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Vid(
             env, nullptr, handle, prompt, nullptr,
             256, 256, 4, 12, 7.5f, 42L,
+            0, 0, 0.8f,
             nullptr, 0, 0,
+            0.0f,
             JNI_FALSE, 0.2f, 0.15f, 0.95f);
     env->DeleteLocalRef(prompt);
 
@@ -186,7 +184,7 @@ static bool test_nativeTxt2Vid_memory(JNIEnv* env) {
         }
     }
 
-    Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, handle);
+    Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, handle);
 
     if (g_frameBufferFrees.load() != 4) {
         std::cerr << "Expected 4 frame buffer frees, got " << g_frameBufferFrees.load() << std::endl;
@@ -205,9 +203,9 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     // Step 1: Load T5-only context
     std::cout << "Step 1: Loading T5-only context..." << std::endl;
     jstring t5Path = env->NewStringUTF("stub-t5.gguf");
-        jlong t5Handle = Java_io_aatricks_llmedge_StableDiffusion_nativeCreate(
-            env, nullptr, t5Path, nullptr, nullptr, 4,
-            JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
+        jlong t5Handle = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
+            env, nullptr, t5Path, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
+            JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
             std::numeric_limits<float>::infinity(), nullptr, 0);
     env->DeleteLocalRef(t5Path);
     
@@ -224,15 +222,17 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     
     // Call the precompute function (we'll need to add this to the JNI interface)
     // For now, simulate by calling txt2vid which should internally use precompute
-        jobjectArray frames = Java_io_aatricks_llmedge_StableDiffusion_nativeTxt2Vid(
+        jobjectArray frames = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Vid(
             env, nullptr, t5Handle, prompt, negPrompt,
             256, 256, 13, 12, 7.5f, 42L,
+            0, 0, 0.8f,
             nullptr, 0, 0,
+            0.0f,
             JNI_FALSE, 0.2f, 0.15f, 0.95f);
     
     if (!frames) {
         std::cerr << "Precompute conditions failed" << std::endl;
-        Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, t5Handle);
+        Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, t5Handle);
         env->DeleteLocalRef(prompt);
         env->DeleteLocalRef(negPrompt);
         return false;
@@ -241,16 +241,16 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     
     // Step 3: Free T5 context
     std::cout << "Step 3: Freeing T5 context..." << std::endl;
-    Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, t5Handle);
+    Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, t5Handle);
     std::cout << "T5 context freed" << std::endl;
     
     // Step 4: Load diffusion model
     std::cout << "Step 4: Loading diffusion model..." << std::endl;
     jstring modelPath = env->NewStringUTF("stub-diffusion.safetensors");
     jstring vaePath = env->NewStringUTF("stub-vae.safetensors");
-        jlong diffusionHandle = Java_io_aatricks_llmedge_StableDiffusion_nativeCreate(
-            env, nullptr, modelPath, vaePath, nullptr, 4,
-            JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
+        jlong diffusionHandle = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
+            env, nullptr, modelPath, vaePath, nullptr, nullptr, nullptr, nullptr, 4,
+            JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
             std::numeric_limits<float>::infinity(), nullptr, 0);
     env->DeleteLocalRef(modelPath);
     env->DeleteLocalRef(vaePath);
@@ -267,11 +267,12 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     std::cout << "Step 5: Generating video..." << std::endl;
     // This would use the new nativeTxt2VidWithPrecomputedCondition function
     // For now, test with regular txt2vid
-    frames = Java_io_aatricks_llmedge_StableDiffusion_nativeTxt2Vid(
+    frames = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Vid(
             env, nullptr, diffusionHandle, prompt, negPrompt,
             256, 256, 13, 12, 7.5f, 42L,
-            0, 0.8f, // scheduler and strength
+            0, 0, 0.8f, // sample method, scheduler, strength
             nullptr, 0, 0,
+            0.0f, // vace strength
             JNI_FALSE, 0.2f, 0.15f, 0.95f); // easycache params
     
     env->DeleteLocalRef(prompt);
@@ -279,7 +280,7 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     
     if (!frames) {
         std::cerr << "Video generation failed" << std::endl;
-        Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, diffusionHandle);
+        Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, diffusionHandle);
         return false;
     }
     
@@ -287,14 +288,16 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     std::cout << "Video generation successful! Generated " << frameCount << " frames" << std::endl;
     
     // Cleanup
-    Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, diffusionHandle);
+    Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, diffusionHandle);
     
     return frameCount > 0;
 }
+
+static bool test_progress_callback_bridge(JNIEnv* env) {
     jstring modelPath = env->NewStringUTF("stub-model.gguf");
-        jlong handlePtr = Java_io_aatricks_llmedge_StableDiffusion_nativeCreate(
-            env, nullptr, modelPath, nullptr, nullptr, 2,
-            JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
+        jlong handlePtr = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
+            env, nullptr, modelPath, nullptr, nullptr, nullptr, nullptr, nullptr, 2,
+            JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
             std::numeric_limits<float>::infinity(), nullptr, 0);
     env->DeleteLocalRef(modelPath);
     if (handlePtr == 0) {
@@ -305,18 +308,18 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     jclass callbackClass = env->FindClass("io/aatricks/llmedge/NativeTestProgressCallback");
     if (!callbackClass) {
         std::cerr << "Unable to locate NativeTestProgressCallback" << std::endl;
-        Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
+        Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
         return false;
     }
     jmethodID ctor = env->GetMethodID(callbackClass, "<init>", "()V");
     jobject callbackInstance = env->NewObject(callbackClass, ctor);
     if (!callbackInstance) {
         std::cerr << "Failed to instantiate progress callback" << std::endl;
-        Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
+        Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
         return false;
     }
 
-    Java_io_aatricks_llmedge_StableDiffusion_nativeSetProgressCallback(env, nullptr, handlePtr, callbackInstance);
+    Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeSetProgressCallback(env, nullptr, handlePtr, callbackInstance);
 
     auto* handle = reinterpret_cast<SdHandle*>(handlePtr);
     handle->totalFrames = 4;
@@ -328,7 +331,7 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
         sd_video_progress_wrapper(5, handle->totalSteps, 1.5f, handle);
     } catch (const std::exception& ex) {
         std::cerr << "Progress wrapper threw unexpectedly: " << ex.what() << std::endl;
-        Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
+        Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
         return false;
     }
 
@@ -338,7 +341,7 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     jint reportedFrame = env->GetIntField(callbackInstance, lastFrameField);
     if (callCount == 0 || reportedFrame != 1) {
         std::cerr << "Progress callback did not update fields as expected" << std::endl;
-        Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
+        Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
         return false;
     }
 
@@ -351,13 +354,61 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     }
     if (!cancellationRaised) {
         std::cerr << "Expected cancellation exception" << std::endl;
-        Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
+        Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
         return false;
     }
 
-    Java_io_aatricks_llmedge_StableDiffusion_nativeCancelGeneration(env, nullptr, handlePtr);
-    Java_io_aatricks_llmedge_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
+    Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCancelGeneration(env, nullptr, handlePtr);
+    Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(env, nullptr, handlePtr);
     env->DeleteLocalRef(callbackInstance);
+    return true;
+}
+
+// Verifies llmedge_jstring_to_utf8 produces *standard* UTF-8 for supplementary
+// characters (emoji), where GetStringUTFChars would produce Modified UTF-8
+// (a 6-byte surrogate encoding native tokenizers reject).
+static bool test_jstring_utf8_conversion(JNIEnv* env) {
+    // "hi <U+1F600> <U+00E9>" — U+1F600 needs a surrogate pair in UTF-16.
+    const jchar utf16[] = {'h', 'i', ' ', 0xD83D, 0xDE00, ' ', 0x00E9};
+    jstring value = env->NewString(utf16, sizeof(utf16) / sizeof(jchar));
+    if (!value) {
+        std::cerr << "NewString failed" << std::endl;
+        return false;
+    }
+
+    const std::string expected = "hi \xF0\x9F\x98\x80 \xC3\xA9";  // real UTF-8
+    std::string actual;
+    if (!llmedge_jstring_to_utf8(env, value, &actual)) {
+        std::cerr << "llmedge_jstring_to_utf8 reported failure" << std::endl;
+        env->DeleteLocalRef(value);
+        return false;
+    }
+    if (actual != expected) {
+        std::cerr << "UTF-8 conversion mismatch: got " << actual.size()
+                  << " bytes, expected " << expected.size() << std::endl;
+        env->DeleteLocalRef(value);
+        return false;
+    }
+
+    // Modified UTF-8 from GetStringUTFChars must differ on the emoji —
+    // this documents why the byte path exists.
+    const char* modified = env->GetStringUTFChars(value, nullptr);
+    const bool modifiedDiffers = modified && expected != modified;
+    if (modified) {
+        env->ReleaseStringUTFChars(value, modified);
+    }
+    env->DeleteLocalRef(value);
+    if (!modifiedDiffers) {
+        std::cerr << "Expected GetStringUTFChars to yield Modified UTF-8 (differs from standard)" << std::endl;
+        return false;
+    }
+
+    // Null string converts to empty.
+    std::string fromNull = "sentinel";
+    if (!llmedge_jstring_to_utf8(env, nullptr, &fromNull) || !fromNull.empty()) {
+        std::cerr << "null jstring should convert to empty string" << std::endl;
+        return false;
+    }
     return true;
 }
 
@@ -368,7 +419,8 @@ int main() {
         bool txt2vidResult = test_nativeTxt2Vid_memory(env);
         bool progressResult = test_progress_callback_bridge(env);
         bool progressiveResult = test_progressive_loading_e2e(env);
-        if (!txt2vidResult || !progressResult || !progressiveResult) {
+        bool utf8Result = test_jstring_utf8_conversion(env);
+        if (!txt2vidResult || !progressResult || !progressiveResult || !utf8Result) {
             std::cerr << "video_jni_tests FAILED" << std::endl;
             return 1;
         }

--- a/llmedge/src/test/java/io/aatricks/llmedge/ModelCacheTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/ModelCacheTest.kt
@@ -157,6 +157,27 @@ class ModelCacheTest {
     }
 
     @Test
+    fun `conditional pin matches exact instance`() {
+        val cache = ModelCache<DummyModel>(maxCacheSize = 2, maxMemoryMB = 1024)
+        val first = DummyModel()
+        val replacement = DummyModel()
+
+        cache.put("first", first, 10L)
+
+        // pin with replacement model should fail
+        assertFalse(cache.pin("first", replacement))
+
+        // pin with correct model should succeed
+        assertTrue(cache.pin("first", first))
+
+        // Let's test that replacement cannot be pinned even if we put it afterward without unpinning
+        cache.unpin("first")
+        cache.put("first", replacement, 10L)
+        assertFalse(cache.pin("first", first))
+        assertTrue(cache.pin("first", replacement))
+    }
+
+    @Test
     fun `oversized insert after eviction does not loop forever`() {
         val cache = ModelCache<DummyModel>(maxCacheSize = 1, maxMemoryMB = 4096)
         cache.systemMemoryProvider = { 64L }

--- a/llmedge/src/test/java/io/aatricks/llmedge/StableDiffusionTxt2ImgTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/StableDiffusionTxt2ImgTest.kt
@@ -226,4 +226,102 @@ class StableDiffusionTxt2ImgTest {
 
         org.junit.Assert.assertTrue(sd.state.closed.get())
     }
+
+    @Test
+    fun `txt2img on closed instance throws IllegalStateException and does not call bridge`() = runTest {
+        var bridgeCalled = false
+        StableDiffusion.overrideNativeBridgeForTests { _ ->
+            object : StableDiffusion.NativeBridge {
+                override fun txt2imgArgb(
+                    handle: Long,
+                    prompt: String,
+                    negative: String,
+                    width: Int,
+                    height: Int,
+                    steps: Int,
+                    cfg: Float,
+                    seed: Long,
+                    vaeTiling: Boolean,
+                    easyCacheEnabled: Boolean,
+                    easyCacheReuseThreshold: Float,
+                    easyCacheStartPercent: Float,
+                    easyCacheEndPercent: Float,
+                ): IntArray? {
+                    bridgeCalled = true
+                    return intArrayOf()
+                }
+
+                override fun txt2img(
+                    handle: Long,
+                    prompt: String,
+                    negative: String,
+                    width: Int,
+                    height: Int,
+                    steps: Int,
+                    cfg: Float,
+                    seed: Long,
+                    vaeTiling: Boolean,
+                    easyCacheEnabled: Boolean,
+                    easyCacheReuseThreshold: Float,
+                    easyCacheStartPercent: Float,
+                    easyCacheEndPercent: Float,
+                ): ByteArray? {
+                    bridgeCalled = true
+                    return byteArrayOf()
+                }
+
+                override fun txt2vid(
+                    handle: Long,
+                    prompt: String,
+                    negative: String,
+                    width: Int,
+                    height: Int,
+                    videoFrames: Int,
+                    steps: Int,
+                    cfg: Float,
+                    seed: Long,
+                    sampleMethod: SampleMethod,
+                    scheduler: Scheduler,
+                    strength: Float,
+                    initImage: ByteArray?,
+                    initWidth: Int,
+                    initHeight: Int,
+                    vaceStrength: Float,
+                    easyCacheEnabled: Boolean,
+                    easyCacheReuseThreshold: Float,
+                    easyCacheStartPercent: Float,
+                    easyCacheEndPercent: Float,
+                ): Array<ByteArray>? = null
+
+                override fun setProgressCallback(handle: Long, callback: VideoProgressCallback?) {}
+                override fun cancelGeneration(handle: Long) {}
+                override fun precomputeCondition(
+                    handle: Long,
+                    prompt: String,
+                    negative: String,
+                    width: Int,
+                    height: Int,
+                    clipSkip: Int,
+                ): PrecomputedCondition? = null
+            }
+        }
+
+        val sd = StableDiffusion::class.java.getDeclaredConstructor(Long::class.javaPrimitiveType).apply { isAccessible = true }
+            .newInstance(1L)
+
+        // Close the instance
+        sd.close()
+
+        var threwExpected = false
+        try {
+            sd.txt2img(GenerateParams(prompt = "hi", width = 64, height = 64, steps = 1))
+        } catch (e: IllegalStateException) {
+            if (e.message == "StableDiffusion is closed") {
+                threwExpected = true
+            }
+        }
+
+        assertEquals(true, threwExpected)
+        org.junit.Assert.assertFalse("Bridge txt2img must not be called after close", bridgeCalled)
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/core/runtime/RuntimeCoordinatorTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/core/runtime/RuntimeCoordinatorTest.kt
@@ -101,6 +101,56 @@ class RuntimeCoordinatorTest {
         assertEquals(ComputeBackend.VULKAN, runtime.backend)
     }
 
+    @Test
+    fun `non-backend failure during load falls through and does not blacklist gpu candidate`() = runTest {
+        var loadCalls = 0
+        val attemptedBackends = mutableListOf<ComputeBackend>()
+        val coordinator = createCoordinator { _, _, backend ->
+            loadCalls++
+            attemptedBackends += backend
+            if (backend == ComputeBackend.OPENCL) {
+                throw IllegalStateException("model load failed: file not found")
+            }
+            FakeRuntime(backend)
+        }
+
+        val options = FakeOptions(allowGpu = true, openClAvailable = true)
+        val first = coordinator.acquire("model", options)
+        assertEquals(ComputeBackend.CPU, first.backend)
+        assertEquals(2, loadCalls)
+        assertEquals(listOf(ComputeBackend.OPENCL, ComputeBackend.CPU), attemptedBackends)
+
+        attemptedBackends.clear()
+        val second = coordinator.acquire("model2", options)
+        assertEquals(ComputeBackend.CPU, second.backend)
+        assertEquals(listOf(ComputeBackend.OPENCL, ComputeBackend.CPU), attemptedBackends)
+    }
+
+    @Test
+    fun `backend failure during load falls through and blacklists gpu candidate`() = runTest {
+        var loadCalls = 0
+        val attemptedBackends = mutableListOf<ComputeBackend>()
+        val coordinator = createCoordinator { _, _, backend ->
+            loadCalls++
+            attemptedBackends += backend
+            if (backend == ComputeBackend.OPENCL) {
+                throw IllegalStateException("backend device lost")
+            }
+            FakeRuntime(backend)
+        }
+
+        val options = FakeOptions(allowGpu = true, openClAvailable = true)
+        val first = coordinator.acquire("model", options)
+        assertEquals(ComputeBackend.CPU, first.backend)
+        assertEquals(2, loadCalls)
+        assertEquals(listOf(ComputeBackend.OPENCL, ComputeBackend.CPU), attemptedBackends)
+
+        attemptedBackends.clear()
+        val second = coordinator.acquire("model2", options)
+        assertEquals(ComputeBackend.CPU, second.backend)
+        assertEquals(listOf(ComputeBackend.CPU), attemptedBackends)
+    }
+
     private fun createCoordinator(
         loader: suspend (String, FakeOptions, ComputeBackend) -> FakeRuntime,
     ): RuntimeCoordinator<String, FakeOptions, FakeRuntime> =

--- a/llmedge/src/test/java/io/aatricks/llmedge/core/runtime/RuntimePoolTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/core/runtime/RuntimePoolTest.kt
@@ -115,6 +115,30 @@ class RuntimePoolTest {
         assertEquals(1, closeCalls)
     }
 
+    @Test
+    fun `acquireLeased does not pin a replacement entry with same key when identities differ`() = runTest {
+        val pool = createPool { _, _, backend ->
+            FakeRuntime(backend)
+        }
+
+        val options = FakeOptions(allowGpu = false)
+        val spec = "model"
+
+        val result = pool.coordinator.acquireDetailed(spec, options)
+        val key = RuntimeCacheKeyBuilder.withBackend(result.keyPrefix, result.backend)
+
+        val replacementInstance = FakeRuntime(ComputeBackend.CPU)
+        pool.cache.put(key, replacementInstance, 1L)
+
+        // pin with the old runtime instance must fail because the cache now holds replacementInstance
+        val pinSuccessOld = pool.cache.pin(key, result.runtime)
+        assertFalse("Should not pin when instance differs", pinSuccessOld)
+
+        // pin with matching replacementInstance must succeed
+        val pinSuccessNew = pool.cache.pin(key, replacementInstance)
+        assertTrue("Should pin when instance matches", pinSuccessNew)
+    }
+
     private fun createPool(
         loader: suspend (String, FakeOptions, ComputeBackend) -> FakeRuntime,
     ): RuntimePool<String, FakeOptions, FakeRuntime> =

--- a/llmedge/src/test/java/io/aatricks/llmedge/vision/VisionPipelineTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/vision/VisionPipelineTest.kt
@@ -154,4 +154,59 @@ class VisionPipelineTest {
             projectorFile.delete()
         }
     }
+
+    @Test
+    fun `projector readiness failure closes smol and projector exactly once`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val resolver = mockk<ModelRepository>()
+        val config =
+            LLMEdgeConfig(
+                text = TextRuntimeConfig(useVulkan = false, promptThreads = 4, generationThreads = 2),
+                vision = VisionRuntimeConfig(useVulkan = false, promptThreads = 4, generationThreads = 2),
+            )
+        val smol = mockk<SmolLM>(relaxed = true)
+        val projector = mockk<Projector>(relaxed = true)
+        val model = mockk<ModelSpec>()
+        val projectorSpec = mockk<ModelSpec>()
+        val modelFile = File.createTempFile("llava-fail-model", ".gguf").apply { writeText("model") }
+        val projectorFile = File.createTempFile("llava-fail-projector", ".mmproj.gguf").apply { writeText("projector") }
+        val edgeScope = LLMEdgeScope(this, config.text.promptThreads)
+
+        coEvery { resolver.resolve(context, model) } returns modelFile
+        coEvery { resolver.resolve(context, projectorSpec) } returns projectorFile
+        every { model.cacheKey } returns "fail-model"
+        every { projectorSpec.cacheKey } returns "fail-projector"
+        coEvery { smol.load(any(), any(), any()) } returns Unit
+        every { smol.getNativeModelPointer() } returns 33L
+        every { smol.getActiveBackend() } returns io.aatricks.llmedge.runtime.ComputeBackend.CPU
+        every { projector.isReady() } returns false // Simulate readiness failure
+
+        val pipeline =
+            VisionPipeline(
+                context = context,
+                scope = edgeScope,
+                resolver = resolver,
+                config = config,
+                smolLmFactory = { smol },
+                projectorFactory = { projector },
+            )
+
+        var threwExpected = false
+        try {
+            pipeline.prepare(model = model, projector = projectorSpec, promptThreads = 4, generationThreads = 2)
+        } catch (e: IllegalStateException) {
+            if (e.message?.contains("Native projector initialization failed") == true) {
+                threwExpected = true
+            }
+        } finally {
+            pipeline.close()
+            edgeScope.close()
+            modelFile.delete()
+            projectorFile.delete()
+        }
+
+        assertEquals(true, threwExpected)
+        verify(exactly = 1) { smol.close() }
+        verify(exactly = 1) { projector.close() }
+    }
 }


### PR DESCRIPTION
Fixes:

- RuntimeCoordinator: only classifier-confirmed backend failures blacklist a GPU backend; model/config errors no longer poison OpenCL/Vulkan for the rest of the process.
- jni_thread_cache: move state from an unnamed namespace (one copy per translation unit) into jni_thread_cache.cpp compiled into each shared library, so whisper/sd/bark callbacks initialized in one TU can attach threads from another.
- StableDiffusionExecutor: recheck closed under the generation mutex in both txt2img paths, closing the close()/txt2img use-after-free window.
- VisionRuntimeSupport: close SmolLM and projector when projector init fails instead of leaking them on every backend retry.
- RuntimePool/ModelCache: pin(key, instance) verifies identity so a lease can't pin a replacement runtime while returning the evicted one.
- JNI input text: new llmedge_jstring_to_utf8 converts via UTF-16 to standard UTF-8 (GetStringUTFChars emits Modified UTF-8 that native tokenizers reject for emoji); adopted by ScopedUtfChars, SD prompts, and Bark text.
- test/cpp harness: repair video_jni_tests (JNI package rename, upstream generate_video/new_upscaler_ctx signatures, missing function header) and guard host-unlinkable encoder-only paths behind SD_JNI_TESTING.
- New RuntimeHardeningDeviceGateTest instrumented gate covering real native progress/segment callbacks and emoji prompts.

Verification:
- video_jni_tests green, including a red/green check of the callback fix and UTF-8 emoji conversion against a real JVM.
- :llmedge:testDebugUnitTest 324 tests / 0 failures, plus the E2E-excluded StableDiffusionTxt2ImgTest run explicitly (5/0).
- externalNativeBuildDebug rebuilt sdcpp/whisper/bark for both ABIs.
- S22 (SM-S901B): SD txt2img progress callback fires through real natives; whisper segment+progress callbacks fire and transcript is correct; SmolLM answers an emoji prompt.