### PR TITLE
Fix MiniT2I model download: resolve nested HuggingFace repo-file paths

### DIFF
--- a/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFDownloadSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFDownloadSupport.kt
@@ -67,10 +67,11 @@ internal object HFDownloadSupport {
         systemDownloadContext: Context?,
         onProgress: ((downloaded: Long, total: Long?) -> Unit)?,
         noMatchMessage: String,
+        recursive: Boolean = false,
         fileSelector: (List<HFModelTree.HFModelFile>) -> HFModelTree.HFModelFile?,
     ): HuggingFaceHub.ModelDownloadResult = withContext(Dispatchers.IO) {
         val resolved = resolveModelReference(modelId, revision)
-        val files = HFModels.tree().getModelFileTree(resolved.modelId, resolved.revision, token)
+        val files = HFModels.tree().getModelFileTree(resolved.modelId, resolved.revision, token, recursive)
         val modelFile = fileSelector(files) ?: throw IllegalArgumentException(noMatchMessage)
         val target = buildDownloadTarget(destinationRoot, resolved, modelFile)
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFModelTree.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFModelTree.kt
@@ -66,9 +66,18 @@ internal class HFModelTree(
         modelId: String,
         revision: String,
         token: String? = null,
+        recursive: Boolean = false,
     ): List<HFModelFile> {
+        // The HF tree API lists only the top level by default, so a nested filename such as
+        // "minit2i-b-16/transformer/diffusion_pytorch_model.safetensors" never appears as a
+        // selection candidate (the subdirectory shows up as a "directory" entry instead).
+        // Request the recursive listing when resolving an exact repo file that may live in a
+        // subdirectory. (For very large repos HF paginates the recursive tree; the models we
+        // resolve this way are small, so a single page suffices.)
+        val endpoint = HFEndpoints.modelTreeEndpoint(modelId, revision)
+        val url = if (recursive) "$endpoint?recursive=true" else endpoint
         val response =
-            client.get(HFEndpoints.modelTreeEndpoint(modelId, revision)) {
+            client.get(url) {
                 token?.let { header(HttpHeaders.Authorization, "Bearer $it") }
             }
         if (!response.status.isSuccess()) {

--- a/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HuggingFaceHub.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HuggingFaceHub.kt
@@ -228,6 +228,9 @@ object HuggingFaceHub {
                     systemDownloadContext = systemDownloadContext,
                     onProgress = request.onProgress,
                     noMatchMessage = "No file found for '${request.modelId}' matching ${request.filename ?: request.allowedExtensions}",
+                    // An exact repo file (e.g. a diffusion model or VAE) may live in a
+                    // subdirectory; list the tree recursively so nested paths are selectable.
+                    recursive = true,
                     fileSelector = { files ->
                         HFFileSelectionSupport.selectRepoFile(files, request.filename, request.allowedExtensions)
                     },

--- a/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HFModelTreeRecursiveTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HFModelTreeRecursiveTest.kt
@@ -1,0 +1,98 @@
+package io.aatricks.llmedge.huggingface
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression test for nested repo-file resolution (e.g. MiniT2I's
+ * "minit2i-b-16/transformer/diffusion_pytorch_model.safetensors").
+ *
+ * The HF tree API is non-recursive by default: the subdirectory shows up as a "directory" entry
+ * and the nested file never becomes a selection candidate, so [HFFileSelectionSupport.selectRepoFile]
+ * returned null and the app failed with "No file found for '<repo>' matching <nested path>".
+ * Exact repo files must therefore be listed recursively.
+ */
+class HFModelTreeRecursiveTest {
+    private val nestedPath = "minit2i-b-16/transformer/diffusion_pytorch_model.safetensors"
+
+    // What HF returns WITHOUT ?recursive=true: the nested file is hidden behind a directory entry.
+    private val nonRecursiveBody = """
+        [
+          {"type":"directory","path":"minit2i-b-16"},
+          {"type":"file","size":123,"path":"README.md"}
+        ]
+    """.trimIndent()
+
+    // What HF returns WITH ?recursive=true: the nested file is present.
+    private val recursiveBody = """
+        [
+          {"type":"directory","path":"minit2i-b-16"},
+          {"type":"file","size":123,"path":"README.md"},
+          {"type":"file","size":1032534472,"path":"$nestedPath"}
+        ]
+    """.trimIndent()
+
+    private fun treeReturning(
+        body: String,
+        capturedUrls: MutableList<String>,
+    ): HFModelTree {
+        val engine =
+            MockEngine { request ->
+                capturedUrls += request.url.toString()
+                respond(
+                    content = body,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+        val client =
+            HttpClient(engine) {
+                install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            }
+        return HFModelTree(client)
+    }
+
+    @Test
+    fun `recursive listing requests recursive=true and exposes nested files`() =
+        runBlocking {
+            val urls = mutableListOf<String>()
+            val files =
+                treeReturning(recursiveBody, urls)
+                    .getModelFileTree("MiniT2I/MiniT2I", "main", recursive = true)
+
+            assertTrue(
+                "recursive listing must request ?recursive=true, was ${urls.first()}",
+                urls.first().contains("recursive=true"),
+            )
+            val selected = HFFileSelectionSupport.selectRepoFile(files, nestedPath, listOf(".safetensors"))
+            assertNotNull("nested repo file must be selectable from a recursive listing", selected)
+            assertEquals(nestedPath, selected!!.path)
+        }
+
+    @Test
+    fun `non-recursive listing hides nested files (reproduces the bug)`() =
+        runBlocking {
+            val urls = mutableListOf<String>()
+            val files =
+                treeReturning(nonRecursiveBody, urls)
+                    .getModelFileTree("MiniT2I/MiniT2I", "main", recursive = false)
+
+            assertTrue(
+                "default listing must not request recursion, was ${urls.first()}",
+                !urls.first().contains("recursive=true"),
+            )
+            val selected = HFFileSelectionSupport.selectRepoFile(files, nestedPath, listOf(".safetensors"))
+            assertNull("nested repo file is invisible without a recursive listing", selected)
+        }
+}


### PR DESCRIPTION
MiniT2I failed in the example app with:

```
Failed: No file found for 'MiniT2I/MiniT2I' matching minit2i-b-16/transformer/diffusion_pytorch_model.safetensors
```

The diffusion model lives in a subdirectory. When resolving an exact repo file, the SDK listed the HuggingFace tree **non-recursively**, so the nested path never appeared as a selection candidate (the subdirectory showed up as a `directory` entry), and `selectRepoFile` returned null. It was never the download itself — the model was never located to download.

This lists the tree recursively for the repo-file path so nested files are selectable. GGUF model selection is unchanged (still non-recursive), and the download URL already used the full nested path.

Verified:
- New offline MockEngine regression test (recursive listing exposes + selects the nested file; non-recursive reproduces the null/no-match).
- End-to-end against live HuggingFace: the nested `config.json` downloads through the real `ensureRepoFileOnDisk` path.
- Full SDK unit suite green (336 tests).

Note: this bug was masked earlier because the model E2E fed MiniT2I local files via env vars, bypassing the download path entirely.