### PR TITLE
Remove the per-generation SD runtime eviction workaround

### DIFF
--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/RuntimeHardeningDeviceGateTest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/RuntimeHardeningDeviceGateTest.kt
@@ -51,7 +51,10 @@ class RuntimeHardeningDeviceGateTest {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val progressCalls = AtomicInteger(0)
 
-        val sd = StableDiffusion.load(context = context, modelPath = model.absolutePath)
+        // Pass llmedge.gate.sd_vulkan=true to exercise warm-context reuse on the
+        // Vulkan backend (where the original second-generation crash was seen).
+        val useVulkan = InstrumentationRegistry.getArguments().getString("llmedge.gate.sd_vulkan") == "true"
+        val sd = StableDiffusion.load(context = context, modelPath = model.absolutePath, forceVulkan = useVulkan)
         sd.use { engine ->
             engine.setProgressCallback { _, _, _, _, _ -> progressCalls.incrementAndGet() }
             // Two generations on the same instance: warm sd_ctx reuse crashed on

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageGenerationExecutor.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageGenerationExecutor.kt
@@ -111,7 +111,6 @@ internal class ImageGenerationExecutor(
                 logTag,
                 "Image request entering runtime acquisition: requestId=$requestId size=${params.width}x${params.height} steps=${params.steps}",
             )
-            try {
             requestExecutor.withRuntimeModel(
                 spec = request.spec,
                 options = request.options,
@@ -226,14 +225,6 @@ internal class ImageGenerationExecutor(
                         "Image request active model exit: requestId=$requestId phases=${state.lastImageRequestTrace.size}",
                     )
                 }
-            }
-            } finally {
-                // The sd.cpp context is not safe to reuse for a second generate_image: a warm
-                // cached handle crashes natively on the next txt2img (SIGSEGV, with or without a
-                // LoRA). Evict it after every generation so the next request loads a fresh
-                // context — the warm-from-disk reload is only ~5s.
-                requestExecutor.invalidateRuntime(request.spec, request.options)
-                AndroidLogAdapter.i(logTag, "Image request runtime invalidated after generation: requestId=$requestId")
             }
         }
 

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -894,7 +894,7 @@ class ImageClientTest {
     }
 
     @Test
-    fun `image generation evicts the runtime after each request so the SD context is never reused`() = runTest {
+    fun `image generation reuses the cached runtime across requests`() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val modelFile = java.io.File.createTempFile("cached-image-model", ".gguf", context.filesDir).apply { writeBytes(byteArrayOf(0x01)) }
 
@@ -984,10 +984,10 @@ class ImageClientTest {
                 metrics += requireNotNull(client.getLastGenerationMetrics()?.imageRequestMetrics)
             }
 
-            // The SD context is evicted after every generation (a warm cached sd_ctx crashes
-            // natively on a second txt2img), so each request loads fresh — two loads, and the
-            // second request is a cold miss, not a warm hit.
-            coVerify(exactly = 2) {
+            // Warm reuse: the sd.cpp context keeps its weights now that
+            // free_params_immediately is off, so the second request is a cache
+            // hit with no second load.
+            coVerify(exactly = 1) {
                 StableDiffusion.loadWithRuntimeBackend(
                     any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
                     any(),
@@ -997,8 +997,7 @@ class ImageClientTest {
             assertFalse(metrics.first().cacheHit)
             assertTrue(metrics.first().modelLoadMs > 0L)
             assertTrue(metrics.first().runtimeAcquireMs >= metrics.first().modelLoadMs)
-            assertFalse(metrics.last().cacheHit)
-            assertTrue(metrics.last().modelLoadMs > 0L)
+            assertTrue(metrics.last().cacheHit)
         } finally {
             client.close()
             edgeScope.close()


### PR DESCRIPTION
863491a evicted the diffusion runtime after every generation because a warm sd_ctx crashed on the second txt2img. The root cause was free_params_immediately freeing module weights after each stage (fixed in #42), so the eviction now only costs a ~5s cold reload per request without protecting anything.

- ImageGenerationExecutor no longer invalidates the runtime after each generation; the second request on the same spec is a warm cache hit. The FLUX.2 sequential encoder invalidation is unrelated (peak-memory management) and stays.
- ImageClientTest's eviction test is rewritten to assert warm reuse: one load, second request cacheHit=true. Unit suite 331/0.
- The device gate's SD test accepts llmedge.gate.sd_vulkan=true to run the warm-context double generation on the Vulkan backend (where the original crash was observed).

Verification: unit suite 331/0; CPU warm reuse already covered by the CI image E2E and the S22 device gate (both green on #42). Vulkan warm reuse on the S22 pending — the device dropped off adb; to be run before merge.