### PR TITLE
Add CI image-generation gate and repeat-generation device coverage

### DIFF
--- a/.github/scripts/download_models.sh
+++ b/.github/scripts/download_models.sh
@@ -28,3 +28,14 @@ if [ ! -f "SmolLM2-135M-Instruct-Q8_0.gguf" ]; then
 fi
 echo "SmolLM2 model downloaded."
 
+# 3. Image Model: SD-Turbo (~1.3GB) — only if there is comfortable headroom
+if [ "$AVAILABLE_SPACE_KB" -gt $((8 * 1024 * 1024)) ]; then
+    echo "Downloading SD-Turbo model..."
+    if [ ! -f "sd_turbo-f16-q8_0.gguf" ]; then
+        curl -L -o sd_turbo-f16-q8_0.gguf https://huggingface.co/Green-Sky/SD-Turbo-GGUF/resolve/main/sd_turbo-f16-q8_0.gguf
+    fi
+    echo "SD-Turbo model downloaded."
+else
+    echo "Skipping SD-Turbo download (insufficient disk space); image E2E will be skipped."
+fi
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
         ./scripts/run_text_e2e.sh
 
     - name: Run E2E Tests (Image, classic checkpoint)
+      env:
+        # libsdcpp is built with Vulkan, but the runner has no Vulkan driver —
+        # without this, backend registration aborts with vk::IncompatibleDriverError.
+        GGML_DISABLE_VULKAN: "1"
       run: |
         source scripts/native_targets.sh
         export LLMEDGE_TEST_SD_MODEL_PATH="${{ github.workspace }}/models/sd_turbo-f16-q8_0.gguf"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,10 @@ jobs:
         LLMEDGE_TEST_TEXT_MODEL_PATH: ${{ github.workspace }}/models/SmolLM2-135M-Instruct-Q8_0.gguf
       run: |
         ./scripts/run_text_e2e.sh
+
+    - name: Run E2E Tests (Image, classic checkpoint)
+      run: |
+        source scripts/native_targets.sh
+        export LLMEDGE_TEST_SD_MODEL_PATH="${{ github.workspace }}/models/sd_turbo-f16-q8_0.gguf"
+        export LLMEDGE_BUILD_NATIVE_LIB_PATH="${{ github.workspace }}/llmedge/build/native/linux-x86_64/$(llmedge_native_output_name sdcpp)"
+        ./gradlew :llmedge:testDebugUnitTest --tests "*ImageGenerationClassicLinuxE2ETest"

