### PR TITLE
Install SPIRV-Headers so Vulkan native builds configure on CI

### DIFF
--- a/.github/workflows/android-smoke.yml
+++ b/.github/workflows/android-smoke.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Native Build Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake build-essential ninja-build glslc libvulkan-dev
+          sudo apt-get install -y cmake build-essential ninja-build glslc libvulkan-dev spirv-headers
 
       - name: Run managed-device smoke tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install Native Build Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake build-essential ninja-build glslc libvulkan-dev
+        sudo apt-get install -y cmake build-essential ninja-build glslc libvulkan-dev spirv-headers
 
     - name: Build Native Libraries
       run: |

--- a/.github/workflows/publish-central.yml
+++ b/.github/workflows/publish-central.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Native Build Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake build-essential ninja-build glslc libvulkan-dev
+          sudo apt-get install -y cmake build-essential ninja-build glslc libvulkan-dev spirv-headers
 
       - name: Normalize signing key
         env:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Native Build Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake build-essential ninja-build glslc libvulkan-dev
+          sudo apt-get install -y cmake build-essential ninja-build glslc libvulkan-dev spirv-headers
 
       - name: Publish release AAR to GitHub Packages
         env:

--- a/llmedge/src/main/cpp/cmake/llmedge-stable-diffusion.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-stable-diffusion.cmake
@@ -185,6 +185,26 @@ if (CMAKE_HOST_APPLE AND NOT DEFINED SPIRV-Headers_DIR)
         endif()
 endif()
 
+# Linux hosts (including CI runners) install SPIRV-Headers via the system package
+# manager (apt: spirv-headers), which ships SPIRV-HeadersConfig.cmake under
+# /usr/share/cmake/SPIRV-Headers. Set SPIRV-Headers_DIR explicitly so ggml-vulkan's
+# find_package(SPIRV-Headers CONFIG REQUIRED) resolves even under the Android NDK
+# toolchain's CMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY, which otherwise skips host
+# config paths during the cross-compile (mirrors the Apple branch above).
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND NOT DEFINED SPIRV-Headers_DIR)
+        foreach(_LLMEDGE_SPIRV_HEADERS_CAND
+                "/usr/share/cmake/SPIRV-Headers"
+                "/usr/local/share/cmake/SPIRV-Headers"
+                "/usr/lib/x86_64-linux-gnu/cmake/SPIRV-Headers"
+                "/usr/lib/cmake/SPIRV-Headers")
+                if (EXISTS "${_LLMEDGE_SPIRV_HEADERS_CAND}/SPIRV-HeadersConfig.cmake")
+                        set(SPIRV-Headers_DIR "${_LLMEDGE_SPIRV_HEADERS_CAND}"
+                                CACHE PATH "Host SPIR-V headers package" FORCE)
+                        break()
+                endif()
+        endforeach()
+endif()
+
 # Ensure ggml-vulkan's ExternalProject (vulkan-shaders-gen) can find the correct build tool.
 if (CMAKE_MAKE_PROGRAM)
         set(_GGML_VK_HOST_TC "${CMAKE_CURRENT_BINARY_DIR}/ggml_vulkan_host_toolchain.cmake")


### PR DESCRIPTION
The stable-diffusion update needs the SPIR-V headers package when Vulkan builds run on Linux. Install it in the Vulkan workflows and point the Android cross-build at the host CMake package.