### PR TITLE
Add jni_thread_cache.cpp to desktop JNI builds

### DIFF
--- a/scripts/jni-desktop/CMakeLists.txt
+++ b/scripts/jni-desktop/CMakeLists.txt
@@ -59,6 +59,7 @@ if(BUILD_SDCPP)
         ${LLMEDGE_CPP_ROOT}/sdcpp_jni_image.cpp
         ${LLMEDGE_CPP_ROOT}/sdcpp_jni_load.cpp
         ${LLMEDGE_CPP_ROOT}/sdcpp_jni_video.cpp
+        ${LLMEDGE_CPP_ROOT}/jni_thread_cache.cpp
     )
 
     target_include_directories(${LLMEDGE_TARGET_SDCPP} PRIVATE
@@ -191,6 +192,7 @@ if(BUILD_BARK)
 
         add_library(${LLMEDGE_TARGET_BARK_JNI} SHARED
             ${LLMEDGE_CPP_ROOT}/bark_jni.cpp
+            ${LLMEDGE_CPP_ROOT}/jni_thread_cache.cpp
         )
 
         target_include_directories(${LLMEDGE_TARGET_BARK_JNI} PRIVATE
@@ -252,6 +254,7 @@ if(WHISPER_DESKTOP_JNI)
         add_library(${LLMEDGE_TARGET_WHISPER_JNI} SHARED
             ${LLMEDGE_CPP_ROOT}/whisper_jni_common.cpp
             ${LLMEDGE_CPP_ROOT}/whisper_jni.cpp
+            ${LLMEDGE_CPP_ROOT}/jni_thread_cache.cpp
         )
 
         target_include_directories(${LLMEDGE_TARGET_WHISPER_JNI} PRIVATE


### PR DESCRIPTION
The shared JNI thread-attach cache from #38 was wired into the Android cmake files but not scripts/jni-desktop/CMakeLists.txt, so the CI host build of libwhisper_jni.so (and sdcpp/bark) failed at load with an undefined jni_thread_cache_init symbol, breaking WhisperLinuxE2ETest.

Adds the file to the whisper, sdcpp, and bark desktop targets. Verified locally: the host whisper library now exports the symbol and WhisperLinuxE2ETest passes against it (3 ran, 0 failed, 1 audio-file-gated skip).