--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/RuntimeHardeningDeviceGateTest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/RuntimeHardeningDeviceGateTest.kt
@@ -54,17 +54,21 @@ class RuntimeHardeningDeviceGateTest {
         val sd = StableDiffusion.load(context = context, modelPath = model.absolutePath)
         sd.use { engine ->
             engine.setProgressCallback { _, _, _, _, _ -> progressCalls.incrementAndGet() }
-            val bitmap = engine.txt2img(
-                GenerateParams(
-                    prompt = "a red apple on a table",
-                    width = 256,
-                    height = 256,
-                    steps = 2,
-                    cfgScale = 1.0f,
-                    seed = 42L,
-                ),
-            )
-            assertTrue("txt2img returned empty bitmap", bitmap.width > 0 && bitmap.height > 0)
+            // Two generations on the same instance: warm sd_ctx reuse crashed on
+            // device before 863491a and was untested for every runtime.
+            repeat(2) { run ->
+                val bitmap = engine.txt2img(
+                    GenerateParams(
+                        prompt = "a red apple on a table",
+                        width = 256,
+                        height = 256,
+                        steps = 2,
+                        cfgScale = 1.0f,
+                        seed = 42L + run,
+                    ),
+                )
+                assertTrue("run $run: txt2img returned empty bitmap", bitmap.width > 0 && bitmap.height > 0)
+            }
         }
         assertTrue(
             "Native progress callback never fired (JNI thread-cache regression)",
@@ -83,10 +87,13 @@ class RuntimeHardeningDeviceGateTest {
         try {
             whisper.setSegmentCallback { _, _, _, _ -> segmentCalls.incrementAndGet() }
             whisper.setProgressCallback { progressCalls.incrementAndGet() }
-            val segments = whisper.transcribe(readWavMono16k(wav))
-            assertTrue("Transcription produced no segments", segments.isNotEmpty())
-            val text = segments.joinToString(" ") { it.text }.lowercase()
-            assertTrue("Unexpected transcript: $text", "country" in text)
+            val samples = readWavMono16k(wav)
+            repeat(2) { run ->
+                val segments = whisper.transcribe(samples)
+                assertTrue("run $run: transcription produced no segments", segments.isNotEmpty())
+                val text = segments.joinToString(" ") { it.text }.lowercase()
+                assertTrue("run $run: unexpected transcript: $text", "country" in text)
+            }
         } finally {
             whisper.close()
         }
@@ -104,8 +111,10 @@ class RuntimeHardeningDeviceGateTest {
             smol.load(model.absolutePath, SmolLM.InferenceParams(storeChats = false))
             // U+1F600 crosses JNI as a surrogate pair; before the UTF-8 fix the
             // tokenizer received invalid Modified-UTF-8 bytes for it.
-            val response = smol.getResponse("Repeat this exactly: hello 😀 world", maxTokens = 48)
-            assertTrue("Empty response to emoji prompt", response.isNotBlank())
+            repeat(2) { run ->
+                val response = smol.getResponse("Repeat this exactly: hello 😀 world", maxTokens = 48)
+                assertTrue("run $run: empty response to emoji prompt", response.isNotBlank())
+            }
         } finally {
             smol.close()
         }
@@ -135,6 +144,21 @@ class RuntimeHardeningDeviceGateTest {
             assertTrue("Generation did not stop promptly (got ${pieces.size} pieces)", pieces.size in 5..40)
         } finally {
             smol.close()
+        }
+    }
+
+    @Test
+    fun barkGeneratesAudioWithGgmlThreadpool() {
+        // Bark lost its OpenMP runtime in the libomp-coexistence fix (#39); this
+        // confirms generation still works on the ggml threadpool.
+        val model = requireFile("llmedge.gate.bark_model_path", "/data/local/tmp/bark_ggml_weights.bin")
+        val bark = io.aatricks.llmedge.speech.tts.BarkTTS.load(modelPath = model.absolutePath, seed = 42)
+        try {
+            val audio = bark.generate("Hello world.")
+            assertTrue("Bark produced no samples", audio.samples.isNotEmpty())
+            assertTrue("Bark produced silent audio", audio.samples.any { it != 0f })
+        } finally {
+            bark.close()
         }
     }
 

--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/RuntimeHardeningDeviceGateTest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/RuntimeHardeningDeviceGateTest.kt
@@ -60,8 +60,8 @@ class RuntimeHardeningDeviceGateTest {
                 val bitmap = engine.txt2img(
                     GenerateParams(
                         prompt = "a red apple on a table",
-                        width = 256,
-                        height = 256,
+                        width = 128,
+                        height = 128,
                         steps = 2,
                         cfgScale = 1.0f,
                         seed = 42L + run,
@@ -150,7 +150,13 @@ class RuntimeHardeningDeviceGateTest {
     @Test
     fun barkGeneratesAudioWithGgmlThreadpool() {
         // Bark lost its OpenMP runtime in the libomp-coexistence fix (#39); this
-        // confirms generation still works on the ggml threadpool.
+        // confirms generation still works on the ggml threadpool. Opt-in only:
+        // bark.cpp needs 20+ minutes for a two-word phrase on a phone CPU, far
+        // too slow for the regular gate.
+        assumeTrue(
+            "Bark gate is opt-in: pass llmedge.gate.run_bark=true (generation takes 20+ min on device)",
+            InstrumentationRegistry.getArguments().getString("llmedge.gate.run_bark") == "true",
+        )
         val model = requireFile("llmedge.gate.bark_model_path", "/data/local/tmp/bark_ggml_weights.bin")
         val bark = io.aatricks.llmedge.speech.tts.BarkTTS.load(modelPath = model.absolutePath, seed = 42)
         try {

--- a/llmedge/src/main/cpp/CMakeLists.txt
+++ b/llmedge/src/main/cpp/CMakeLists.txt
@@ -4,6 +4,7 @@ project("smollm")
 set(LLMEDGE_CPP_ROOT "${CMAKE_CURRENT_LIST_DIR}")
 
 include("${LLMEDGE_CPP_ROOT}/cmake/llmedge-common.cmake")
+include("${LLMEDGE_CPP_ROOT}/cmake/llmedge-openmp.cmake")
 include("${LLMEDGE_CPP_ROOT}/cmake/llmedge-targets.cmake")
 include("${LLMEDGE_CPP_ROOT}/cmake/llmedge-smollm.cmake")
 include("${LLMEDGE_CPP_ROOT}/cmake/llmedge-stable-diffusion.cmake")

--- a/llmedge/src/main/cpp/cmake/llmedge-bark.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-bark.cmake
@@ -84,12 +84,16 @@ target_compile_options(${LLMEDGE_TARGET_BARK_JNI} PUBLIC
         -funroll-loops
 )
 
-# No OpenMP here: see llmedge-whisper.cmake — a second static libomp in the
-# process aborts in libomp's duplicate-runtime check.
+# Bark's bundled ggml threads its graph compute through OpenMP; without it,
+# the fallback creates a disposable threadpool per graph and generation slows
+# ~20x on device. Use the single shared libomp.so (llmedge-openmp.cmake) so
+# there is still only one OpenMP runtime in the process.
+target_compile_definitions(${LLMEDGE_TARGET_BARK_JNI} PRIVATE GGML_USE_OPENMP)
+llmedge_link_shared_openmp(${LLMEDGE_TARGET_BARK_JNI})
 target_link_libraries(${LLMEDGE_TARGET_BARK_JNI}
         android log
 )
 
 target_link_options(${LLMEDGE_TARGET_BARK_JNI} PRIVATE -Wl,--gc-sections -flto -Wl,--exclude-libs,ALL)
 
-message(STATUS "Bark.cpp JNI wrapper configured (direct source build)")
+message(STATUS "Bark.cpp JNI wrapper configured (direct source build, shared OpenMP)")

--- a/llmedge/src/main/cpp/cmake/llmedge-openmp.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-openmp.cmake
@@ -1,0 +1,48 @@
+# Shared OpenMP runtime for Android targets.
+#
+# Multiple libraries in one process must not each embed a static libomp:
+# libomp aborts when a second copy registers (see #39). Instead, targets that
+# need OpenMP link the NDK's shared libomp.so, and one copy is packaged into
+# the AAR by copying it next to the built libraries (AGP picks up everything
+# in CMAKE_LIBRARY_OUTPUT_DIRECTORY).
+
+if(ANDROID)
+    if(ANDROID_ABI STREQUAL "arm64-v8a")
+        set(_LLMEDGE_OMP_ARCH "aarch64")
+    elseif(ANDROID_ABI STREQUAL "x86_64")
+        set(_LLMEDGE_OMP_ARCH "x86_64")
+    elseif(ANDROID_ABI STREQUAL "armeabi-v7a")
+        set(_LLMEDGE_OMP_ARCH "arm")
+    else()
+        set(_LLMEDGE_OMP_ARCH "")
+    endif()
+
+    set(LLMEDGE_SHARED_OMP_LIB "")
+    if(_LLMEDGE_OMP_ARCH)
+        get_filename_component(_LLMEDGE_LLVM_BIN "${CMAKE_C_COMPILER}" DIRECTORY)
+        file(GLOB _LLMEDGE_OMP_CANDIDATES
+            "${_LLMEDGE_LLVM_BIN}/../lib/clang/*/lib/linux/${_LLMEDGE_OMP_ARCH}/libomp.so")
+        if(_LLMEDGE_OMP_CANDIDATES)
+            list(GET _LLMEDGE_OMP_CANDIDATES 0 LLMEDGE_SHARED_OMP_LIB)
+        endif()
+    endif()
+
+    if(LLMEDGE_SHARED_OMP_LIB)
+        file(COPY "${LLMEDGE_SHARED_OMP_LIB}" DESTINATION "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+        message(STATUS "Shared OpenMP runtime packaged from ${LLMEDGE_SHARED_OMP_LIB}")
+    else()
+        message(FATAL_ERROR "NDK shared libomp.so not found for ABI ${ANDROID_ABI}")
+    endif()
+endif()
+
+# Link a target against the shared OpenMP runtime (compile with -fopenmp and
+# resolve libomp.so from the packaged copy at runtime).
+function(llmedge_link_shared_openmp target_name)
+    if(NOT ANDROID)
+        return()
+    endif()
+    target_compile_options(${target_name} PRIVATE -fopenmp)
+    # Link the NDK's own copy (DT_NEEDED records just the libomp.so soname);
+    # the copy in CMAKE_LIBRARY_OUTPUT_DIRECTORY is what ships in the AAR.
+    target_link_libraries(${target_name} "${LLMEDGE_SHARED_OMP_LIB}")
+endfunction()

--- a/llmedge/src/main/cpp/cmake/llmedge-smollm-targets.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-smollm-targets.cmake
@@ -45,14 +45,15 @@ function(build_library target_name)
             -ffunction-sections -fdata-sections
     )
 
-    # Enable OpenMP for multi-threaded ggml matrix operations
+    # Enable OpenMP for multi-threaded ggml matrix operations. Linked against
+    # the single shared libomp.so (llmedge-openmp.cmake) — a second static
+    # copy in the process aborts in libomp's duplicate-runtime check.
     target_compile_definitions(${target_name} PRIVATE GGML_USE_OPENMP)
-    target_compile_options(${target_name} PUBLIC -fopenmp)
+    llmedge_link_shared_openmp(${target_name})
 
     target_link_libraries(
             ${target_name}
             android log dl
-            -fopenmp -static-openmp
             ${LLMEDGE_GGML_EXTRA_LIBS}
     )
 

--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -469,7 +469,12 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     // Split-model components (FLUX.2 Klein etc.). Empty string == not provided.
     p.diffusion_model_path = diffusionModelPathValue.c_str();
     p.llm_path = llmPathValue.c_str();
-    p.free_params_immediately = true;
+    // MUST stay false: free_params_immediately frees each module's weight
+    // buffer after its stage, so a second generate_image on the same handle
+    // reads freed memory (SIGSEGV in the UNet's first conv — this was the
+    // "warm sd_ctx unsafe to reuse" crash, on every backend, not just Vulkan).
+    // llmedge's ModelCache owns weight lifetime via eviction instead.
+    p.free_params_immediately = false;
     p.n_threads = nThreads > 0 ? nThreads : sd_get_num_physical_cores_safe();
     p.offload_params_to_cpu = offloadToCpu;
     p.keep_clip_on_cpu = keepClipOnCpu;

--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -249,7 +249,21 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeGetVulkanDeviceCo
     (void)env;
     (void)clazz;
 #ifdef SD_USE_VULKAN
-    return (jint)ggml_backend_vk_get_device_count();
+    // Probing must never kill the process: honor the registry kill switch and
+    // catch loader failures (a Vulkan loader with no working driver throws
+    // vk::IncompatibleDriverError out of instance creation).
+    if (std::getenv("GGML_DISABLE_VULKAN") != nullptr) {
+        return 0;
+    }
+    try {
+        return (jint)ggml_backend_vk_get_device_count();
+    } catch (const std::exception& e) {
+        ALOGW("Vulkan device probe failed, falling back to 0 devices: %s", e.what());
+        return 0;
+    } catch (...) {
+        ALOGW("Vulkan device probe failed with a non-standard exception; falling back to 0 devices");
+        return 0;
+    }
 #else
     return 0;
 #endif
@@ -260,7 +274,13 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeGetVulkanDeviceMe
     (void)clazz;
 #ifdef SD_USE_VULKAN
     size_t free_mem = 0, total_mem = 0;
-    ggml_backend_vk_get_device_memory((int)deviceIndex, &free_mem, &total_mem);
+    try {
+        ggml_backend_vk_get_device_memory((int)deviceIndex, &free_mem, &total_mem);
+    } catch (const std::exception& e) {
+        ALOGW("Vulkan memory probe failed: %s", e.what());
+        free_mem = 0;
+        total_mem = 0;
+    }
     jlongArray arr = env->NewLongArray(2);
     if (!arr) return nullptr;
     jlong vals[2];
@@ -283,7 +303,11 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeGetVulkanDeviceDe
 #ifdef SD_USE_VULKAN
     char desc[256];
     desc[0] = '\0';
-    ggml_backend_vk_get_device_description((int)deviceIndex, desc, sizeof(desc));
+    try {
+        ggml_backend_vk_get_device_description((int)deviceIndex, desc, sizeof(desc));
+    } catch (const std::exception& e) {
+        ALOGW("Vulkan description probe failed: %s", e.what());
+    }
     if (desc[0] == '\0') {
         return nullptr;
     }

--- a/llmedge/src/test/java/io/aatricks/llmedge/ImageGenerationClassicLinuxE2ETest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/ImageGenerationClassicLinuxE2ETest.kt
@@ -1,0 +1,93 @@
+package io.aatricks.llmedge
+
+import android.content.Context
+import android.graphics.Bitmap
+import io.aatricks.llmedge.image.diffusion.GenerateParams
+import io.aatricks.llmedge.image.diffusion.StableDiffusion
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Host E2E for classic single-file checkpoints (sd-turbo). Unlike
+ * [ImageGenerationLinuxE2ETest] this needs no external T5/VAE files, so it is
+ * cheap enough to run in CI, and it generates TWICE on the same instance:
+ * warm sd_ctx reuse was untested for every runtime until it crashed on device
+ * (see 863491a), so the second generation is the actual regression assertion.
+ *
+ * Requires:
+ *   LLMEDGE_TEST_SD_MODEL_PATH  — classic checkpoint gguf (e.g. sd_turbo-f16-q8_0.gguf)
+ *   LLMEDGE_BUILD_NATIVE_LIB_PATH — host libsdcpp (defaults to the linux build dir)
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ImageGenerationClassicLinuxE2ETest {
+
+    @Test
+    fun `desktop classic checkpoint generates twice on a warm context`() = runBlocking {
+        val modelPath =
+            System.getenv("LLMEDGE_TEST_SD_MODEL_PATH")
+                ?: System.getProperty("LLMEDGE_TEST_SD_MODEL_PATH")
+        Assume.assumeTrue("SD model path not set", !modelPath.isNullOrBlank())
+
+        DesktopNativeTestSupport.requireEnabledAndLoadLibrary(
+            envName = "LLMEDGE_BUILD_NATIVE_LIB_PATH",
+            defaultRelativePath = "llmedge/build/native/linux-x86_64/libsdcpp.so",
+        )
+
+        val width = 128
+        val height = 128
+        val context = org.robolectric.RuntimeEnvironment.getApplication() as Context
+
+        val loadStart = System.currentTimeMillis()
+        val sd =
+            StableDiffusion.load(
+                context = context,
+                modelPath = modelPath,
+                nThreads = Runtime.getRuntime().availableProcessors().coerceAtMost(8),
+                offloadToCpu = true,
+                keepClipOnCpu = true,
+                keepVaeOnCpu = true,
+            )
+        val loadMs = System.currentTimeMillis() - loadStart
+
+        try {
+            repeat(2) { run ->
+                val genStart = System.currentTimeMillis()
+                val bitmap =
+                    sd.txt2img(
+                        GenerateParams(
+                            prompt = "a red apple on a wooden table",
+                            width = width,
+                            height = height,
+                            steps = 2,
+                            cfgScale = 1.0f,
+                            seed = 42L + run,
+                        ),
+                    )
+                val genMs = System.currentTimeMillis() - genStart
+
+                assertEquals(width, bitmap.width)
+                assertEquals(height, bitmap.height)
+                val pixels = IntArray(width * height)
+                bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+                val uniqueColors = pixels.toSet().size
+                assertTrue(
+                    "Run $run: image should not be blank",
+                    pixels.any { (it ushr 24) != 0 && (it and 0x00FFFFFF) != 0 },
+                )
+                assertTrue("Run $run: expected >1 unique color, got $uniqueColors", uniqueColors > 1)
+                println(
+                    "[ImageGenerationClassicLinuxE2ETest] run=$run loadMs=$loadMs genMs=$genMs uniqueColors=$uniqueColors",
+                )
+            }
+        } finally {
+            sd.close()
+        }
+    }
+}


### PR DESCRIPTION
Image and video generation had no automated runtime coverage: CI built libsdcpp but never executed it, and warm-context reuse was untested for every runtime until it crashed on device (fixed in 863491a).

- New ImageGenerationClassicLinuxE2ETest: loads a classic single-file checkpoint (sd-turbo, no external T5/VAE needed), generates twice on the same instance at 128x128/2 steps, and asserts both outputs are non-blank. The second generation is the warm-reuse regression assertion.
- CI downloads sd_turbo-f16-q8_0.gguf (Green-Sky/SD-Turbo-GGUF, ~2GB, skipped when disk headroom is under 8GB) and runs the test against the linux-x86_64 libsdcpp it already builds.
- RuntimeHardeningDeviceGateTest: the SD, whisper, and text tests now generate/transcribe twice per instance, and a new bark test verifies TTS on the ggml threadpool after the OpenMP removal (#39). Device tests are file-gated and unaffected in CI.