### PR TITLE
Fix one-frame Wan generation and add Wan 2.2 Q6 support

### DIFF
--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
@@ -13,6 +13,7 @@ import io.aatricks.llmedge.core.runtime.createCachedRuntimePool
 import io.aatricks.llmedge.core.runtime.runtimePoolProfile
 import io.aatricks.llmedge.image.diffusion.LoraApplyMode
 import io.aatricks.llmedge.image.diffusion.StableDiffusion
+import io.aatricks.llmedge.model.ModelArtifactKind
 import io.aatricks.llmedge.model.ModelRepository
 import io.aatricks.llmedge.model.ModelSpec
 import io.aatricks.llmedge.runtime.ComputeBackend
@@ -120,6 +121,7 @@ internal class DiffusionRuntimeLoader(
                 resolvedTaehv,
             )
         val preferredFlash = options.flashAttn
+        val diffusionModelOnly = spec.model.hints.artifactKind == ModelArtifactKind.DIFFUSION_MODEL
         try {
             return createManagedModel(
                 options = options,
@@ -130,6 +132,7 @@ internal class DiffusionRuntimeLoader(
                 resolvedTaehv = resolvedTaehv,
                 fileSizeBytes = fileSizeBytes,
                 flashAttn = preferredFlash,
+                diffusionModelOnly = diffusionModelOnly,
                 splitDiffusionModel = spec.splitDiffusionModel,
                 encoderOnly = spec.encoderOnly,
             )
@@ -151,6 +154,7 @@ internal class DiffusionRuntimeLoader(
                     resolvedTaehv = resolvedTaehv,
                     fileSizeBytes = fileSizeBytes,
                     flashAttn = false,
+                    diffusionModelOnly = diffusionModelOnly,
                     splitDiffusionModel = spec.splitDiffusionModel,
                 encoderOnly = spec.encoderOnly,
                 )
@@ -170,6 +174,7 @@ internal class DiffusionRuntimeLoader(
         resolvedTaehv: File?,
         fileSizeBytes: Long,
         flashAttn: Boolean,
+        diffusionModelOnly: Boolean,
         splitDiffusionModel: Boolean,
         encoderOnly: Boolean,
     ): ManagedDiffusionModel {
@@ -182,11 +187,11 @@ internal class DiffusionRuntimeLoader(
             StableDiffusion.loadWithRuntimeBackend(
                 context = context,
                 // encoderOnly: load just the Qwen3 encoder via llm_path (no model/diffusion/vae).
-                modelPath = if (splitDiffusionModel || encoderOnly) null else resolvedModel.absolutePath,
+                modelPath = if (splitDiffusionModel || diffusionModelOnly || encoderOnly) null else resolvedModel.absolutePath,
                 vaePath = if (encoderOnly) null else resolvedVae?.absolutePath,
                 t5xxlPath = if (splitDiffusionModel || encoderOnly) null else resolvedTextEncoder?.absolutePath,
                 taesdPath = if (encoderOnly) null else resolvedTaehv?.absolutePath,
-                diffusionModelPath = if (splitDiffusionModel) resolvedModel.absolutePath else null,
+                diffusionModelPath = if (splitDiffusionModel || diffusionModelOnly) resolvedModel.absolutePath else null,
                 llmPath =
                     when {
                         encoderOnly -> resolvedModel.absolutePath

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionTypes.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionTypes.kt
@@ -141,8 +141,8 @@ data class VideoGenerateParams(
     init {
         require(width > 0) { "Width must be positive" }
         require(height > 0) { "Height must be positive" }
-        require(width % 64 == 0) { "Width must be a multiple of 64" }
-        require(height % 64 == 0) { "Height must be a multiple of 64" }
+        require(width % 32 == 0) { "Width must be a multiple of 32" }
+        require(height % 32 == 0) { "Height must be a multiple of 32" }
     }
     /**
      * Calculate the actual number of frames that will be generated. Wan model uses formula:
@@ -152,11 +152,11 @@ data class VideoGenerateParams(
 
     fun validate(): Result<Unit> = runCatching {
         require(prompt.isNotBlank()) { "Prompt cannot be blank" }
-        require(width % 64 == 0 && width in 256..960) {
-            "Width must be a multiple of 64 in range 256..960"
+        require(width % 32 == 0 && width in 256..960) {
+            "Width must be a multiple of 32 in range 256..960"
         }
-        require(height % 64 == 0 && height in 256..960) {
-            "Height must be a multiple of 64 in range 256..960"
+        require(height % 32 == 0 && height in 256..960) {
+            "Height must be a multiple of 32 in range 256..960"
         }
         // Wan model uses formula: actual_frames = (videoFrames-1)/4*4+1
         // So 1-4 -> 1 frame, 5-8 -> 5 frames, 9-12 -> 9 frames, etc.

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionTypes.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionTypes.kt
@@ -160,8 +160,8 @@ data class VideoGenerateParams(
         }
         // Wan model uses formula: actual_frames = (videoFrames-1)/4*4+1
         // So 1-4 -> 1 frame, 5-8 -> 5 frames, 9-12 -> 9 frames, etc.
-        require(videoFrames in 4..64) {
-            "Frame count must be between 5 and 64. Note: Wan model rounds to (n-1)/4*4+1, so use 5+ for multiple frames"
+        require(videoFrames in 1..64) {
+            "Frame count must be between 1 and 64. Note: Wan model rounds to (n-1)/4*4+1, so use 5+ for multiple frames"
         }
         require(steps in 1..50) { "Steps must be between 1 and 50" }
         require(cfgScale in 1.0f..15.0f) { "CFG scale must be between 1.0 and 15.0" }

--- a/llmedge/src/test/java/io/aatricks/llmedge/VideoGenerateParamsTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/VideoGenerateParamsTest.kt
@@ -2,6 +2,7 @@ package io.aatricks.llmedge
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import io.aatricks.llmedge.image.diffusion.Scheduler
@@ -25,6 +26,17 @@ class VideoGenerateParamsTest {
     }
 
     @Test
+    fun `Wan documented 480x832 resolution passes validation`() {
+        val params = VideoGenerateParams(
+            prompt = "a cat",
+            width = 480,
+            height = 832,
+        )
+
+        assertTrue(params.validate().isSuccess)
+    }
+
+    @Test
     fun `blank prompt fails validation`() {
         val params = VideoGenerateParams(prompt = " ")
 
@@ -32,13 +44,15 @@ class VideoGenerateParamsTest {
     }
 
     @Test
-    fun `width must be multiple of 64`() {
-        val params = VideoGenerateParams(
-            prompt = "valid",
-            width = 510,
-        )
+    fun `width must be multiple of 32`() {
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            VideoGenerateParams(
+                prompt = "valid",
+                width = 510,
+            )
+        }
 
-        assertValidationFails(params, "Width must be a multiple of 64")
+        assertEquals("Width must be a multiple of 32", failure.message)
     }
 
     @Test
@@ -48,7 +62,7 @@ class VideoGenerateParamsTest {
             height = 128,
         )
 
-        assertValidationFails(params, "Height must be a multiple of 64")
+        assertValidationFails(params, "Height must be a multiple of 32")
     }
 
     @Test
@@ -153,7 +167,7 @@ class VideoGenerateParamsTest {
             height = 960,
         )
 
-        assertValidationFails(params, "Width must be a multiple of 64 in range 256..960")
+        assertValidationFails(params, "Width must be a multiple of 32 in range 256..960")
     }
 
     @Test
@@ -204,7 +218,7 @@ class VideoGenerateParamsTest {
             width = 192,
         )
 
-        assertValidationFails(params, "Width must be a multiple of 64 in range 256..960")
+        assertValidationFails(params, "Width must be a multiple of 32 in range 256..960")
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/VideoGenerateParamsTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/VideoGenerateParamsTest.kt
@@ -52,13 +52,16 @@ class VideoGenerateParamsTest {
     }
 
     @Test
-    fun `frame count must be between 4 and 64`() {
-        val params = VideoGenerateParams(
-            prompt = "valid",
-            videoFrames = 2,
-        )
+    fun `one through four requested frames produce one valid frame`() {
+        for (requestedFrames in 1..4) {
+            val params = VideoGenerateParams(
+                prompt = "valid",
+                videoFrames = requestedFrames,
+            )
 
-        assertValidationFails(params, "Frame count must be between 5 and 64")
+            assertTrue("$requestedFrames requested frames should be valid", params.validate().isSuccess)
+            assertEquals(1, params.actualFrameCount())
+        }
     }
 
     @Test
@@ -68,7 +71,7 @@ class VideoGenerateParamsTest {
             videoFrames = 0,
         )
 
-        assertValidationFails(params, "Frame count must be between 5 and 64")
+        assertValidationFails(params, "Frame count must be between 1 and 64")
     }
 
     @Test
@@ -170,7 +173,7 @@ class VideoGenerateParamsTest {
             videoFrames = 65,
         )
 
-        assertValidationFails(params, "Frame count must be between 5 and 64")
+        assertValidationFails(params, "Frame count must be between 1 and 64")
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -14,12 +14,16 @@ import io.aatricks.llmedge.image.diffusion.VideoModelMetadata
 import io.aatricks.llmedge.image.diffusion.VideoProgressCallback
 import io.aatricks.llmedge.core.LLMEdgeScope
 import io.aatricks.llmedge.model.DefaultModelRepository
+import io.aatricks.llmedge.model.ModelArtifactKind
+import io.aatricks.llmedge.model.ModelHints
 import io.aatricks.llmedge.model.ModelSpec
 import io.aatricks.llmedge.runtime.ComputeBackend
+import io.aatricks.llmedge.runtime.ComputeSubsystem
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
 import java.lang.Thread.sleep
 import kotlinx.coroutines.flow.collect
@@ -61,6 +65,58 @@ class ImageClientTest {
         } catch (_: Throwable) {
         }
         clearAllMocks()
+    }
+
+    @Test
+    fun `video diffusion artifact routes to native diffusion model path`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val modelFile =
+            java.io.File.createTempFile("wan22", ".gguf", context.filesDir).apply {
+                writeBytes(byteArrayOf(0x01))
+            }
+        val model =
+            ModelSpec.localFile(
+                modelFile,
+                ModelHints(artifactKind = ModelArtifactKind.DIFFUSION_MODEL),
+            )
+        var observedModelPath: String? = "unset"
+        var observedDiffusionModelPath: String? = "unset"
+        coEvery {
+            StableDiffusion.loadWithRuntimeBackend(
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+            )
+        } coAnswers {
+            observedModelPath = it.invocation.args[3] as String?
+            observedDiffusionModelPath = it.invocation.args[21] as String?
+            mockk(relaxed = true)
+        }
+
+        val loaded =
+            DiffusionRuntimeLoader(context, DefaultModelRepository()).load(
+                spec = DiffusionRuntimeSpec(role = DiffusionRuntimeRole.VIDEO, model = model),
+                options =
+                    DiffusionLoadOptions(
+                        subsystem = ComputeSubsystem.VIDEO,
+                        allowGpu = false,
+                        nThreads = 1,
+                        offloadToCpu = true,
+                        keepClipOnCpu = true,
+                        keepVaeOnCpu = true,
+                        flashAttn = true,
+                        preferPerformanceMode = false,
+                    ),
+                backend = ComputeBackend.CPU,
+            )
+        try {
+            assertEquals(null, observedModelPath)
+            assertEquals(modelFile.absolutePath, observedDiffusionModelPath)
+        } finally {
+            loaded.close()
+        }
     }
 
     @Test


### PR DESCRIPTION
Allows Wan video requests to return one frame, routes diffusion-only video models to the correct native input, and accepts Wan’s documented 480x832 resolution. The previous frame minimum and multiple-of-64 guard blocked valid Wan requests.

Checked with the SDK unit suite and a local Kotlin-to-JNI-to-C++ Wan 2.2 Q6 generation.