### PR TITLE
Fix libomp duplicate abort and make SmolLM stop/cancel actually work

### DIFF
--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/RuntimeHardeningDeviceGateTest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/RuntimeHardeningDeviceGateTest.kt
@@ -10,7 +10,10 @@ import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeTrue
 import org.junit.Test
@@ -103,6 +106,33 @@ class RuntimeHardeningDeviceGateTest {
             // tokenizer received invalid Modified-UTF-8 bytes for it.
             val response = smol.getResponse("Repeat this exactly: hello 😀 world", maxTokens = 48)
             assertTrue("Empty response to emoji prompt", response.isNotBlank())
+        } finally {
+            smol.close()
+        }
+    }
+
+    @Test
+    fun smolLmFlowCancellationAndStopCompletionEndGeneration() = runBlocking {
+        val model = requireFile("llmedge.gate.text_model_path", "/data/local/tmp/smollm135.gguf")
+        val smol = SmolLM()
+        try {
+            smol.load(model.absolutePath, SmolLM.InferenceParams(storeChats = false))
+
+            // Cancelling the flow (take) must end the stream cleanly.
+            val taken = withTimeout(120_000) {
+                smol.getResponseAsFlow("Write a very long story about the sea.").take(5).toList()
+            }
+            assertTrue("take(5) returned ${taken.size} pieces", taken.size == 5)
+
+            // stopCompletion() from the collector must end an in-flight generation.
+            val pieces = mutableListOf<String>()
+            withTimeout(120_000) {
+                smol.getResponseAsFlow("Write another very long story about the sea.").collect {
+                    pieces.add(it)
+                    if (pieces.size == 5) smol.stopCompletion()
+                }
+            }
+            assertTrue("Generation did not stop promptly (got ${pieces.size} pieces)", pieces.size in 5..40)
         } finally {
             smol.close()
         }

--- a/llmedge/src/main/cpp/LLMInference.cpp
+++ b/llmedge/src/main/cpp/LLMInference.cpp
@@ -328,6 +328,7 @@ LLMInference::isContextLimitReached() const {
 
 void
 LLMInference::startCompletion(const char *query) {
+    _stopRequested.store(false, std::memory_order_relaxed);
     if (!_storeChats) {
         for (auto it = _messages.begin(); it != _messages.end();) {
             if (std::strcmp(it->role, "system") != 0) {
@@ -600,6 +601,9 @@ LLMInference::_isValidUtf8(const char *response) {
 
 std::string
 LLMInference::completionLoop() {
+    if (_stopRequested.load(std::memory_order_relaxed)) {
+        _eogReached = true;
+    }
     if (_eogReached) {
         return "[EOG]";
     }
@@ -700,6 +704,7 @@ LLMInference::completionLoopBatch(int maxTokens) {
 
 void
 LLMInference::stopCompletion() {
+    _stopRequested.store(true, std::memory_order_relaxed);
     if (_storeChats) {
         if (!_eogReached && !_response.empty()) {
             // Cancelled mid-generation: the partial reply's tokens are already in

--- a/llmedge/src/main/cpp/LLMInference.h
+++ b/llmedge/src/main/cpp/LLMInference.h
@@ -4,6 +4,7 @@
 #include "chat.h"
 #include "common.h"
 #include "sampling.h"
+#include <atomic>
 #include <string>
 #include <vector>
 #include <functional>
@@ -74,6 +75,11 @@ class LLMInference {
     // subsequent calls to completionLoop() return "[EOG]" immediately
     // instead of attempting another llama_decode with stale batch data.
     bool _eogReached = false;
+
+    // Set by stopCompletion() (possibly from another thread, between native
+    // calls) so the next completionLoop() ends the stream instead of decoding.
+    // Cleared by startCompletion().
+    std::atomic<bool> _stopRequested{false};
 
     // Set when a completion ended because the context window filled up
     // mid-generation (the partial response was still returned to the caller).

--- a/llmedge/src/main/cpp/cmake/llmedge-bark.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-bark.cmake
@@ -81,17 +81,15 @@ target_compile_options(${LLMEDGE_TARGET_BARK_JNI} PUBLIC
         -ffunction-sections
         -fdata-sections
         -O3
-        -fopenmp
         -funroll-loops
 )
 
-target_compile_definitions(${LLMEDGE_TARGET_BARK_JNI} PRIVATE GGML_USE_OPENMP)
-
+# No OpenMP here: see llmedge-whisper.cmake — a second static libomp in the
+# process aborts in libomp's duplicate-runtime check.
 target_link_libraries(${LLMEDGE_TARGET_BARK_JNI}
         android log
-        -fopenmp -static-openmp
 )
 
 target_link_options(${LLMEDGE_TARGET_BARK_JNI} PRIVATE -Wl,--gc-sections -flto -Wl,--exclude-libs,ALL)
 
-message(STATUS "Bark.cpp JNI wrapper configured (direct source build with OpenMP)")
+message(STATUS "Bark.cpp JNI wrapper configured (direct source build)")

--- a/llmedge/src/main/cpp/cmake/llmedge-whisper.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-whisper.cmake
@@ -74,7 +74,6 @@ target_compile_definitions(${LLMEDGE_TARGET_WHISPER_JNI} PRIVATE
         WHISPER_VERSION="1.0.0"
         GGML_VERSION="0.9.4"
         GGML_COMMIT="unknown"
-        GGML_USE_OPENMP
 )
 
 if (${ANDROID_ABI} STREQUAL "arm64-v8a")
@@ -95,17 +94,20 @@ target_include_directories(${LLMEDGE_TARGET_WHISPER_JNI}
 
 target_compile_features(${LLMEDGE_TARGET_WHISPER_JNI} PUBLIC c_std_11 cxx_std_17)
 
-target_compile_options(${LLMEDGE_TARGET_WHISPER_JNI} PUBLIC -fvisibility=hidden -fvisibility-inlines-hidden -ffunction-sections -fdata-sections -O3 -fopenmp)
+target_compile_options(${LLMEDGE_TARGET_WHISPER_JNI} PUBLIC -fvisibility=hidden -fvisibility-inlines-hidden -ffunction-sections -fdata-sections -O3)
 
 if (LLMEDGE_OPENCL_ENABLED)
         llmedge_enable_android_opencl(${LLMEDGE_TARGET_WHISPER_JNI} "${WHISPER_GGML_DIR}")
 endif()
 
+# No OpenMP here: each -static-openmp library embeds its own libomp, and
+# libomp aborts the process when a second copy registers (e.g. whisper loaded
+# after smollm). ggml's internal threadpool is used instead; only the smollm
+# targets keep OpenMP.
 target_link_libraries(${LLMEDGE_TARGET_WHISPER_JNI}
         android log
-        -fopenmp -static-openmp
 )
 
 target_link_options(${LLMEDGE_TARGET_WHISPER_JNI} PRIVATE -Wl,--gc-sections -flto -Wl,--exclude-libs,ALL)
 
-message(STATUS "Whisper.cpp JNI wrapper configured (direct source build with bundled ggml, OpenMP enabled)")
+message(STATUS "Whisper.cpp JNI wrapper configured (direct source build with bundled ggml, ggml threadpool)")

--- a/llmedge/src/main/java/io/aatricks/llmedge/text/runtime/SmolLM.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/text/runtime/SmolLM.kt
@@ -506,7 +506,12 @@ class SmolLM internal constructor(
         batchSize: Int = DEFAULT_BLOCKING_BATCH_SIZE,
     ): String = SmolLMFacadeOperations.getResponse(this, query, maxTokens, batchSize)
 
-    /** Public helper to stop a currently running completion loop (best effort). */
+    /**
+     * Stops a currently running completion: the in-flight [getResponse] or
+     * [getResponseAsFlow] ends at its next step (any partial response is kept as
+     * the assistant turn when chats are stored). Cancelling the collecting
+     * coroutine has the same effect for flows.
+     */
     fun stopCompletion() = SmolLMFacadeOperations.stopCompletion(this)
 
     /**

--- a/llmedge/src/main/java/io/aatricks/llmedge/text/runtime/internal/SmolLMCompletionSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/text/runtime/internal/SmolLMCompletionSupport.kt
@@ -95,28 +95,36 @@ internal object SmolLMCompletionSupport {
     ): Flow<String> =
         flow {
             try {
-                startCompletionLocked(instance, query)
+                // Wrap only the native calls: emit() throws when a downstream
+                // operator cancels the flow (take/first), and a catch around it
+                // would turn normal cancellation into InferenceFailedException.
+                wrapNativeFailure { startCompletionLocked(instance, query) }
                 val stepper = CompletionStepper(instance)
                 val step = batchSize.coerceAtLeast(1)
                 while (true) {
                     currentCoroutineContext().ensureActive()
-                    val piece = stepper.next(step) ?: break
+                    val piece = wrapNativeFailure { stepper.next(step) } ?: break
                     // An empty piece means the native side is buffering an incomplete
                     // UTF-8 sequence; keep looping until it resolves or the stream ends.
                     if (piece.isNotEmpty()) {
                         emit(piece)
                     }
                 }
-            } catch (e: IllegalStateException) {
-                throw InferenceFailedException(
-                    operation = "SmolLM streaming completion",
-                    detail = e.message ?: "The native completion loop failed.",
-                    cause = e,
-                )
             } finally {
                 stopCompletionLocked(instance)
             }
         }.flowOn(dispatcher)
+
+    private inline fun <T> wrapNativeFailure(block: () -> T): T =
+        try {
+            block()
+        } catch (e: IllegalStateException) {
+            throw InferenceFailedException(
+                operation = "SmolLM streaming completion",
+                detail = e.message ?: "The native completion loop failed.",
+                cause = e,
+            )
+        }
 
     fun getResponse(
         instance: SmolLM,

--- a/llmedge/src/test/java/io/aatricks/llmedge/SmolLMInferenceTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/SmolLMInferenceTest.kt
@@ -1,5 +1,6 @@
 package io.aatricks.llmedge
 
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -134,5 +135,84 @@ class SmolLMInferenceTest {
         assertEquals("Hi", bridge.messages[0].second)
         assertEquals("system", bridge.messages[1].first)
         assertEquals("Assistant test", bridge.messages[2].second)
+    }
+
+    /** Bridge that streams tokens forever until stopCompletion is called. */
+    private class EndlessBridge : SmolLM.NativeBridge {
+        var stopCalls = 0
+
+        override fun loadModel(
+            instance: SmolLM,
+            modelPath: String,
+            minP: Float,
+            temperature: Float,
+            storeChats: Boolean,
+            contextSize: Long,
+            chatTemplate: String,
+            nThreads: Int,
+            useMmap: Boolean,
+            useMlock: Boolean,
+            useVulkan: Boolean,
+            useFlashAttn: Boolean,
+            kvCacheTypeK: Int,
+            kvCacheTypeV: Int,
+            nGpuLayers: Int,
+        ): Long = 1L
+
+        override fun setReasoningOptions(instance: SmolLM, modelPtr: Long, disableThinking: Boolean, reasoningBudget: Int) {}
+        override fun addChatMessage(instance: SmolLM, modelPtr: Long, message: String, role: String) {}
+        override fun getResponseGenerationSpeed(instance: SmolLM, modelPtr: Long): Float = 1f
+        override fun getResponseGeneratedTokenCount(instance: SmolLM, modelPtr: Long): Long = 1
+        override fun getResponseGenerationDurationMicros(instance: SmolLM, modelPtr: Long): Long = 1L
+        override fun getContextSizeUsed(instance: SmolLM, modelPtr: Long): Int = 1
+        override fun getNativeModelPtr(instance: SmolLM, modelPtr: Long): Long = 0L
+        override fun nativeDecodePreparedEmbeddings(instance: SmolLM, modelPtr: Long, embdPath: String, metaPath: String, nBatch: Int): Boolean = true
+        override fun close(instance: SmolLM, modelPtr: Long) {}
+        override fun startCompletion(instance: SmolLM, modelPtr: Long, prompt: String) {}
+        override fun completionLoop(instance: SmolLM, modelPtr: Long): String = "tok "
+        override fun completionLoopBatch(instance: SmolLM, modelPtr: Long, maxTokens: Int): String = "tok "
+        override fun stopCompletion(instance: SmolLM, modelPtr: Long) {
+            stopCalls++
+        }
+        override fun clearKvCache(instance: SmolLM, modelPtr: Long) {}
+    }
+
+    @Test
+    fun test_flow_cancellation_via_take_is_not_wrapped_as_failure() = runBlocking {
+        val bridge = EndlessBridge()
+        SmolLM.overrideNativeBridgeForTests { _ -> bridge }
+        val smol = SmolLM.createLoadedForTests(1L, useVulkan = false)
+
+        // take() cancels the flow after 3 emissions; this must terminate the
+        // stream cleanly, not surface as InferenceFailedException.
+        val pieces = smol.getResponseAsFlow("q", kotlinx.coroutines.Dispatchers.Unconfined, 1)
+            .take(3)
+            .toList()
+
+        assertEquals(3, pieces.size)
+        assertEquals(1, bridge.stopCalls)
+    }
+
+    @Test
+    fun test_native_failure_in_completion_loop_is_wrapped() = runBlocking {
+        val bridge = object : SmolLM.NativeBridge by EndlessBridge() {
+            override fun completionLoopBatch(instance: SmolLM, modelPtr: Long, maxTokens: Int): String =
+                throw IllegalStateException("native loop failed")
+            override fun completionLoop(instance: SmolLM, modelPtr: Long): String =
+                throw IllegalStateException("native loop failed")
+        }
+        SmolLM.overrideNativeBridgeForTests { _ -> bridge }
+        val smol = SmolLM.createLoadedForTests(1L, useVulkan = false)
+
+        var thrown: Throwable? = null
+        try {
+            smol.getResponseAsFlow("q", kotlinx.coroutines.Dispatchers.Unconfined, 1).toList()
+        } catch (e: Throwable) {
+            thrown = e
+        }
+        assertEquals(
+            io.aatricks.llmedge.core.InferenceFailedException::class.java,
+            thrown?.javaClass,
+        )
     }
 }


### PR DESCRIPTION
Fixes the two defects surfaced by the device gate in #38.

libomp duplicate abort:
- whisper_jni, bark_jni, and smollm each linked -static-openmp, embedding three copies of libomp; libomp aborts the process when a second copy registers, so loading whisper after smollm (STT after text gen in one app process) crashed with SIGABRT.
- OpenMP is now dropped from whisper and bark (ggml's internal threadpool is used) and kept only in the smollm targets, so a process never holds two runtimes. Whisper transcription of jfk.wav on the S22 measured 5.5s without OpenMP vs 6.8s with it.

SmolLM stop/cancel:
- stopCompletion() only did next-turn bookkeeping; nothing stopped an in-flight generation. LLMInference now has an atomic stop flag set by stopCompletion, cleared by startCompletion, and checked in completionLoop, so the stream ends at the next step.
- Cancelling getResponseAsFlow (take/first or coroutine cancellation) was caught by the catch(IllegalStateException) around the flow body and rethrown as InferenceFailedException. The wrapping is now limited to the native calls so cancellation propagates cleanly.

Verification:
- Unit suite 326 tests / 0 failures; the new cancellation test fails against the previous flow builder and passes with the fix.
- externalNativeBuildDebug green for both ABIs; KMP_DUPLICATE_LIB_OK marker present only in libsmollm.
- Full RuntimeHardeningDeviceGateTest class green on the S22 in a single process (whisper loaded after smollm), including the new flow-cancel/stop test (generation stops within a batch).