### PR TITLE
Add MiniT2I image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,19 @@ imageView.setImageBitmap(bitmap)
 
 For explicit runtime ownership or custom native-load experiments, the `StableDiffusion` class remains available in the expert API layer.
 
+#### MiniT2I
+
+The `MiniT2I` helper downloads the standalone MiniT2I B/16 diffusion transformer and its FLAN-T5 Large text encoder, then routes them to stable-diffusion.cpp's split diffusion and T5 model slots:
+
+```kotlin
+val edge = LLMEdge.create(context, viewModelScope)
+val bitmap = edge.image.generate(
+    MiniT2I.imageRequest("a small robot watering flowers"),
+)
+```
+
+The helper defaults to the model's 512×512, 100-step, CFG 6 configuration. Width, height, steps, CFG, seed, and flash attention remain configurable through `MiniT2I.imageRequest(...)`.
+
 #### FLUX.2 Klein 4B (distilled DiT, split model)
 
 [FLUX.2 Klein 4B](https://huggingface.co/black-forest-labs/FLUX.2-klein-4B) is a step-distilled diffusion transformer that produces high-quality images in ~4 steps. It is the same architecture PrismML's binary/ternary **Bonsai Image** models are built on — Bonsai's own 1-bit/ternary weights ship only in MLX (Apple) and GemLite (CUDA) packings, which don't load on Android, so this GGUF build is the Android-runnable equivalent at a comparable footprint.

--- a/llmedge/src/main/cpp/cmake/llmedge-stable-diffusion.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-stable-diffusion.cmake
@@ -133,8 +133,10 @@ elseif (LLMEDGE_SDCPP_USE_MODS OR (DEFINED ENV{LLMEDGE_SDCPP_USE_MODS} AND "$ENV
         set(SD_DIR "${PATCHED_SD_ROOT}")
 endif()
 
-if (NOT EXISTS "${SD_DIR}/wan.hpp" AND NOT EXISTS "${SD_DIR}/src/wan.hpp")
-        message(FATAL_ERROR "stable-diffusion.cpp Wan headers not found at ${SD_DIR} (expected wan.hpp or src/wan.hpp). Run git submodule update --init --recursive (or disable overlays).")
+if (NOT EXISTS "${SD_DIR}/wan.hpp" AND
+    NOT EXISTS "${SD_DIR}/src/wan.hpp" AND
+    NOT EXISTS "${SD_DIR}/src/model/diffusion/wan.hpp")
+        message(FATAL_ERROR "stable-diffusion.cpp Wan headers not found at ${SD_DIR}. Run git submodule update --init --recursive (or disable overlays).")
 endif()
 
 option(WAN_SUPPORT "Enable Wan video generation support" ON)
@@ -164,6 +166,24 @@ set(SD_MUSA OFF CACHE BOOL "sd: musa backend" FORCE)
 set(GGML_OPENCL_EMBED_KERNELS ON CACHE BOOL "ggml: embed OpenCL kernels" FORCE)
 set(GGML_OPENCL_USE_ADRENO_KERNELS ON CACHE BOOL "ggml: use optimized kernels for Adreno" FORCE)
 set(GGML_OPENCL_TARGET_VERSION 300 CACHE STRING "ggml: target OpenCL version" FORCE)
+
+if (CMAKE_HOST_APPLE AND NOT DEFINED SPIRV-Headers_DIR)
+        find_program(_LLMEDGE_BREW_EXECUTABLE brew NO_CMAKE_FIND_ROOT_PATH)
+        if (_LLMEDGE_BREW_EXECUTABLE)
+                execute_process(
+                        COMMAND "${_LLMEDGE_BREW_EXECUTABLE}" --prefix spirv-headers
+                        OUTPUT_VARIABLE _LLMEDGE_SPIRV_HEADERS_PREFIX
+                        OUTPUT_STRIP_TRAILING_WHITESPACE
+                        RESULT_VARIABLE _LLMEDGE_SPIRV_HEADERS_RESULT
+                )
+                if (_LLMEDGE_SPIRV_HEADERS_RESULT EQUAL 0 AND
+                    EXISTS "${_LLMEDGE_SPIRV_HEADERS_PREFIX}/share/cmake/SPIRV-Headers/SPIRV-HeadersConfig.cmake")
+                        set(SPIRV-Headers_DIR
+                                "${_LLMEDGE_SPIRV_HEADERS_PREFIX}/share/cmake/SPIRV-Headers"
+                                CACHE PATH "Host SPIR-V headers package" FORCE)
+                endif()
+        endif()
+endif()
 
 # Ensure ggml-vulkan's ExternalProject (vulkan-shaders-gen) can find the correct build tool.
 if (CMAKE_MAKE_PROGRAM)

--- a/llmedge/src/main/cpp/sd_jni_internal.h
+++ b/llmedge/src/main/cpp/sd_jni_internal.h
@@ -2,9 +2,10 @@
 
 #include <jni.h>
 #include <atomic>
+#include <memory>
 #include <string>
 #include <vector>
-#include "model.h"
+#include "model_manager.h"
 
 struct sd_ctx_t;
 
@@ -13,7 +14,8 @@ struct SdHandle {
     void* t5_ctx = nullptr; // Pointer to T5CLIPEmbedder for T5-only mode
     void* llm_ctx = nullptr; // Pointer to LLMEmbedder for Qwen3-only mode (FLUX.2 sequential)
     void* backend = nullptr; // Pointer to ggml_backend_t for encoder-only handles
-    std::vector<MmapTensorStore> mmap_stores;
+    void* params_backend = nullptr; // Optional separate CPU params backend for encoder-only handles
+    std::shared_ptr<ModelManager> model_manager;
     float flowShift = 0.0f;
     std::string loraModelDir;
     int last_width = 0;

--- a/llmedge/src/main/cpp/sdcpp_jni_condition.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_condition.cpp
@@ -12,7 +12,15 @@
 // conditioner.hpp drags in the full header-only sd.cpp model graph code, which the
 // host-native test harness cannot link (it stubs libstable-diffusion instead).
 #ifndef SD_JNI_TESTING
-#include "conditioner.hpp"
+#include "conditioning/conditioner.hpp"
+
+struct ConditionerRunnerDoneOnExit {
+    Conditioner* conditioner;
+
+    ~ConditionerRunnerDoneOnExit() {
+        conditioner->runner_done();
+    }
+};
 #endif
 #include "ggml-backend.h"
 #include "model.h"
@@ -136,6 +144,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativePrecomputeConditi
 #ifndef SD_JNI_TESTING
         else if (handle->t5_ctx) {
             auto* t5 = static_cast<T5CLIPEmbedder*>(handle->t5_ctx);
+            ConditionerRunnerDoneOnExit runnerDone{t5};
             try {
                 ConditionerParams cparams;
                 cparams.text = resolved.prompt.c_str();
@@ -179,6 +188,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativePrecomputeConditi
         } else if (handle->llm_ctx) {
             // FLUX.2 sequential mode: encoder-only (Qwen3) handle precomputes the conditioning.
             auto* llm = static_cast<LLMEmbedder*>(handle->llm_ctx);
+            ConditionerRunnerDoneOnExit runnerDone{llm};
             try {
                 ConditionerParams cparams;
                 cparams.text      = resolved.prompt.c_str();

--- a/llmedge/src/main/cpp/sdcpp_jni_image.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_image.cpp
@@ -60,10 +60,12 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Img(
                            static_cast<float>(jEasyCacheEndPercent));
 
     sd_image_t* out = nullptr;
+    int numImages = 0;
+    bool generated = false;
     const auto t0 = std::chrono::steady_clock::now();
     ALOGI("nativeTxt2Img: generate_image start width=%d height=%d steps=%d promptChars=%zu loraCount=%u", width, height, steps, resolved.prompt.size(), gen.lora_count);
     try {
-        out = generate_image(handle->ctx, &gen);
+        generated = generate_image(handle->ctx, &gen, &out, &numImages);
     } catch (const std::exception& e) {
         const char* clazz = handle->cancellationRequested.load()
                 ? "java/util/concurrent/CancellationException"
@@ -72,9 +74,9 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Img(
         return nullptr;
     }
 
-    if (!out || !out[0].data) {
+    if (!generated || numImages < 1 || !out || !out[0].data) {
         ALOGE("generate_image failed");
-        if (out) free(out);
+        if (out) free_sd_images(out, numImages);
         return nullptr;
     }
 
@@ -86,14 +88,12 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Img(
     const size_t byteCount = static_cast<size_t>(out[0].width) * out[0].height * out[0].channel;
     jbyteArray jbytes = env->NewByteArray(static_cast<jsize>(byteCount));
     if (!jbytes) {
-        free(out[0].data);
-        free(out);
+        free_sd_images(out, numImages);
         return nullptr;
     }
     env->SetByteArrayRegion(jbytes, 0, static_cast<jsize>(byteCount), reinterpret_cast<jbyte*>(out[0].data));
 
-    free(out[0].data);
-    free(out);
+    free_sd_images(out, numImages);
 
     handle->cancellationRequested.store(false);
     return jbytes;
@@ -153,10 +153,12 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2ImgArgb(
                            static_cast<float>(jEasyCacheEndPercent));
 
     sd_image_t* out = nullptr;
+    int numImages = 0;
+    bool generated = false;
     const auto t0 = std::chrono::steady_clock::now();
     ALOGI("nativeTxt2ImgArgb: generate_image start width=%d height=%d steps=%d promptChars=%zu loraCount=%u", width, height, steps, resolved.prompt.size(), gen.lora_count);
     try {
-        out = generate_image(handle->ctx, &gen);
+        generated = generate_image(handle->ctx, &gen, &out, &numImages);
     } catch (const std::exception& e) {
         const char* clazz = handle->cancellationRequested.load()
                 ? "java/util/concurrent/CancellationException"
@@ -165,9 +167,9 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2ImgArgb(
         return nullptr;
     }
 
-    if (!out || !out[0].data) {
+    if (!generated || numImages < 1 || !out || !out[0].data) {
         ALOGE("generate_image failed");
-        if (out) free(out);
+        if (out) free_sd_images(out, numImages);
         return nullptr;
     }
 
@@ -178,8 +180,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2ImgArgb(
 
     jintArray result = rgb_to_argb_int_array(env, out[0].data, out[0].width, out[0].height, out[0].channel);
 
-    free(out[0].data);
-    free(out);
+    free_sd_images(out, numImages);
 
     handle->cancellationRequested.store(false);
     return result;

--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -20,9 +20,9 @@
 // conditioner.hpp drags in the full header-only sd.cpp model graph code, which the
 // host-native test harness cannot link (it stubs libstable-diffusion instead).
 #ifndef SD_JNI_TESTING
-#include "conditioner.hpp"
+#include "conditioning/conditioner.hpp"
 #endif
-#include "ggml_extend_backend.h"
+#include "core/ggml_extend_backend.h"
 #include "ggml-backend.h"
 #include "model.h"
 
@@ -66,12 +66,16 @@ static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, b
 
     ALOGI("Attempting T5-only context load for sequential prompt conditioning: %s", modelPath);
 
-    ModelLoader model_loader;
+    auto model_manager = std::make_shared<ModelManager>();
+    model_manager->set_n_threads(sd_get_num_physical_cores_safe());
+    model_manager->set_enable_mmap(true);
+    ModelLoader& model_loader = model_manager->loader();
     if (!model_loader.init_from_file(modelPath, "text_encoders.t5xxl.transformer.")) {
         ALOGE("Failed to initialize ModelLoader for T5-only context: %s", modelPath);
         return nullptr;
     }
     model_loader.convert_tensors_name();
+    model_loader.process_model_files(true, false);
 
     ggml_backend_t backend = nullptr;
 #ifdef SD_USE_VULKAN
@@ -93,30 +97,22 @@ static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, b
     ggml_backend_t params_backend = offloadToCpu ? sd_backend_cpu_init() : backend;
     auto* t5 = new T5CLIPEmbedder(
         backend,
-        params_backend,
-        model_loader.get_tensor_storage_map(),
-        offloadToCpu,
+        model_manager->loader().get_tensor_storage_map(),
+        false,
         0,
-        is_umt5);
-    std::map<std::string, struct ggml_tensor*> tensors;
-    t5->get_param_tensors(tensors);
-
-    std::vector<MmapTensorStore> mmap_stores = model_loader.mmap_tensors(tensors, {}, false);
-    bool load_ok = true;
-    if (mmap_stores.empty()) {
-        ALOGW("mmap failed or disabled for T5, falling back to loading into allocated memory buffer");
-        t5->alloc_params_buffer();
-        std::set<std::string> ignore_tensors;
-        load_ok = model_loader.load_tensors(tensors, ignore_tensors, sd_get_num_physical_cores_safe(), false);
-    } else {
-        ALOGI("Successfully memory-mapped T5 tensors directly (skipped separate buffer allocation)");
-        t5->alloc_params_buffer();
-    }
-
-    if (!load_ok) {
-        ALOGE("Failed to load tensors for T5 context");
-        t5->free_params_buffer();
+        is_umt5,
+        model_manager);
+    if (!model_manager->register_runner_params(
+            "T5 encoder",
+            *t5,
+            ModelManager::ResidencyMode::ParamBackend,
+            backend,
+            params_backend) ||
+        !model_manager->validate_registered_tensors()) {
+        ALOGE("Failed to register tensors for T5 context");
         delete t5;
+        model_manager.reset();
+        if (params_backend != backend) ggml_backend_free(params_backend);
         ggml_backend_free(backend);
         return nullptr;
     }
@@ -125,7 +121,8 @@ static SdHandle* try_create_t5_only_handle(JNIEnv* env, const char* modelPath, b
     handle->ctx = nullptr;
     handle->t5_ctx = t5;
     handle->backend = backend;
-    handle->mmap_stores = std::move(mmap_stores);
+    handle->params_backend = params_backend == backend ? nullptr : params_backend;
+    handle->model_manager = std::move(model_manager);
     if (env) {
         env->GetJavaVM(&handle->jvm);
         jni_thread_cache_init(handle->jvm);
@@ -149,12 +146,16 @@ static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bo
     }
     ALOGI("Attempting LLM-only (Qwen3) context load for sequential FLUX.2 conditioning: %s", llmPath);
 
-    ModelLoader model_loader;
+    auto model_manager = std::make_shared<ModelManager>();
+    model_manager->set_n_threads(sd_get_num_physical_cores_safe());
+    model_manager->set_enable_mmap(true);
+    ModelLoader& model_loader = model_manager->loader();
     if (!model_loader.init_from_file(llmPath, "text_encoders.llm.")) {
         ALOGE("Failed to initialize ModelLoader for LLM-only context: %s", llmPath);
         return nullptr;
     }
     model_loader.convert_tensors_name();
+    model_loader.process_model_files(true, false);
 
     ggml_backend_t backend = nullptr;
 #ifdef SD_USE_VULKAN
@@ -175,28 +176,22 @@ static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bo
     ggml_backend_t params_backend = offloadToCpu ? sd_backend_cpu_init() : backend;
     auto* llm = new LLMEmbedder(
         backend,
-        params_backend,
-        model_loader.get_tensor_storage_map(),
-        VERSION_FLUX2_KLEIN);
-    std::map<std::string, struct ggml_tensor*> tensors;
-    llm->get_param_tensors(tensors);
-
-    std::vector<MmapTensorStore> mmap_stores = model_loader.mmap_tensors(tensors, {}, false);
-    bool load_ok = true;
-    if (mmap_stores.empty()) {
-        ALOGW("mmap failed or disabled for LLM, falling back to loading into allocated memory buffer");
-        llm->alloc_params_buffer();
-        std::set<std::string> ignore_tensors;
-        load_ok = model_loader.load_tensors(tensors, ignore_tensors, sd_get_num_physical_cores_safe(), false);
-    } else {
-        ALOGI("Successfully memory-mapped LLM tensors directly (skipped separate buffer allocation)");
-        llm->alloc_params_buffer();
-    }
-
-    if (!load_ok) {
-        ALOGE("Failed to load tensors for LLM context");
-        llm->free_params_buffer();
+        model_manager->loader().get_tensor_storage_map(),
+        VERSION_FLUX2_KLEIN,
+        "",
+        false,
+        model_manager);
+    if (!model_manager->register_runner_params(
+            "LLM encoder",
+            *llm,
+            ModelManager::ResidencyMode::ParamBackend,
+            backend,
+            params_backend) ||
+        !model_manager->validate_registered_tensors()) {
+        ALOGE("Failed to register tensors for LLM context");
         delete llm;
+        model_manager.reset();
+        if (params_backend != backend) ggml_backend_free(params_backend);
         ggml_backend_free(backend);
         return nullptr;
     }
@@ -205,7 +200,8 @@ static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bo
     handle->ctx     = nullptr;
     handle->llm_ctx = llm;
     handle->backend = backend;
-    handle->mmap_stores = std::move(mmap_stores);
+    handle->params_backend = params_backend == backend ? nullptr : params_backend;
+    handle->model_manager = std::move(model_manager);
     if (env) {
         env->GetJavaVM(&handle->jvm);
         jni_thread_cache_init(handle->jvm);
@@ -469,19 +465,19 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     // Split-model components (FLUX.2 Klein etc.). Empty string == not provided.
     p.diffusion_model_path = diffusionModelPathValue.c_str();
     p.llm_path = llmPathValue.c_str();
-    // MUST stay false: free_params_immediately frees each module's weight
-    // buffer after its stage, so a second generate_image on the same handle
-    // reads freed memory (SIGSEGV in the UNet's first conv — this was the
-    // "warm sd_ctx unsafe to reuse" crash, on every backend, not just Vulkan).
-    // llmedge's ModelCache owns weight lifetime via eviction instead.
-    p.free_params_immediately = false;
     p.n_threads = nThreads > 0 ? nThreads : sd_get_num_physical_cores_safe();
-    p.offload_params_to_cpu = offloadToCpu;
-    p.keep_clip_on_cpu = keepClipOnCpu;
-    p.keep_vae_on_cpu = keepVaeOnCpu;
     p.diffusion_flash_attn = flashAttn;
-    p.vae_decode_only = jvaeDecodeOnly;
     p.lora_apply_mode = static_cast<enum lora_apply_mode_t>(jLoraApplyMode);
+
+    std::string backendSpec;
+    if (keepClipOnCpu == JNI_TRUE) backendSpec = "te=cpu";
+    if (keepVaeOnCpu == JNI_TRUE) {
+        if (!backendSpec.empty()) backendSpec += ",";
+        backendSpec += "vae=cpu";
+    }
+    std::string paramsBackendSpec = offloadToCpu == JNI_TRUE ? "*=cpu" : "";
+    p.backend = backendSpec.c_str();
+    p.params_backend = paramsBackendSpec.c_str();
 
     bool isLlmOnly = !llmPathValue.empty() && diffusionModelPathValue.empty() && (!modelPath || modelPath[0] == '\0');
     bool isT5OnlyRequest = modelPath && modelPath[0] != '\0' &&
@@ -567,17 +563,20 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(JNIEnv* e
 #ifndef SD_JNI_TESTING
     if (handle->t5_ctx) {
         auto* t5 = static_cast<T5CLIPEmbedder*>(handle->t5_ctx);
-        t5->free_params_buffer();
         delete t5;
         handle->t5_ctx = nullptr;
     }
     if (handle->llm_ctx) {
         auto* llm = static_cast<LLMEmbedder*>(handle->llm_ctx);
-        llm->free_params_buffer();
         delete llm;
         handle->llm_ctx = nullptr;
     }
 #endif
+    handle->model_manager.reset();
+    if (handle->params_backend) {
+        ggml_backend_free(static_cast<ggml_backend_t>(handle->params_backend));
+        handle->params_backend = nullptr;
+    }
     if (handle->backend) {
         ggml_backend_free(static_cast<ggml_backend_t>(handle->backend));
         handle->backend = nullptr;

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
@@ -44,6 +44,9 @@ data class ImageGenerationRequest(
     // true the runtime routes [model] -> diffusion_model_path and [textEncoder] -> llm_path.
     val vae: ModelSpec? = null,
     val textEncoder: ModelSpec? = null,
+    // Standalone DiT checkpoints (for example MiniT2I) are routed through
+    // diffusion_model_path while [textEncoder] remains in the T5 slot.
+    val diffusionModelOnly: Boolean = false,
     val splitDiffusionModel: Boolean = false,
     // FLUX.2 sequential low-memory mode: load the encoder alone to precompute the conditioning,
     // free it, then load the DiT alone to generate. Peak RAM = max(encoder, DiT) instead of the

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
@@ -32,6 +32,7 @@ internal object ImageRuntimeRequestPlanner {
                     model = params.model ?: config.models.image,
                     vae = params.vae,
                     textEncoder = params.textEncoder,
+                    diffusionModelOnly = params.diffusionModelOnly,
                     splitDiffusionModel = params.splitDiffusionModel,
                 ),
             options =

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
@@ -31,6 +31,7 @@ internal data class DiffusionRuntimeSpec(
     val vae: ModelSpec? = null,
     val textEncoder: ModelSpec? = null,
     val taehv: ModelSpec? = null,
+    val diffusionModelOnly: Boolean = false,
     // FLUX.2 Klein split model: route [model] to diffusion_model_path and [textEncoder] (Qwen3)
     // to llm_path instead of the default model_path / t5xxl_path slots.
     val splitDiffusionModel: Boolean = false,
@@ -130,6 +131,7 @@ internal class DiffusionRuntimeLoader(
                 resolvedTaehv = resolvedTaehv,
                 fileSizeBytes = fileSizeBytes,
                 flashAttn = preferredFlash,
+                diffusionModelOnly = spec.diffusionModelOnly,
                 splitDiffusionModel = spec.splitDiffusionModel,
                 encoderOnly = spec.encoderOnly,
             )
@@ -151,8 +153,9 @@ internal class DiffusionRuntimeLoader(
                     resolvedTaehv = resolvedTaehv,
                     fileSizeBytes = fileSizeBytes,
                     flashAttn = false,
+                    diffusionModelOnly = spec.diffusionModelOnly,
                     splitDiffusionModel = spec.splitDiffusionModel,
-                encoderOnly = spec.encoderOnly,
+                    encoderOnly = spec.encoderOnly,
                 )
             } catch (fallbackError: Throwable) {
                 fallbackError.addSuppressed(error)
@@ -170,6 +173,7 @@ internal class DiffusionRuntimeLoader(
         resolvedTaehv: File?,
         fileSizeBytes: Long,
         flashAttn: Boolean,
+        diffusionModelOnly: Boolean,
         splitDiffusionModel: Boolean,
         encoderOnly: Boolean,
     ): ManagedDiffusionModel {
@@ -182,11 +186,11 @@ internal class DiffusionRuntimeLoader(
             StableDiffusion.loadWithRuntimeBackend(
                 context = context,
                 // encoderOnly: load just the Qwen3 encoder via llm_path (no model/diffusion/vae).
-                modelPath = if (splitDiffusionModel || encoderOnly) null else resolvedModel.absolutePath,
+                modelPath = if (splitDiffusionModel || diffusionModelOnly || encoderOnly) null else resolvedModel.absolutePath,
                 vaePath = if (encoderOnly) null else resolvedVae?.absolutePath,
                 t5xxlPath = if (splitDiffusionModel || encoderOnly) null else resolvedTextEncoder?.absolutePath,
                 taesdPath = if (encoderOnly) null else resolvedTaehv?.absolutePath,
-                diffusionModelPath = if (splitDiffusionModel) resolvedModel.absolutePath else null,
+                diffusionModelPath = if (splitDiffusionModel || diffusionModelOnly) resolvedModel.absolutePath else null,
                 llmPath =
                     when {
                         encoderOnly -> resolvedModel.absolutePath
@@ -247,6 +251,7 @@ internal fun createDiffusionRuntimePool(
                         spec.vae?.cacheKey,
                         spec.textEncoder?.cacheKey,
                         spec.taehv?.cacheKey,
+                        "diffusionOnly=${spec.diffusionModelOnly}",
                         "threads=${options.nThreads}",
                         "gpu=${options.allowGpu}",
                         "offload=${options.offloadToCpu}",

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
@@ -13,6 +13,7 @@ import io.aatricks.llmedge.core.runtime.createCachedRuntimePool
 import io.aatricks.llmedge.core.runtime.runtimePoolProfile
 import io.aatricks.llmedge.image.diffusion.LoraApplyMode
 import io.aatricks.llmedge.image.diffusion.StableDiffusion
+import io.aatricks.llmedge.model.ModelArtifactKind
 import io.aatricks.llmedge.model.ModelRepository
 import io.aatricks.llmedge.model.ModelSpec
 import io.aatricks.llmedge.runtime.ComputeBackend
@@ -121,6 +122,9 @@ internal class DiffusionRuntimeLoader(
                 resolvedTaehv,
             )
         val preferredFlash = options.flashAttn
+        val diffusionModelOnly =
+            spec.diffusionModelOnly ||
+                spec.model.hints.artifactKind == ModelArtifactKind.DIFFUSION_MODEL
         try {
             return createManagedModel(
                 options = options,
@@ -131,7 +135,7 @@ internal class DiffusionRuntimeLoader(
                 resolvedTaehv = resolvedTaehv,
                 fileSizeBytes = fileSizeBytes,
                 flashAttn = preferredFlash,
-                diffusionModelOnly = spec.diffusionModelOnly,
+                diffusionModelOnly = diffusionModelOnly,
                 splitDiffusionModel = spec.splitDiffusionModel,
                 encoderOnly = spec.encoderOnly,
             )
@@ -153,7 +157,7 @@ internal class DiffusionRuntimeLoader(
                     resolvedTaehv = resolvedTaehv,
                     fileSizeBytes = fileSizeBytes,
                     flashAttn = false,
-                    diffusionModelOnly = spec.diffusionModelOnly,
+                    diffusionModelOnly = diffusionModelOnly,
                     splitDiffusionModel = spec.splitDiffusionModel,
                     encoderOnly = spec.encoderOnly,
                 )

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/MiniT2I.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/MiniT2I.kt
@@ -1,0 +1,61 @@
+package io.aatricks.llmedge.image
+
+import io.aatricks.llmedge.model.ModelArtifactKind
+import io.aatricks.llmedge.model.ModelCapability
+import io.aatricks.llmedge.model.ModelHints
+import io.aatricks.llmedge.model.ModelSpec
+
+/** MiniT2I image generation with the FLAN-T5 Large text encoder. */
+object MiniT2I {
+    @JvmField
+    val diffusionModel: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "MiniT2I/MiniT2I",
+            filename = "minit2i-b-16/transformer/diffusion_pytorch_model.safetensors",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.DIFFUSION_MODEL,
+                    capabilities = setOf(ModelCapability.IMAGE),
+                ),
+        )
+
+    @JvmField
+    val textEncoder: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "google/flan-t5-large",
+            filename = "model.safetensors",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.TEXT_ENCODER,
+                    capabilities = setOf(ModelCapability.TEXT, ModelCapability.IMAGE),
+                ),
+        )
+
+    @JvmStatic
+    @JvmOverloads
+    fun imageRequest(
+        prompt: String,
+        negative: String = "",
+        width: Int = 512,
+        height: Int = 512,
+        steps: Int = 100,
+        cfgScale: Float = 6.0f,
+        seed: Long = -1L,
+        flashAttention: Boolean = true,
+    ): ImageGenerationRequest =
+        ImageGenerationRequest(
+            prompt = prompt,
+            negative = negative,
+            width = width,
+            height = height,
+            steps = steps,
+            cfgScale = cfgScale,
+            seed = seed,
+            flashAttention = flashAttention,
+            model = diffusionModel,
+            textEncoder = textEncoder,
+            diffusionModelOnly = true,
+        )
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionTypes.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionTypes.kt
@@ -141,8 +141,8 @@ data class VideoGenerateParams(
     init {
         require(width > 0) { "Width must be positive" }
         require(height > 0) { "Height must be positive" }
-        require(width % 64 == 0) { "Width must be a multiple of 64" }
-        require(height % 64 == 0) { "Height must be a multiple of 64" }
+        require(width % 32 == 0) { "Width must be a multiple of 32" }
+        require(height % 32 == 0) { "Height must be a multiple of 32" }
     }
     /**
      * Calculate the actual number of frames that will be generated. Wan model uses formula:
@@ -152,11 +152,11 @@ data class VideoGenerateParams(
 
     fun validate(): Result<Unit> = runCatching {
         require(prompt.isNotBlank()) { "Prompt cannot be blank" }
-        require(width % 64 == 0 && width in 256..960) {
-            "Width must be a multiple of 64 in range 256..960"
+        require(width % 32 == 0 && width in 256..960) {
+            "Width must be a multiple of 32 in range 256..960"
         }
-        require(height % 64 == 0 && height in 256..960) {
-            "Height must be a multiple of 64 in range 256..960"
+        require(height % 32 == 0 && height in 256..960) {
+            "Height must be a multiple of 32 in range 256..960"
         }
         // Wan model uses formula: actual_frames = (videoFrames-1)/4*4+1
         // So 1-4 -> 1 frame, 5-8 -> 5 frames, 9-12 -> 9 frames, etc.

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcCodecs.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcCodecs.kt
@@ -115,6 +115,7 @@ internal object IpcCodecs {
             model = request.model?.let(::toIpc),
             vae = request.vae?.let(::toIpc),
             textEncoder = request.textEncoder?.let(::toIpc),
+            diffusionModelOnly = request.diffusionModelOnly,
             splitDiffusionModel = request.splitDiffusionModel,
             sequential = request.sequential,
         )
@@ -142,6 +143,7 @@ internal object IpcCodecs {
             model = request.model?.let(::fromIpc),
             vae = request.vae?.let(::fromIpc),
             textEncoder = request.textEncoder?.let(::fromIpc),
+            diffusionModelOnly = request.diffusionModelOnly,
             splitDiffusionModel = request.splitDiffusionModel,
             sequential = request.sequential,
         )

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcTypes.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcTypes.kt
@@ -61,6 +61,7 @@ internal data class IpcImageRequest(
     val model: IpcModelSpec?,
     val vae: IpcModelSpec?,
     val textEncoder: IpcModelSpec?,
+    val diffusionModelOnly: Boolean,
     val splitDiffusionModel: Boolean,
     val sequential: Boolean,
 ) : Parcelable

--- a/llmedge/src/test/java/io/aatricks/llmedge/VideoGenerateParamsTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/VideoGenerateParamsTest.kt
@@ -2,6 +2,7 @@ package io.aatricks.llmedge
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import io.aatricks.llmedge.image.diffusion.Scheduler
@@ -25,6 +26,17 @@ class VideoGenerateParamsTest {
     }
 
     @Test
+    fun `Wan documented 480x832 resolution passes validation`() {
+        val params = VideoGenerateParams(
+            prompt = "a cat",
+            width = 480,
+            height = 832,
+        )
+
+        assertTrue(params.validate().isSuccess)
+    }
+
+    @Test
     fun `blank prompt fails validation`() {
         val params = VideoGenerateParams(prompt = " ")
 
@@ -32,13 +44,15 @@ class VideoGenerateParamsTest {
     }
 
     @Test
-    fun `width must be multiple of 64`() {
-        val params = VideoGenerateParams(
-            prompt = "valid",
-            width = 510,
-        )
+    fun `width must be multiple of 32`() {
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            VideoGenerateParams(
+                prompt = "valid",
+                width = 510,
+            )
+        }
 
-        assertValidationFails(params, "Width must be a multiple of 64")
+        assertEquals("Width must be a multiple of 32", failure.message)
     }
 
     @Test
@@ -48,7 +62,7 @@ class VideoGenerateParamsTest {
             height = 128,
         )
 
-        assertValidationFails(params, "Height must be a multiple of 64")
+        assertValidationFails(params, "Height must be a multiple of 32")
     }
 
     @Test
@@ -153,7 +167,7 @@ class VideoGenerateParamsTest {
             height = 960,
         )
 
-        assertValidationFails(params, "Width must be a multiple of 64 in range 256..960")
+        assertValidationFails(params, "Width must be a multiple of 32 in range 256..960")
     }
 
     @Test
@@ -204,7 +218,7 @@ class VideoGenerateParamsTest {
             width = 192,
         )
 
-        assertValidationFails(params, "Width must be a multiple of 64 in range 256..960")
+        assertValidationFails(params, "Width must be a multiple of 32 in range 256..960")
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -14,12 +14,16 @@ import io.aatricks.llmedge.image.diffusion.VideoModelMetadata
 import io.aatricks.llmedge.image.diffusion.VideoProgressCallback
 import io.aatricks.llmedge.core.LLMEdgeScope
 import io.aatricks.llmedge.model.DefaultModelRepository
+import io.aatricks.llmedge.model.ModelArtifactKind
+import io.aatricks.llmedge.model.ModelHints
 import io.aatricks.llmedge.model.ModelSpec
 import io.aatricks.llmedge.runtime.ComputeBackend
+import io.aatricks.llmedge.runtime.ComputeSubsystem
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
 import java.lang.Thread.sleep
 import kotlinx.coroutines.flow.collect
@@ -61,6 +65,58 @@ class ImageClientTest {
         } catch (_: Throwable) {
         }
         clearAllMocks()
+    }
+
+    @Test
+    fun `video diffusion artifact routes to native diffusion model path`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val modelFile =
+            java.io.File.createTempFile("wan22", ".gguf", context.filesDir).apply {
+                writeBytes(byteArrayOf(0x01))
+            }
+        val model =
+            ModelSpec.localFile(
+                modelFile,
+                ModelHints(artifactKind = ModelArtifactKind.DIFFUSION_MODEL),
+            )
+        var observedModelPath: String? = "unset"
+        var observedDiffusionModelPath: String? = "unset"
+        coEvery {
+            StableDiffusion.loadWithRuntimeBackend(
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+            )
+        } coAnswers {
+            observedModelPath = it.invocation.args[3] as String?
+            observedDiffusionModelPath = it.invocation.args[21] as String?
+            mockk(relaxed = true)
+        }
+
+        val loaded =
+            DiffusionRuntimeLoader(context, DefaultModelRepository()).load(
+                spec = DiffusionRuntimeSpec(role = DiffusionRuntimeRole.VIDEO, model = model),
+                options =
+                    DiffusionLoadOptions(
+                        subsystem = ComputeSubsystem.VIDEO,
+                        allowGpu = false,
+                        nThreads = 1,
+                        offloadToCpu = true,
+                        keepClipOnCpu = true,
+                        keepVaeOnCpu = true,
+                        flashAttn = true,
+                        preferPerformanceMode = false,
+                    ),
+                backend = ComputeBackend.CPU,
+            )
+        try {
+            assertEquals(null, observedModelPath)
+            assertEquals(modelFile.absolutePath, observedDiffusionModelPath)
+        } finally {
+            loaded.close()
+        }
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
@@ -2,7 +2,10 @@ package io.aatricks.llmedge.image
 
 import io.aatricks.llmedge.ImageRuntimeConfig
 import io.aatricks.llmedge.LLMEdgeConfig
+import io.aatricks.llmedge.model.ModelSpec
+import java.io.File
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,6 +36,24 @@ class ImageRuntimeRequestPlannerTest {
         assertFalse(plan.diffusionRequest.options.allowGpu)
         // The conditioning phase is CPU-pinned regardless of config (peak-RAM promise).
         assertFalse(plan.conditioningRequest.options.allowGpu)
+    }
+
+    @Test
+    fun `standalone diffusion model route is retained in runtime spec`() {
+        val model = ModelSpec.LocalFile(File("/minit2i.safetensors"))
+        val request =
+            ImageRuntimeRequestPlanner.imageRequest(
+                ImageGenerationRequest(
+                    prompt = "x",
+                    model = model,
+                    diffusionModelOnly = true,
+                ),
+                LLMEdgeConfig(),
+            )
+
+        assertSame(model, request.spec.model)
+        assertTrue(request.spec.diffusionModelOnly)
+        assertFalse(request.spec.splitDiffusionModel)
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/MiniT2ITest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/MiniT2ITest.kt
@@ -1,0 +1,33 @@
+package io.aatricks.llmedge.image
+
+import io.aatricks.llmedge.model.ModelSpec
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MiniT2ITest {
+    @Test
+    fun `image request uses MiniT2I transformer and FLAN T5 encoder`() {
+        val request = MiniT2I.imageRequest(prompt = "a cat", seed = 42L)
+
+        val model = request.model as ModelSpec.HuggingFace
+        assertEquals("MiniT2I/MiniT2I", model.repoId)
+        assertEquals("minit2i-b-16/transformer/diffusion_pytorch_model.safetensors", model.filename)
+
+        val textEncoder = request.textEncoder as ModelSpec.HuggingFace
+        assertEquals("google/flan-t5-large", textEncoder.repoId)
+        assertEquals("model.safetensors", textEncoder.filename)
+
+        assertSame(MiniT2I.diffusionModel, request.model)
+        assertSame(MiniT2I.textEncoder, request.textEncoder)
+        assertNull(request.vae)
+        assertTrue(request.diffusionModelOnly)
+        assertFalse(request.splitDiffusionModel)
+        assertEquals(100, request.steps)
+        assertEquals(6.0f, request.cfgScale)
+        assertEquals(42L, request.seed)
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IpcMarshallingTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IpcMarshallingTest.kt
@@ -82,6 +82,7 @@ class IpcMarshallingTest {
                 loraModelDir = "/lora",
                 loraApplyMode = LoraApplyMode.AT_RUNTIME,
                 model = ModelSpec.LocalFile(File("/m.gguf")),
+                diffusionModelOnly = true,
                 splitDiffusionModel = true,
                 sequential = true,
             )


### PR DESCRIPTION
Adds MiniT2I as a first-class image model with FLAN-T5 text encoding and routes it through the existing Kotlin, JNI, and stable-diffusion.cpp path. The public helper supplies the model defaults used by the examples app.

Checked with the SDK unit suite and a local 512x512 MiniT2I generation through Kotlin and JNI.