### PR TITLE
Expose all sd.cpp component paths and add SD3 Medium presets

### DIFF
--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -528,12 +528,6 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     p.audio_vae_path = audioVaePathValue.c_str();
     p.control_net_path = controlNetPathValue.c_str();
     p.photo_maker_path = photoMakerPathValue.c_str();
-    // MUST stay false: free_params_immediately frees each module's weight
-    // buffer after its stage, so a second generate_image on the same handle
-    // reads freed memory (SIGSEGV in the UNet's first conv — this was the
-    // "warm sd_ctx unsafe to reuse" crash, on every backend, not just Vulkan).
-    // llmedge's ModelCache owns weight lifetime via eviction instead.
-    p.free_params_immediately = false;
     p.n_threads = nThreads > 0 ? nThreads : sd_get_num_physical_cores_safe();
     p.diffusion_flash_attn = flashAttn;
     p.lora_apply_mode = static_cast<enum lora_apply_mode_t>(jLoraApplyMode);

--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -384,6 +384,15 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
         jstring jTaesdPath,
         jstring jDiffusionModelPath,
         jstring jLlmPath,
+        jstring jClipLPath,
+        jstring jClipGPath,
+        jstring jClipVisionPath,
+        jstring jLlmVisionPath,
+        jstring jHighNoiseDiffusionModelPath,
+        jstring jEmbeddingsConnectorsPath,
+        jstring jAudioVaePath,
+        jstring jControlNetPath,
+        jstring jPhotoMakerPath,
         jint nThreads,
         jboolean enableOpenCl,
         jboolean useVulkan,
@@ -413,6 +422,42 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     const std::string llmPathValue = llmPathRaw ? llmPathRaw : "";
     if (jLlmPath && llmPathRaw) env->ReleaseStringUTFChars(jLlmPath, llmPathRaw);
 
+    const char* clipLPathRaw = jClipLPath ? env->GetStringUTFChars(jClipLPath, nullptr) : nullptr;
+    const std::string clipLPathValue = clipLPathRaw ? clipLPathRaw : "";
+    if (jClipLPath && clipLPathRaw) env->ReleaseStringUTFChars(jClipLPath, clipLPathRaw);
+
+    const char* clipGPathRaw = jClipGPath ? env->GetStringUTFChars(jClipGPath, nullptr) : nullptr;
+    const std::string clipGPathValue = clipGPathRaw ? clipGPathRaw : "";
+    if (jClipGPath && clipGPathRaw) env->ReleaseStringUTFChars(jClipGPath, clipGPathRaw);
+
+    const char* clipVisionPathRaw = jClipVisionPath ? env->GetStringUTFChars(jClipVisionPath, nullptr) : nullptr;
+    const std::string clipVisionPathValue = clipVisionPathRaw ? clipVisionPathRaw : "";
+    if (jClipVisionPath && clipVisionPathRaw) env->ReleaseStringUTFChars(jClipVisionPath, clipVisionPathRaw);
+
+    const char* llmVisionPathRaw = jLlmVisionPath ? env->GetStringUTFChars(jLlmVisionPath, nullptr) : nullptr;
+    const std::string llmVisionPathValue = llmVisionPathRaw ? llmVisionPathRaw : "";
+    if (jLlmVisionPath && llmVisionPathRaw) env->ReleaseStringUTFChars(jLlmVisionPath, llmVisionPathRaw);
+
+    const char* highNoiseDiffusionModelPathRaw = jHighNoiseDiffusionModelPath ? env->GetStringUTFChars(jHighNoiseDiffusionModelPath, nullptr) : nullptr;
+    const std::string highNoiseDiffusionModelPathValue = highNoiseDiffusionModelPathRaw ? highNoiseDiffusionModelPathRaw : "";
+    if (jHighNoiseDiffusionModelPath && highNoiseDiffusionModelPathRaw) env->ReleaseStringUTFChars(jHighNoiseDiffusionModelPath, highNoiseDiffusionModelPathRaw);
+
+    const char* embeddingsConnectorsPathRaw = jEmbeddingsConnectorsPath ? env->GetStringUTFChars(jEmbeddingsConnectorsPath, nullptr) : nullptr;
+    const std::string embeddingsConnectorsPathValue = embeddingsConnectorsPathRaw ? embeddingsConnectorsPathRaw : "";
+    if (jEmbeddingsConnectorsPath && embeddingsConnectorsPathRaw) env->ReleaseStringUTFChars(jEmbeddingsConnectorsPath, embeddingsConnectorsPathRaw);
+
+    const char* audioVaePathRaw = jAudioVaePath ? env->GetStringUTFChars(jAudioVaePath, nullptr) : nullptr;
+    const std::string audioVaePathValue = audioVaePathRaw ? audioVaePathRaw : "";
+    if (jAudioVaePath && audioVaePathRaw) env->ReleaseStringUTFChars(jAudioVaePath, audioVaePathRaw);
+
+    const char* controlNetPathRaw = jControlNetPath ? env->GetStringUTFChars(jControlNetPath, nullptr) : nullptr;
+    const std::string controlNetPathValue = controlNetPathRaw ? controlNetPathRaw : "";
+    if (jControlNetPath && controlNetPathRaw) env->ReleaseStringUTFChars(jControlNetPath, controlNetPathRaw);
+
+    const char* photoMakerPathRaw = jPhotoMakerPath ? env->GetStringUTFChars(jPhotoMakerPath, nullptr) : nullptr;
+    const std::string photoMakerPathValue = photoMakerPathRaw ? photoMakerPathRaw : "";
+    if (jPhotoMakerPath && photoMakerPathRaw) env->ReleaseStringUTFChars(jPhotoMakerPath, photoMakerPathRaw);
+
     sd_set_log_callback(sd_android_log_cb, nullptr);
 
     ALOGI("Initializing Stable Diffusion with:");
@@ -422,6 +467,15 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     ALOGI("  taesdPath=%s", taesdPath ? taesdPath : "NULL");
     ALOGI("  diffusionModelPath=%s", diffusionModelPathValue.empty() ? "NULL" : diffusionModelPathValue.c_str());
     ALOGI("  llmPath=%s", llmPathValue.empty() ? "NULL" : llmPathValue.c_str());
+    ALOGI("  clipLPath=%s", clipLPathValue.empty() ? "NULL" : clipLPathValue.c_str());
+    ALOGI("  clipGPath=%s", clipGPathValue.empty() ? "NULL" : clipGPathValue.c_str());
+    ALOGI("  clipVisionPath=%s", clipVisionPathValue.empty() ? "NULL" : clipVisionPathValue.c_str());
+    ALOGI("  llmVisionPath=%s", llmVisionPathValue.empty() ? "NULL" : llmVisionPathValue.c_str());
+    ALOGI("  highNoiseDiffusionModelPath=%s", highNoiseDiffusionModelPathValue.empty() ? "NULL" : highNoiseDiffusionModelPathValue.c_str());
+    ALOGI("  embeddingsConnectorsPath=%s", embeddingsConnectorsPathValue.empty() ? "NULL" : embeddingsConnectorsPathValue.c_str());
+    ALOGI("  audioVaePath=%s", audioVaePathValue.empty() ? "NULL" : audioVaePathValue.c_str());
+    ALOGI("  controlNetPath=%s", controlNetPathValue.empty() ? "NULL" : controlNetPathValue.c_str());
+    ALOGI("  photoMakerPath=%s", photoMakerPathValue.empty() ? "NULL" : photoMakerPathValue.c_str());
     ALOGI("  loraModelDir=%s, loraApplyMode=%d", loraModelDirValue.empty() ? "NULL" : loraModelDirValue.c_str(), static_cast<int>(jLoraApplyMode));
     ALOGI("  enableOpenCl=%s, useVulkan=%s, offloadToCpu=%s, keepClipOnCpu=%s, keepVaeOnCpu=%s, flashAttn=%s, vaeDecodeOnly=%s",
           enableOpenCl ? "true" : "false",
@@ -469,6 +523,15 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     // Split-model components (FLUX.2 Klein etc.). Empty string == not provided.
     p.diffusion_model_path = diffusionModelPathValue.c_str();
     p.llm_path = llmPathValue.c_str();
+    p.clip_l_path = clipLPathValue.c_str();
+    p.clip_g_path = clipGPathValue.c_str();
+    p.clip_vision_path = clipVisionPathValue.c_str();
+    p.llm_vision_path = llmVisionPathValue.c_str();
+    p.high_noise_diffusion_model_path = highNoiseDiffusionModelPathValue.c_str();
+    p.embeddings_connectors_path = embeddingsConnectorsPathValue.c_str();
+    p.audio_vae_path = audioVaePathValue.c_str();
+    p.control_net_path = controlNetPathValue.c_str();
+    p.photo_maker_path = photoMakerPathValue.c_str();
     // MUST stay false: free_params_immediately frees each module's weight
     // buffer after its stage, so a second generate_image on the same handle
     // reads freed memory (SIGSEGV in the UNet's first conv — this was the
@@ -483,13 +546,23 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     p.vae_decode_only = jvaeDecodeOnly;
     p.lora_apply_mode = static_cast<enum lora_apply_mode_t>(jLoraApplyMode);
 
-    bool isLlmOnly = !llmPathValue.empty() && diffusionModelPathValue.empty() && (!modelPath || modelPath[0] == '\0');
+    bool hasExtraComponentPaths = !clipLPathValue.empty() ||
+                                  !clipGPathValue.empty() ||
+                                  !clipVisionPathValue.empty() ||
+                                  !llmVisionPathValue.empty() ||
+                                  !highNoiseDiffusionModelPathValue.empty() ||
+                                  !embeddingsConnectorsPathValue.empty() ||
+                                  !audioVaePathValue.empty() ||
+                                  !controlNetPathValue.empty() ||
+                                  !photoMakerPathValue.empty();
+
+    bool isLlmOnly = !llmPathValue.empty() && diffusionModelPathValue.empty() && (!modelPath || modelPath[0] == '\0') && !hasExtraComponentPaths;
     bool isT5OnlyRequest = modelPath && modelPath[0] != '\0' &&
                            !vaePath && !t5xxlPath && !taesdPath &&
                            diffusionModelPathValue.empty() && llmPathValue.empty() &&
+                           !hasExtraComponentPaths &&
                            (std::string(modelPath).find("t5") != std::string::npos ||
-                            std::string(modelPath).find("encoder") != std::string::npos ||
-                            std::string(modelPath).find("clip") != std::string::npos);
+                            std::string(modelPath).find("encoder") != std::string::npos);
 
     sd_ctx_t* ctx = nullptr;
     if (!isLlmOnly) {

--- a/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFEndpoints.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFEndpoints.kt
@@ -22,9 +22,7 @@ internal object HFEndpoints {
     val listModelsEndpoint: () -> String = { HF_BASE_ENDPOINT }
 
     val modelTreeEndpoint: (String, String) -> String = { modelId, revision ->
-        // recursive: the root-only listing hides files in subdirectories, so specs like
-        // "text_encoders/clip_l.safetensors" would never match their repo entry.
-        "$HF_BASE_ENDPOINT/$modelId/tree/$revision?recursive=true"
+        "$HF_BASE_ENDPOINT/$modelId/tree/$revision"
     }
 
     val modelSpecsEndpoint: (String) -> String = { modelId -> "$HF_BASE_ENDPOINT/$modelId" }

--- a/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFEndpoints.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFEndpoints.kt
@@ -22,7 +22,9 @@ internal object HFEndpoints {
     val listModelsEndpoint: () -> String = { HF_BASE_ENDPOINT }
 
     val modelTreeEndpoint: (String, String) -> String = { modelId, revision ->
-        "$HF_BASE_ENDPOINT/$modelId/tree/$revision"
+        // recursive: the root-only listing hides files in subdirectories, so specs like
+        // "text_encoders/clip_l.safetensors" would never match their repo entry.
+        "$HF_BASE_ENDPOINT/$modelId/tree/$revision?recursive=true"
     }
 
     val modelSpecsEndpoint: (String) -> String = { modelId -> "$HF_BASE_ENDPOINT/$modelId" }

--- a/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFFileSelectionSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFFileSelectionSupport.kt
@@ -62,6 +62,9 @@ internal object HFFileSelectionSupport {
                 it.path.equals(filename, ignoreCase = true) ||
                     it.path.endsWith(filename, ignoreCase = true)
             }?.let { return it }
+            // An explicit filename that is not in the repo must fail the resolve; falling
+            // through to the size heuristic silently downloads an unrelated checkpoint.
+            return null
         }
 
         return allFiles

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
@@ -44,6 +44,13 @@ data class ImageGenerationRequest(
     // true the runtime routes [model] -> diffusion_model_path and [textEncoder] -> llm_path.
     val vae: ModelSpec? = null,
     val textEncoder: ModelSpec? = null,
+    val clipL: ModelSpec? = null,
+    val clipG: ModelSpec? = null,
+    val clipVision: ModelSpec? = null,
+    val llmVision: ModelSpec? = null,
+    val controlNet: ModelSpec? = null,
+    val photoMaker: ModelSpec? = null,
+    val embeddingsConnectors: ModelSpec? = null,
     val splitDiffusionModel: Boolean = false,
     // FLUX.2 sequential low-memory mode: load the encoder alone to precompute the conditioning,
     // free it, then load the DiT alone to generate. Peak RAM = max(encoder, DiT) instead of the
@@ -74,6 +81,7 @@ data class VideoGenerationRequest(
     val model: ModelSpec? = null,
     val vae: ModelSpec? = null,
     val textEncoder: ModelSpec? = null,
+    val highNoiseDiffusionModel: ModelSpec? = null,
 ) {
     fun actualFrameCount(): Int = (videoFrames - 1) / 4 * 4 + 1
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageGenerationExecutor.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageGenerationExecutor.kt
@@ -25,6 +25,7 @@ internal class ImageGenerationExecutor(
     private val phaseListener: DiffusionPhaseListener? = null,
 ) {
     suspend fun generate(params: ImageGenerationRequest): Bitmap {
+        // Clip-slot (component-path) presets intentionally stay on the direct path.
         if (params.sequential && params.splitDiffusionModel && params.textEncoder != null) {
             return generateSequential(params)
         }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
@@ -32,6 +32,13 @@ internal object ImageRuntimeRequestPlanner {
                     model = params.model ?: config.models.image,
                     vae = params.vae,
                     textEncoder = params.textEncoder,
+                    clipL = params.clipL,
+                    clipG = params.clipG,
+                    clipVision = params.clipVision,
+                    llmVision = params.llmVision,
+                    controlNet = params.controlNet,
+                    photoMaker = params.photoMaker,
+                    embeddingsConnectors = params.embeddingsConnectors,
                     splitDiffusionModel = params.splitDiffusionModel,
                 ),
             options =
@@ -212,6 +219,7 @@ internal object ImageRuntimeRequestPlanner {
             vae = if (usingCustomTae) null else (params.vae ?: config.models.video.vae),
             textEncoder = if (includeTextEncoder) params.textEncoder ?: config.models.video.textEncoder else null,
             taehv = params.taehv,
+            highNoiseDiffusionModel = params.highNoiseDiffusionModel,
         )
     }
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
@@ -165,7 +165,8 @@ internal class DiffusionRuntimeLoader(
         val preferredFlash = options.flashAttn
         val diffusionModelOnly =
             spec.diffusionModelOnly ||
-                spec.model.hints.artifactKind == ModelArtifactKind.DIFFUSION_MODEL
+                (spec.role != DiffusionRuntimeRole.IMAGE &&
+                    spec.model.hints.artifactKind == ModelArtifactKind.DIFFUSION_MODEL)
         try {
             return createManagedModel(
                 options = options,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
@@ -13,6 +13,7 @@ import io.aatricks.llmedge.core.runtime.createCachedRuntimePool
 import io.aatricks.llmedge.core.runtime.runtimePoolProfile
 import io.aatricks.llmedge.image.diffusion.LoraApplyMode
 import io.aatricks.llmedge.image.diffusion.StableDiffusion
+import io.aatricks.llmedge.image.diffusion.StableDiffusionComponentPaths
 import io.aatricks.llmedge.model.ModelRepository
 import io.aatricks.llmedge.model.ModelSpec
 import io.aatricks.llmedge.runtime.ComputeBackend
@@ -31,6 +32,14 @@ internal data class DiffusionRuntimeSpec(
     val vae: ModelSpec? = null,
     val textEncoder: ModelSpec? = null,
     val taehv: ModelSpec? = null,
+    val clipL: ModelSpec? = null,
+    val clipG: ModelSpec? = null,
+    val clipVision: ModelSpec? = null,
+    val llmVision: ModelSpec? = null,
+    val controlNet: ModelSpec? = null,
+    val photoMaker: ModelSpec? = null,
+    val embeddingsConnectors: ModelSpec? = null,
+    val highNoiseDiffusionModel: ModelSpec? = null,
     // FLUX.2 Klein split model: route [model] to diffusion_model_path and [textEncoder] (Qwen3)
     // to llm_path instead of the default model_path / t5xxl_path slots.
     val splitDiffusionModel: Boolean = false,
@@ -89,6 +98,14 @@ internal class DiffusionRuntimeLoader(
         val resolvedVae = spec.vae?.let { resolver.resolve(context, it) }
         val resolvedTextEncoder = spec.textEncoder?.let { resolver.resolve(context, it) }
         val resolvedTaehv = spec.taehv?.let { resolver.resolve(context, it) }
+        val resolvedClipL = spec.clipL?.let { resolver.resolve(context, it) }
+        val resolvedClipG = spec.clipG?.let { resolver.resolve(context, it) }
+        val resolvedClipVision = spec.clipVision?.let { resolver.resolve(context, it) }
+        val resolvedLlmVision = spec.llmVision?.let { resolver.resolve(context, it) }
+        val resolvedControlNet = spec.controlNet?.let { resolver.resolve(context, it) }
+        val resolvedPhotoMaker = spec.photoMaker?.let { resolver.resolve(context, it) }
+        val resolvedEmbeddingsConnectors = spec.embeddingsConnectors?.let { resolver.resolve(context, it) }
+        val resolvedHighNoiseDiffusionModel = spec.highNoiseDiffusionModel?.let { resolver.resolve(context, it) }
         return loadManagedModel(
             spec = spec,
             options = options,
@@ -97,6 +114,14 @@ internal class DiffusionRuntimeLoader(
             resolvedVae = resolvedVae,
             resolvedTextEncoder = resolvedTextEncoder,
             resolvedTaehv = resolvedTaehv,
+            resolvedClipL = resolvedClipL,
+            resolvedClipG = resolvedClipG,
+            resolvedClipVision = resolvedClipVision,
+            resolvedLlmVision = resolvedLlmVision,
+            resolvedControlNet = resolvedControlNet,
+            resolvedPhotoMaker = resolvedPhotoMaker,
+            resolvedEmbeddingsConnectors = resolvedEmbeddingsConnectors,
+            resolvedHighNoiseDiffusionModel = resolvedHighNoiseDiffusionModel,
         )
     }
 
@@ -111,6 +136,14 @@ internal class DiffusionRuntimeLoader(
         resolvedVae: File?,
         resolvedTextEncoder: File?,
         resolvedTaehv: File?,
+        resolvedClipL: File?,
+        resolvedClipG: File?,
+        resolvedClipVision: File?,
+        resolvedLlmVision: File?,
+        resolvedControlNet: File?,
+        resolvedPhotoMaker: File?,
+        resolvedEmbeddingsConnectors: File?,
+        resolvedHighNoiseDiffusionModel: File?,
     ): ManagedDiffusionModel {
         val fileSizeBytes =
             estimateFileSizeBytes(
@@ -118,6 +151,14 @@ internal class DiffusionRuntimeLoader(
                 resolvedVae,
                 resolvedTextEncoder,
                 resolvedTaehv,
+                resolvedClipL,
+                resolvedClipG,
+                resolvedClipVision,
+                resolvedLlmVision,
+                resolvedControlNet,
+                resolvedPhotoMaker,
+                resolvedEmbeddingsConnectors,
+                resolvedHighNoiseDiffusionModel,
             )
         val preferredFlash = options.flashAttn
         try {
@@ -128,6 +169,14 @@ internal class DiffusionRuntimeLoader(
                 resolvedVae = resolvedVae,
                 resolvedTextEncoder = resolvedTextEncoder,
                 resolvedTaehv = resolvedTaehv,
+                resolvedClipL = resolvedClipL,
+                resolvedClipG = resolvedClipG,
+                resolvedClipVision = resolvedClipVision,
+                resolvedLlmVision = resolvedLlmVision,
+                resolvedControlNet = resolvedControlNet,
+                resolvedPhotoMaker = resolvedPhotoMaker,
+                resolvedEmbeddingsConnectors = resolvedEmbeddingsConnectors,
+                resolvedHighNoiseDiffusionModel = resolvedHighNoiseDiffusionModel,
                 fileSizeBytes = fileSizeBytes,
                 flashAttn = preferredFlash,
                 splitDiffusionModel = spec.splitDiffusionModel,
@@ -149,10 +198,18 @@ internal class DiffusionRuntimeLoader(
                     resolvedVae = resolvedVae,
                     resolvedTextEncoder = resolvedTextEncoder,
                     resolvedTaehv = resolvedTaehv,
+                    resolvedClipL = resolvedClipL,
+                    resolvedClipG = resolvedClipG,
+                    resolvedClipVision = resolvedClipVision,
+                    resolvedLlmVision = resolvedLlmVision,
+                    resolvedControlNet = resolvedControlNet,
+                    resolvedPhotoMaker = resolvedPhotoMaker,
+                    resolvedEmbeddingsConnectors = resolvedEmbeddingsConnectors,
+                    resolvedHighNoiseDiffusionModel = resolvedHighNoiseDiffusionModel,
                     fileSizeBytes = fileSizeBytes,
                     flashAttn = false,
                     splitDiffusionModel = spec.splitDiffusionModel,
-                encoderOnly = spec.encoderOnly,
+                    encoderOnly = spec.encoderOnly,
                 )
             } catch (fallbackError: Throwable) {
                 fallbackError.addSuppressed(error)
@@ -168,6 +225,14 @@ internal class DiffusionRuntimeLoader(
         resolvedVae: File?,
         resolvedTextEncoder: File?,
         resolvedTaehv: File?,
+        resolvedClipL: File?,
+        resolvedClipG: File?,
+        resolvedClipVision: File?,
+        resolvedLlmVision: File?,
+        resolvedControlNet: File?,
+        resolvedPhotoMaker: File?,
+        resolvedEmbeddingsConnectors: File?,
+        resolvedHighNoiseDiffusionModel: File?,
         fileSizeBytes: Long,
         flashAttn: Boolean,
         splitDiffusionModel: Boolean,
@@ -178,6 +243,22 @@ internal class DiffusionRuntimeLoader(
             "Creating managed ${backend.name} runtime for ${resolvedModel.name} flash=$flashAttn sequential=${options.sequentialLoad}",
         )
         phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.LOADING, backend.name)
+        val componentPaths = if (encoderOnly) {
+            null
+        } else {
+            val paths = StableDiffusionComponentPaths(
+                clipLPath = resolvedClipL?.absolutePath,
+                clipGPath = resolvedClipG?.absolutePath,
+                clipVisionPath = resolvedClipVision?.absolutePath,
+                llmVisionPath = resolvedLlmVision?.absolutePath,
+                highNoiseDiffusionModelPath = resolvedHighNoiseDiffusionModel?.absolutePath,
+                embeddingsConnectorsPath = resolvedEmbeddingsConnectors?.absolutePath,
+                audioVaePath = null,
+                controlNetPath = resolvedControlNet?.absolutePath,
+                photoMakerPath = resolvedPhotoMaker?.absolutePath
+            )
+            if (paths.isAllNull()) null else paths
+        }
         val model =
             StableDiffusion.loadWithRuntimeBackend(
                 context = context,
@@ -205,6 +286,7 @@ internal class DiffusionRuntimeLoader(
                 loraModelDir = options.loraModelDir,
                 loraApplyMode = options.loraApplyMode,
                 preferredBackend = backend,
+                componentPaths = componentPaths,
             )
         AndroidLogAdapter.i(
             LOG_TAG,
@@ -247,6 +329,14 @@ internal fun createDiffusionRuntimePool(
                         spec.vae?.cacheKey,
                         spec.textEncoder?.cacheKey,
                         spec.taehv?.cacheKey,
+                        spec.clipL?.cacheKey,
+                        spec.clipG?.cacheKey,
+                        spec.clipVision?.cacheKey,
+                        spec.llmVision?.cacheKey,
+                        spec.controlNet?.cacheKey,
+                        spec.photoMaker?.cacheKey,
+                        spec.embeddingsConnectors?.cacheKey,
+                        spec.highNoiseDiffusionModel?.cacheKey,
                         "threads=${options.nThreads}",
                         "gpu=${options.allowGpu}",
                         "offload=${options.offloadToCpu}",

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/Sd3Medium.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/Sd3Medium.kt
@@ -1,0 +1,158 @@
+package io.aatricks.llmedge.image
+
+import io.aatricks.llmedge.model.ModelArtifactKind
+import io.aatricks.llmedge.model.ModelCapability
+import io.aatricks.llmedge.model.ModelHints
+import io.aatricks.llmedge.model.ModelSpec
+
+/**
+ * Stable Diffusion 3 Medium presets for on-device generation through stable-diffusion.cpp.
+ *
+ * This preset skips the optional T5xxl text encoder (stable-diffusion.cpp probes clip_l,
+ * clip_g, and t5 independently) — a quality tradeoff that avoids the ~5 GB T5 download.
+ * The sequential low-RAM mode is unsupported for SD3 because the encoder-only native load/unload
+ * path is Flux2/T5-specific in stable-diffusion.cpp.
+ *
+ * Mobile default resolution is 512x512, though the model's native resolution is 1024x1024.
+ * Callers with sufficient RAM headroom may pass 1024x1024.
+ *
+ * The total split download size is ~3.1 GB.
+ */
+object Sd3Medium {
+    /** The SD3 Medium DiT model (Q4_0, ~1.28 GB). */
+    @JvmField
+    val diffusionModel: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "city96/stable-diffusion-3-medium-gguf",
+            filename = "sd3_medium-Q4_0.gguf",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.DIFFUSION_MODEL,
+                    capabilities = setOf(ModelCapability.IMAGE),
+                ),
+        )
+
+    /** CLIP-L text encoder (fp16/fp8 source, ~250 MB). */
+    @JvmField
+    val clipL: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "Comfy-Org/stable-diffusion-3.5-fp8",
+            filename = "text_encoders/clip_l.safetensors",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.TEXT_ENCODER,
+                    capabilities = setOf(ModelCapability.TEXT, ModelCapability.IMAGE),
+                ),
+        )
+
+    /** CLIP-G text encoder (fp16/fp8 source, ~1.39 GB). */
+    @JvmField
+    val clipG: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "Comfy-Org/stable-diffusion-3.5-fp8",
+            filename = "text_encoders/clip_g.safetensors",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.TEXT_ENCODER,
+                    capabilities = setOf(ModelCapability.TEXT, ModelCapability.IMAGE),
+                ),
+        )
+
+    /** SD3/SD3.5 16-channel VAE (~168 MB). */
+    @JvmField
+    val vae: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "Shio-Koube/SD-3.5-vae",
+            filename = "diffusion_pytorch_model.safetensors",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.VAE,
+                    capabilities = setOf(ModelCapability.IMAGE),
+                ),
+        )
+
+    /** SD3 Medium All-in-One Model (encoders and VAE baked in, Q4_0, ~4.55 GB). */
+    @JvmField
+    val allInOneModel: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "second-state/stable-diffusion-3-medium-GGUF",
+            filename = "sd3-medium-Q4_0.gguf",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.DIFFUSION_MODEL,
+                    capabilities = setOf(ModelCapability.IMAGE),
+                ),
+        )
+
+    /**
+     * Builds an [ImageGenerationRequest] for Stable Diffusion 3 Medium using split models
+     * (diffusionModel, clipL, clipG, and vae).
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun imageRequest(
+        prompt: String,
+        negative: String = "",
+        width: Int = 512,
+        height: Int = 512,
+        steps: Int = 28,
+        cfgScale: Float = 4.5f,
+        seed: Long = -1L,
+        flashAttention: Boolean = true,
+    ): ImageGenerationRequest =
+        ImageGenerationRequest(
+            prompt = prompt,
+            negative = negative,
+            width = width,
+            height = height,
+            steps = steps,
+            cfgScale = cfgScale,
+            seed = seed,
+            flashAttention = flashAttention,
+            model = diffusionModel,
+            vae = vae,
+            clipL = clipL,
+            clipG = clipG,
+            textEncoder = null,
+            splitDiffusionModel = true,
+            sequential = false,
+        )
+
+    /**
+     * Builds an [ImageGenerationRequest] for Stable Diffusion 3 Medium using the all-in-one model.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun allInOneImageRequest(
+        prompt: String,
+        negative: String = "",
+        width: Int = 512,
+        height: Int = 512,
+        steps: Int = 28,
+        cfgScale: Float = 4.5f,
+        seed: Long = -1L,
+        flashAttention: Boolean = true,
+    ): ImageGenerationRequest =
+        ImageGenerationRequest(
+            prompt = prompt,
+            negative = negative,
+            width = width,
+            height = height,
+            steps = steps,
+            cfgScale = cfgScale,
+            seed = seed,
+            flashAttention = flashAttention,
+            model = allInOneModel,
+            vae = null,
+            clipL = null,
+            clipG = null,
+            textEncoder = null,
+            splitDiffusionModel = false,
+            sequential = false,
+        )
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
@@ -276,6 +276,15 @@ class StableDiffusion internal constructor(
                 request.taesdPath,
                 request.diffusionModelPath,
                 request.llmPath,
+                request.clipLPath,
+                request.clipGPath,
+                request.clipVisionPath,
+                request.llmVisionPath,
+                request.highNoiseDiffusionModelPath,
+                request.embeddingsConnectorsPath,
+                request.audioVaePath,
+                request.controlNetPath,
+                request.photoMakerPath,
                 request.nThreads,
                 request.enableOpenCl,
                 request.useVulkan,
@@ -297,6 +306,15 @@ class StableDiffusion internal constructor(
                 taesdPath: String?,
                 diffusionModelPath: String?,
                 llmPath: String?,
+                clipLPath: String?,
+                clipGPath: String?,
+                clipVisionPath: String?,
+                llmVisionPath: String?,
+                highNoiseDiffusionModelPath: String?,
+                embeddingsConnectorsPath: String?,
+                audioVaePath: String?,
+                controlNetPath: String?,
+                photoMakerPath: String?,
                 nThreads: Int,
                 enableOpenCl: Boolean,
                 useVulkan: Boolean,
@@ -362,6 +380,7 @@ class StableDiffusion internal constructor(
                 flowShift: Float = Float.POSITIVE_INFINITY,
                 loraModelDir: String? = null,
                 loraApplyMode: LoraApplyMode = LoraApplyMode.AUTO,
+                componentPaths: StableDiffusionComponentPaths? = null,
         ): StableDiffusion =
             StableDiffusionLoader.load(
                 context = context,
@@ -394,6 +413,7 @@ class StableDiffusion internal constructor(
                         loraApplyMode = loraApplyMode,
                         preferredBackend = null,
                         allowBackendFallbackToCpu = true,
+                        componentPaths = componentPaths,
                     ),
             )
 
@@ -423,6 +443,7 @@ class StableDiffusion internal constructor(
                 // on by mocks/tests) is preserved.
                 diffusionModelPath: String? = null,
                 llmPath: String? = null,
+                componentPaths: StableDiffusionComponentPaths? = null,
         ): StableDiffusion =
             StableDiffusionLoader.load(
                 context = context,
@@ -455,6 +476,7 @@ class StableDiffusion internal constructor(
                         loraApplyMode = loraApplyMode,
                         preferredBackend = preferredBackend,
                         allowBackendFallbackToCpu = false,
+                        componentPaths = componentPaths,
                     ),
             )
 
@@ -510,6 +532,7 @@ class StableDiffusion internal constructor(
                         loraApplyMode = loraApplyMode,
                         preferredBackend = null,
                         allowBackendFallbackToCpu = true,
+                        componentPaths = null,
                     ),
                 onProgress = onProgress,
             )
@@ -542,6 +565,7 @@ class StableDiffusion internal constructor(
             loraApplyMode: LoraApplyMode,
             preferredBackend: ComputeBackend?,
             allowBackendFallbackToCpu: Boolean,
+            componentPaths: StableDiffusionComponentPaths? = null,
         ): StableDiffusionLoadRequest =
             StableDiffusionLoadRequest(
                 assets =
@@ -558,6 +582,7 @@ class StableDiffusion internal constructor(
                         forceDownload = forceDownload,
                         preferSystemDownloader = preferSystemDownloader,
                         loraModelDir = loraModelDir,
+                        componentPaths = componentPaths,
                     ),
                 runtime =
                     StableDiffusionRuntimeRequest(

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadHeuristics.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadHeuristics.kt
@@ -208,11 +208,23 @@ internal object StableDiffusionLoadHeuristics {
         t5xxlPath: String?,
         taesdPath: String?,
         loraModelDir: String?,
+        componentPaths: StableDiffusionComponentPaths? = null,
     ) {
         ModelFileValidator.requireReadableFile(modelPath, "Stable Diffusion model")
         vaePath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion VAE") }
         t5xxlPath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion text encoder") }
         taesdPath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion TAE") }
         loraModelDir?.let { ModelFileValidator.requireReadableDirectory(it, "LoRA model directory") }
+        componentPaths?.let { cp ->
+            cp.clipLPath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion clip_l encoder") }
+            cp.clipGPath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion clip_g encoder") }
+            cp.clipVisionPath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion clip_vision encoder") }
+            cp.llmVisionPath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion llm_vision encoder") }
+            cp.highNoiseDiffusionModelPath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion high_noise_diffusion_model") }
+            cp.embeddingsConnectorsPath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion embeddings_connectors") }
+            cp.audioVaePath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion audio_vae") }
+            cp.controlNetPath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion control_net") }
+            cp.photoMakerPath?.let { ModelFileValidator.requireReadableFile(it, "Stable Diffusion photo_maker") }
+        }
     }
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadRequest.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadRequest.kt
@@ -2,6 +2,29 @@ package io.aatricks.llmedge.image.diffusion
 
 import io.aatricks.llmedge.runtime.ComputeBackend
 
+data class StableDiffusionComponentPaths(
+    val clipLPath: String? = null,
+    val clipGPath: String? = null,
+    val clipVisionPath: String? = null,
+    val llmVisionPath: String? = null,
+    val highNoiseDiffusionModelPath: String? = null,
+    val embeddingsConnectorsPath: String? = null,
+    val audioVaePath: String? = null,
+    val controlNetPath: String? = null,
+    val photoMakerPath: String? = null
+) {
+    fun isAllNull(): Boolean =
+        clipLPath == null &&
+        clipGPath == null &&
+        clipVisionPath == null &&
+        llmVisionPath == null &&
+        highNoiseDiffusionModelPath == null &&
+        embeddingsConnectorsPath == null &&
+        audioVaePath == null &&
+        controlNetPath == null &&
+        photoMakerPath == null
+}
+
 internal data class StableDiffusionAssetRequest(
     val modelId: String? = null,
     val filename: String? = null,
@@ -16,6 +39,7 @@ internal data class StableDiffusionAssetRequest(
     val forceDownload: Boolean = false,
     val preferSystemDownloader: Boolean = true,
     val loraModelDir: String? = null,
+    val componentPaths: StableDiffusionComponentPaths? = null,
 )
 
 internal data class StableDiffusionRuntimeRequest(
@@ -52,6 +76,15 @@ internal data class StableDiffusionNativeLoadRequest(
     val taesdPath: String?,
     val diffusionModelPath: String? = null,
     val llmPath: String? = null,
+    val clipLPath: String? = null,
+    val clipGPath: String? = null,
+    val clipVisionPath: String? = null,
+    val llmVisionPath: String? = null,
+    val highNoiseDiffusionModelPath: String? = null,
+    val embeddingsConnectorsPath: String? = null,
+    val audioVaePath: String? = null,
+    val controlNetPath: String? = null,
+    val photoMakerPath: String? = null,
     val nThreads: Int,
     val enableOpenCl: Boolean,
     val useVulkan: Boolean,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadSupport.kt
@@ -25,6 +25,7 @@ internal data class StableDiffusionResolvedAssets(
     val llmPath: String? = null,
     // Encoder-only (FLUX.2 sequential precompute phase): load ONLY the Qwen3 encoder, no DiT.
     val encoderOnly: Boolean = false,
+    val componentPaths: StableDiffusionComponentPaths? = null,
 )
 
 internal object StableDiffusionLoadSupport {
@@ -33,14 +34,14 @@ internal object StableDiffusionLoadSupport {
     suspend fun resolveRequestedAssets(
         context: Context,
         request: StableDiffusionAssetRequest,
-        validateResolvedAssets: (String, String?, String?, String?, String?) -> Unit,
+        validateResolvedAssets: (String, String?, String?, String?, String?, StableDiffusionComponentPaths?) -> Unit,
         inferVideoModelMetadata: suspend (String, String?, String?) -> VideoModelMetadata,
         onFallback: (String) -> Unit = {},
     ): StableDiffusionResolvedAssets =
         withContext(Dispatchers.IO) {
             // Encoder-only (FLUX.2 sequential precompute): only an llmPath is supplied. Load just the
             // Qwen3 encoder so the precompute phase peaks at the encoder size, not encoder+DiT.
-            if (request.diffusionModelPath == null && request.modelPath == null && request.llmPath != null) {
+            if (request.diffusionModelPath == null && request.modelPath == null && request.llmPath != null && (request.componentPaths == null || request.componentPaths.isAllNull())) {
                 return@withContext StableDiffusionResolvedAssets(
                     modelPath = request.llmPath,
                     vaePath = null,
@@ -49,6 +50,7 @@ internal object StableDiffusionLoadSupport {
                     diffusionModelPath = null,
                     encoderOnly = true,
                     metadata = inferVideoModelMetadata(request.llmPath, request.modelId, request.filename),
+                    componentPaths = null,
                 )
             }
 
@@ -62,6 +64,7 @@ internal object StableDiffusionLoadSupport {
                     request.t5xxlPath,
                     request.taesdPath,
                     request.loraModelDir,
+                    request.componentPaths,
                 )
                 return@withContext StableDiffusionResolvedAssets(
                     modelPath = request.diffusionModelPath,
@@ -75,6 +78,7 @@ internal object StableDiffusionLoadSupport {
                             request.modelId,
                             request.filename,
                         ),
+                    componentPaths = request.componentPaths,
                 )
             }
 
@@ -85,6 +89,7 @@ internal object StableDiffusionLoadSupport {
                     request.t5xxlPath,
                     request.taesdPath,
                     request.loraModelDir,
+                    request.componentPaths,
                 )
                 return@withContext StableDiffusionResolvedAssets(
                     modelPath = request.modelPath,
@@ -96,6 +101,7 @@ internal object StableDiffusionLoadSupport {
                             request.modelId,
                             request.filename,
                         ),
+                    componentPaths = request.componentPaths,
                 )
             }
 
@@ -160,6 +166,7 @@ internal object StableDiffusionLoadSupport {
                 request.t5xxlPath,
                 request.taesdPath,
                 request.loraModelDir,
+                request.componentPaths,
             )
 
             StableDiffusionResolvedAssets(
@@ -167,6 +174,7 @@ internal object StableDiffusionLoadSupport {
                 vaePath = request.vaePath,
                 t5xxlPath = request.t5xxlPath,
                 metadata = inferVideoModelMetadata(resolvedModelPath, resolvedModelId, request.filename),
+                componentPaths = request.componentPaths,
             )
         }
 
@@ -174,7 +182,7 @@ internal object StableDiffusionLoadSupport {
         context: Context,
         request: StableDiffusionAssetRequest,
         onProgress: ((name: String, downloaded: Long, total: Long?) -> Unit)?,
-        validateResolvedAssets: (String, String?, String?, String?, String?) -> Unit,
+        validateResolvedAssets: (String, String?, String?, String?, String?, StableDiffusionComponentPaths?) -> Unit,
         inferVideoModelMetadata: suspend (String, String?, String?) -> VideoModelMetadata,
         registryEntry: WanModelEntry? = null,
     ): StableDiffusionResolvedAssets =
@@ -205,6 +213,7 @@ internal object StableDiffusionLoadSupport {
                 resolvedT5xxlPath,
                 request.taesdPath,
                 request.loraModelDir,
+                request.componentPaths,
             )
 
             StableDiffusionResolvedAssets(
@@ -214,6 +223,7 @@ internal object StableDiffusionLoadSupport {
                 metadata =
                     registryEntry?.toVideoModelMetadata(resolvedModelPath.substringAfterLast('/'))
                         ?: inferVideoModelMetadata(resolvedModelPath, modelId, request.filename),
+                componentPaths = request.componentPaths,
             )
         }
 
@@ -234,6 +244,7 @@ internal object StableDiffusionLoadSupport {
         t5xxlPath: String?,
         taesdPath: String?,
         loraModelDir: String?,
+        componentPaths: StableDiffusionComponentPaths? = null,
     ) {
         StableDiffusionLoadHeuristics.validateResolvedAssets(
             modelPath = modelPath,
@@ -241,6 +252,7 @@ internal object StableDiffusionLoadSupport {
             t5xxlPath = t5xxlPath,
             taesdPath = taesdPath,
             loraModelDir = loraModelDir,
+            componentPaths = componentPaths,
         )
     }
 
@@ -404,6 +416,15 @@ internal object StableDiffusionLoadSupport {
             taesdPath = request.assets.taesdPath,
             diffusionModelPath = resolved.diffusionModelPath,
             llmPath = resolved.llmPath,
+            clipLPath = resolved.componentPaths?.clipLPath,
+            clipGPath = resolved.componentPaths?.clipGPath,
+            clipVisionPath = resolved.componentPaths?.clipVisionPath,
+            llmVisionPath = resolved.componentPaths?.llmVisionPath,
+            highNoiseDiffusionModelPath = resolved.componentPaths?.highNoiseDiffusionModelPath,
+            embeddingsConnectorsPath = resolved.componentPaths?.embeddingsConnectorsPath,
+            audioVaePath = resolved.componentPaths?.audioVaePath,
+            controlNetPath = resolved.componentPaths?.controlNetPath,
+            photoMakerPath = resolved.componentPaths?.photoMakerPath,
             nThreads = request.runtime.nThreads,
             enableOpenCl = backend == ComputeBackend.OPENCL,
             useVulkan = backend == ComputeBackend.VULKAN,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcCodecs.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcCodecs.kt
@@ -115,6 +115,13 @@ internal object IpcCodecs {
             model = request.model?.let(::toIpc),
             vae = request.vae?.let(::toIpc),
             textEncoder = request.textEncoder?.let(::toIpc),
+            clipL = request.clipL?.let(::toIpc),
+            clipG = request.clipG?.let(::toIpc),
+            clipVision = request.clipVision?.let(::toIpc),
+            llmVision = request.llmVision?.let(::toIpc),
+            controlNet = request.controlNet?.let(::toIpc),
+            photoMaker = request.photoMaker?.let(::toIpc),
+            embeddingsConnectors = request.embeddingsConnectors?.let(::toIpc),
             splitDiffusionModel = request.splitDiffusionModel,
             sequential = request.sequential,
         )
@@ -142,6 +149,13 @@ internal object IpcCodecs {
             model = request.model?.let(::fromIpc),
             vae = request.vae?.let(::fromIpc),
             textEncoder = request.textEncoder?.let(::fromIpc),
+            clipL = request.clipL?.let(::fromIpc),
+            clipG = request.clipG?.let(::fromIpc),
+            clipVision = request.clipVision?.let(::fromIpc),
+            llmVision = request.llmVision?.let(::fromIpc),
+            controlNet = request.controlNet?.let(::fromIpc),
+            photoMaker = request.photoMaker?.let(::fromIpc),
+            embeddingsConnectors = request.embeddingsConnectors?.let(::fromIpc),
             splitDiffusionModel = request.splitDiffusionModel,
             sequential = request.sequential,
         )
@@ -173,6 +187,7 @@ internal object IpcCodecs {
             model = request.model?.let(::toIpc),
             vae = request.vae?.let(::toIpc),
             textEncoder = request.textEncoder?.let(::toIpc),
+            highNoiseDiffusionModel = request.highNoiseDiffusionModel?.let(::toIpc),
         )
 
     fun fromIpc(request: IpcVideoRequest): VideoGenerationRequest =
@@ -205,6 +220,7 @@ internal object IpcCodecs {
             model = request.model?.let(::fromIpc),
             vae = request.vae?.let(::fromIpc),
             textEncoder = request.textEncoder?.let(::fromIpc),
+            highNoiseDiffusionModel = request.highNoiseDiffusionModel?.let(::fromIpc),
         )
 
     fun toIpc(metrics: GenerationMetrics): IpcGenerationMetrics {

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcTypes.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcTypes.kt
@@ -61,6 +61,13 @@ internal data class IpcImageRequest(
     val model: IpcModelSpec?,
     val vae: IpcModelSpec?,
     val textEncoder: IpcModelSpec?,
+    val clipL: IpcModelSpec?,
+    val clipG: IpcModelSpec?,
+    val clipVision: IpcModelSpec?,
+    val llmVision: IpcModelSpec?,
+    val controlNet: IpcModelSpec?,
+    val photoMaker: IpcModelSpec?,
+    val embeddingsConnectors: IpcModelSpec?,
     val splitDiffusionModel: Boolean,
     val sequential: Boolean,
 ) : Parcelable
@@ -92,6 +99,7 @@ internal data class IpcVideoRequest(
     val model: IpcModelSpec?,
     val vae: IpcModelSpec?,
     val textEncoder: IpcModelSpec?,
+    val highNoiseDiffusionModel: IpcModelSpec?,
 ) : Parcelable
 
 /** ARGB_8888 pixel frames packed contiguously into one ashmem region. */

--- a/llmedge/src/test/cpp/test_video_jni.cpp
+++ b/llmedge/src/test/cpp/test_video_jni.cpp
@@ -40,6 +40,9 @@ extern "C" {
 JNIEXPORT jlong JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     JNIEnv* env, jclass clazz, jstring jModelPath, jstring jVaePath, jstring jT5xxlPath,
     jstring jTaesdPath, jstring jDiffusionModelPath, jstring jLlmPath,
+    jstring jClipLPath, jstring jClipGPath, jstring jClipVisionPath, jstring jLlmVisionPath,
+    jstring jHighNoiseDiffusionModelPath, jstring jEmbeddingsConnectorsPath,
+    jstring jAudioVaePath, jstring jControlNetPath, jstring jPhotoMakerPath,
     jint nThreads, jboolean enableOpenCl, jboolean useVulkan, jboolean offloadToCpu,
     jboolean keepClipOnCpu, jboolean keepVaeOnCpu, jboolean flashAttn, jboolean jvaeDecodeOnly,
     jfloat flowShift, jstring jLoraModelDir, jint jLoraApplyMode);
@@ -125,7 +128,8 @@ static bool test_nativeTxt2Vid_memory(JNIEnv* env) {
     reset_free_counters();
     jstring modelPath = env->NewStringUTF("stub-model.gguf");
         jlong handle = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
-            env, nullptr, modelPath, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
+            env, nullptr, modelPath, nullptr, nullptr, nullptr, nullptr, nullptr,
+            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
             JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
             std::numeric_limits<float>::infinity(), nullptr, 0);
     env->DeleteLocalRef(modelPath);
@@ -204,7 +208,8 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     std::cout << "Step 1: Loading T5-only context..." << std::endl;
     jstring t5Path = env->NewStringUTF("stub-t5.gguf");
         jlong t5Handle = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
-            env, nullptr, t5Path, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
+            env, nullptr, t5Path, nullptr, nullptr, nullptr, nullptr, nullptr,
+            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
             JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
             std::numeric_limits<float>::infinity(), nullptr, 0);
     env->DeleteLocalRef(t5Path);
@@ -249,7 +254,8 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     jstring modelPath = env->NewStringUTF("stub-diffusion.safetensors");
     jstring vaePath = env->NewStringUTF("stub-vae.safetensors");
         jlong diffusionHandle = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
-            env, nullptr, modelPath, vaePath, nullptr, nullptr, nullptr, nullptr, 4,
+            env, nullptr, modelPath, vaePath, nullptr, nullptr, nullptr, nullptr,
+            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
             JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
             std::numeric_limits<float>::infinity(), nullptr, 0);
     env->DeleteLocalRef(modelPath);
@@ -296,7 +302,8 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
 static bool test_progress_callback_bridge(JNIEnv* env) {
     jstring modelPath = env->NewStringUTF("stub-model.gguf");
         jlong handlePtr = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
-            env, nullptr, modelPath, nullptr, nullptr, nullptr, nullptr, nullptr, 2,
+            env, nullptr, modelPath, nullptr, nullptr, nullptr, nullptr, nullptr,
+            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 2,
             JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
             std::numeric_limits<float>::infinity(), nullptr, 0);
     env->DeleteLocalRef(modelPath);

--- a/llmedge/src/test/java/io/aatricks/llmedge/Sd3MediumLinuxE2ETest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/Sd3MediumLinuxE2ETest.kt
@@ -1,0 +1,111 @@
+package io.aatricks.llmedge
+
+import android.content.Context
+import android.graphics.Bitmap
+import io.aatricks.llmedge.image.diffusion.GenerateParams
+import io.aatricks.llmedge.image.diffusion.StableDiffusion
+import io.aatricks.llmedge.image.diffusion.StableDiffusionComponentPaths
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Desktop (host) E2E for the Stable Diffusion 3 Medium split-model path.
+ *
+ * Provide the component files via env / system properties:
+ *   LLMEDGE_TEST_SD3_DIFFUSION_PATH
+ *   LLMEDGE_TEST_SD3_CLIP_L_PATH
+ *   LLMEDGE_TEST_SD3_CLIP_G_PATH
+ *   LLMEDGE_TEST_SD3_VAE_PATH
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class Sd3MediumLinuxE2ETest {
+    private val libPathEnv = "LLMEDGE_BUILD_NATIVE_LIB_PATH"
+
+    private fun env(name: String): String? = System.getenv(name) ?: System.getProperty(name)
+
+    @Test
+    fun `desktop end-to-end SD3 Medium split-model generation`() = runBlocking {
+        val diffusionPath = env("LLMEDGE_TEST_SD3_DIFFUSION_PATH")
+        val clipLPath = env("LLMEDGE_TEST_SD3_CLIP_L_PATH")
+        val clipGPath = env("LLMEDGE_TEST_SD3_CLIP_G_PATH")
+        val vaePath = env("LLMEDGE_TEST_SD3_VAE_PATH")
+
+        Assume.assumeTrue("Diffusion model path not set", !diffusionPath.isNullOrBlank())
+        Assume.assumeTrue("CLIP_L path not set", !clipLPath.isNullOrBlank())
+        Assume.assumeTrue("CLIP_G path not set", !clipGPath.isNullOrBlank())
+        Assume.assumeTrue("VAE path not set", !vaePath.isNullOrBlank())
+
+        DesktopNativeTestSupport.requireEnabledAndLoadLibrary(
+            envName = libPathEnv,
+            defaultRelativePath = "llmedge/build/native/linux-x86_64/libsdcpp.so",
+        )
+
+        val width = 256
+        val height = 256
+        val steps = 28
+        val cfg = 4.5f
+        val seed = 42L
+        val prompt = "a red fox in snow, detailed, 8k"
+
+        val context = org.robolectric.RuntimeEnvironment.getApplication() as Context
+        val sd =
+            StableDiffusion.load(
+                context = context,
+                diffusionModelPath = diffusionPath,
+                vaePath = vaePath,
+                nThreads = Runtime.getRuntime().availableProcessors().coerceAtMost(8),
+                offloadToCpu = true,
+                keepClipOnCpu = true,
+                keepVaeOnCpu = true,
+                flashAttn = true,
+                sequentialLoad = false,
+                componentPaths = StableDiffusionComponentPaths(
+                    clipLPath = clipLPath,
+                    clipGPath = clipGPath,
+                ),
+            )
+
+        val bitmap =
+            try {
+                sd.txt2img(
+                    GenerateParams(
+                        prompt = prompt,
+                        negative = "",
+                        width = width,
+                        height = height,
+                        steps = steps,
+                        cfgScale = cfg,
+                        seed = seed,
+                    ),
+                )
+            } finally {
+                sd.close()
+            }
+
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+
+        val pixels = IntArray(width * height)
+        bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+        val uniqueColors = pixels.toSet().size
+        val nonBlank = pixels.any { (it ushr 24) != 0 && (it and 0x00FFFFFF) != 0x000000 }
+        assertTrue("Image should not be blank", nonBlank)
+        assertTrue("Expected >1 unique color, got $uniqueColors", uniqueColors > 1)
+
+        val outputDir = File("build/outputs/images")
+        outputDir.mkdirs()
+        val outputFile = File(outputDir, "sd3_medium_e2e_${width}x${height}_s${steps}_seed${seed}.png")
+        FileOutputStream(outputFile).use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+
+        println("[Sd3MediumLinuxE2ETest] uniqueColors=$uniqueColors output=${outputFile.absolutePath}")
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HFEndpointsTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HFEndpointsTest.kt
@@ -10,9 +10,9 @@ class HFEndpointsTest {
     }
 
     @Test
-    fun `modelTreeEndpoint constructs tree url`() {
+    fun `modelTreeEndpoint constructs recursive tree url`() {
         val url = HFEndpoints.modelTreeEndpoint("user/repo", "main")
-        assertEquals("https://huggingface.co/api/models/user/repo/tree/main", url)
+        assertEquals("https://huggingface.co/api/models/user/repo/tree/main?recursive=true", url)
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HFEndpointsTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HFEndpointsTest.kt
@@ -10,9 +10,9 @@ class HFEndpointsTest {
     }
 
     @Test
-    fun `modelTreeEndpoint constructs recursive tree url`() {
+    fun `modelTreeEndpoint constructs tree url`() {
         val url = HFEndpoints.modelTreeEndpoint("user/repo", "main")
-        assertEquals("https://huggingface.co/api/models/user/repo/tree/main?recursive=true", url)
+        assertEquals("https://huggingface.co/api/models/user/repo/tree/main", url)
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HFFileSelectionSupportTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HFFileSelectionSupportTest.kt
@@ -1,0 +1,46 @@
+package io.aatricks.llmedge.huggingface
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HFFileSelectionSupportTest {
+    private val extensions = listOf(".gguf", ".bin", ".safetensors", ".ckpt", ".pt")
+
+    private fun file(path: String, size: Long) =
+        HFModelTree.HFModelFile(type = "file", size = size, path = path)
+
+    private val tree =
+        listOf(
+            HFModelTree.HFModelFile(type = "directory", size = 0, path = "text_encoders"),
+            file("sd3.5_large_fp8_scaled.safetensors", 14_900_000_000L),
+            file("text_encoders/clip_l.safetensors", 250_000_000L),
+            file("text_encoders/clip_g.safetensors", 1_390_000_000L),
+            file("README.md", 1_000L),
+        )
+
+    @Test
+    fun `selectRepoFile matches subdirectory path exactly`() {
+        val selected =
+            HFFileSelectionSupport.selectRepoFile(tree, "text_encoders/clip_l.safetensors", extensions)
+        assertEquals("text_encoders/clip_l.safetensors", selected?.path)
+    }
+
+    @Test
+    fun `selectRepoFile matches by path suffix`() {
+        val selected = HFFileSelectionSupport.selectRepoFile(tree, "clip_g.safetensors", extensions)
+        assertEquals("text_encoders/clip_g.safetensors", selected?.path)
+    }
+
+    @Test
+    fun `selectRepoFile returns null instead of falling back when explicit filename is missing`() {
+        val selected = HFFileSelectionSupport.selectRepoFile(tree, "does_not_exist.safetensors", extensions)
+        assertNull(selected)
+    }
+
+    @Test
+    fun `selectRepoFile without filename picks largest allowed file`() {
+        val selected = HFFileSelectionSupport.selectRepoFile(tree, null, extensions)
+        assertEquals("sd3.5_large_fp8_scaled.safetensors", selected?.path)
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -188,6 +188,7 @@ class ImageClientTest {
                 any(),
                 any(),
                 any(),
+                any(),
             )
         } coAnswers {
             val callArgs = it.invocation.args
@@ -335,6 +336,7 @@ class ImageClientTest {
                 any(), any(), any(), any(), any(), any(), any(),
                 any(),
                 any(),
+                any(),
             )
         } coAnswers {
             val callArgs = it.invocation.args
@@ -449,6 +451,7 @@ class ImageClientTest {
                 any(), any(), any(), any(), any(), any(), any(),
                 any(), any(), any(), any(), any(), any(), any(),
                 any(), any(), any(), any(), any(), any(), any(),
+                any(),
                 any(),
                 any(),
             )
@@ -570,6 +573,7 @@ class ImageClientTest {
                 any(), any(), any(), any(), any(), any(), any(),
                 any(), any(), any(), any(), any(), any(), any(),
                 any(), any(), any(), any(), any(), any(), any(),
+                any(),
                 any(),
                 any(),
             )
@@ -700,6 +704,7 @@ class ImageClientTest {
                 any(), any(), any(), any(), any(), any(), any(),
                 any(), any(), any(), any(), any(), any(), any(),
                 any(), any(), any(), any(), any(), any(), any(),
+                any(),
                 any(),
                 any(),
             )
@@ -845,6 +850,7 @@ class ImageClientTest {
                 any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
                 any(),
                 any(),
+                any(),
             )
         } coAnswers {
             val constructor = StableDiffusion::class.java.getDeclaredConstructor(Long::class.javaPrimitiveType)
@@ -950,6 +956,7 @@ class ImageClientTest {
                 any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
                 any(),
                 any(),
+                any(),
             )
         } coAnswers {
             sleep(5)
@@ -990,6 +997,7 @@ class ImageClientTest {
             coVerify(exactly = 1) {
                 StableDiffusion.loadWithRuntimeBackend(
                     any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                    any(),
                     any(),
                     any(),
                 )
@@ -1108,6 +1116,7 @@ class ImageClientTest {
         coEvery {
             StableDiffusion.loadWithRuntimeBackend(
                 any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(),
                 any(),
                 any(),
             )
@@ -1241,6 +1250,7 @@ class ImageClientTest {
                 any(), any(), any(), any(), any(), any(), any(),
                 any(),
                 any(),
+                any(),
             )
         } coAnswers {
             val callArgs = it.invocation.args
@@ -1360,6 +1370,7 @@ class ImageClientTest {
                 any(), any(), any(), any(), any(), any(), any(),
                 any(),
                 any(),
+                any(),
             )
         } coAnswers {
             val callArgs = it.invocation.args
@@ -1395,6 +1406,185 @@ class ImageClientTest {
             assertEquals(128, bitmap.height)
             assertEquals(listOf(loraDir.absolutePath), observedLoraDirs)
             assertEquals(listOf("portrait <lora:detail-tweaker:1.0> test"), observedPrompts)
+        } finally {
+            client.close()
+            edgeScope.close()
+            StableDiffusion.resetNativeBridgeForTests()
+        }
+    }
+
+    @Test
+    fun `image generate with splitDiffusionModel and clip slots resolved componentPaths`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val baseDir = context.filesDir
+        val ditFile = java.io.File.createTempFile("split-dit", ".gguf", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+        val vaeFile = java.io.File.createTempFile("split-vae", ".safetensors", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+        val clipLFile = java.io.File.createTempFile("split-clip_l", ".safetensors", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+        val clipGFile = java.io.File.createTempFile("split-clip_g", ".safetensors", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+
+        every { RuntimeCapabilities.isStableDiffusionVulkanAvailable() } returns true
+        every { RuntimeCapabilities.isStableDiffusionOpenClAvailable() } returns false
+
+        StableDiffusion.overrideNativeBridgeForTests {
+            object : StableDiffusion.NativeBridge {
+                override fun txt2img(
+                    handle: Long, prompt: String, negative: String, width: Int, height: Int,
+                    steps: Int, cfg: Float, seed: Long, vaeTiling: Boolean,
+                    easyCacheEnabled: Boolean, easyCacheReuseThreshold: Float,
+                    easyCacheStartPercent: Float, easyCacheEndPercent: Float,
+                ): ByteArray = ByteArray(width * height * 3) { 0x33 }
+
+                override fun txt2vid(
+                    handle: Long, prompt: String, negative: String, width: Int, height: Int,
+                    videoFrames: Int, steps: Int, cfg: Float, seed: Long,
+                    sampleMethod: SampleMethod, scheduler: Scheduler, strength: Float,
+                    initImage: ByteArray?, initWidth: Int, initHeight: Int,
+                    vaceStrength: Float, easyCacheEnabled: Boolean, easyCacheReuseThreshold: Float,
+                    easyCacheStartPercent: Float, easyCacheEndPercent: Float,
+                ): Array<ByteArray> = Array(videoFrames) { ByteArray(width * height * 3) { 0x33 } }
+
+                override fun setProgressCallback(handle: Long, callback: VideoProgressCallback?) = Unit
+                override fun cancelGeneration(handle: Long) = Unit
+            }
+        }
+
+        var capturedComponentPaths: io.aatricks.llmedge.image.diffusion.StableDiffusionComponentPaths? = null
+        var capturedLlmPath: String? = "unset"
+        coEvery {
+            StableDiffusion.loadWithRuntimeBackend(
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+                any(),
+            )
+        } coAnswers {
+            val callArgs = it.invocation.args
+            capturedLlmPath = callArgs[22] as String?
+            capturedComponentPaths = callArgs[23] as io.aatricks.llmedge.image.diffusion.StableDiffusionComponentPaths?
+            val constructor = StableDiffusion::class.java.getDeclaredConstructor(Long::class.javaPrimitiveType)
+            constructor.isAccessible = true
+            constructor.newInstance(1L)
+        }
+
+        val edgeScope = LLMEdgeScope(this, 1)
+        val client =
+            ImageClient.forTesting(
+                context = context,
+                scope = edgeScope,
+                config = LLMEdgeConfig(image = ImageRuntimeConfig(preferPerformanceMode = false)),
+                resolver = DefaultModelRepository(),
+            )
+
+        try {
+            client.generate(
+                ImageGenerationRequest(
+                    prompt = "split model image",
+                    width = 64,
+                    height = 64,
+                    model = ModelSpec.localFile(ditFile),
+                    vae = ModelSpec.localFile(vaeFile),
+                    clipL = ModelSpec.localFile(clipLFile),
+                    clipG = ModelSpec.localFile(clipGFile),
+                    splitDiffusionModel = true,
+                ),
+            )
+
+            assertNotNull(capturedComponentPaths)
+            assertEquals(clipLFile.absolutePath, capturedComponentPaths?.clipLPath)
+            assertEquals(clipGFile.absolutePath, capturedComponentPaths?.clipGPath)
+            assertEquals(null, capturedLlmPath)
+        } finally {
+            client.close()
+            edgeScope.close()
+            StableDiffusion.resetNativeBridgeForTests()
+        }
+    }
+
+    @Test
+    fun `two requests identical except different clipG specs produce different cache keys and load twice`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val baseDir = context.filesDir
+        val modelFile = java.io.File.createTempFile("flux-model-cache", ".gguf", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+        val clipG1 = java.io.File.createTempFile("clipG1", ".safetensors", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+        val clipG2 = java.io.File.createTempFile("clipG2", ".safetensors", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+
+        StableDiffusion.overrideNativeBridgeForTests {
+            object : StableDiffusion.NativeBridge {
+                override fun txt2img(
+                    handle: Long, prompt: String, negative: String, width: Int, height: Int,
+                    steps: Int, cfg: Float, seed: Long, vaeTiling: Boolean,
+                    easyCacheEnabled: Boolean, easyCacheReuseThreshold: Float,
+                    easyCacheStartPercent: Float, easyCacheEndPercent: Float,
+                ): ByteArray = ByteArray(width * height * 3) { 0x33 }
+
+                override fun txt2vid(
+                    handle: Long, prompt: String, negative: String, width: Int, height: Int,
+                    videoFrames: Int, steps: Int, cfg: Float, seed: Long,
+                    sampleMethod: SampleMethod, scheduler: Scheduler, strength: Float,
+                    initImage: ByteArray?, initWidth: Int, initHeight: Int,
+                    vaceStrength: Float, easyCacheEnabled: Boolean, easyCacheReuseThreshold: Float,
+                    easyCacheStartPercent: Float, easyCacheEndPercent: Float,
+                ): Array<ByteArray>? = null
+
+                override fun setProgressCallback(handle: Long, callback: VideoProgressCallback?) = Unit
+                override fun cancelGeneration(handle: Long) = Unit
+            }
+        }
+
+        coEvery {
+            StableDiffusion.loadWithRuntimeBackend(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+                any(),
+            )
+        } coAnswers {
+            val constructor = StableDiffusion::class.java.getDeclaredConstructor(Long::class.javaPrimitiveType)
+            constructor.isAccessible = true
+            constructor.newInstance(1L)
+        }
+
+        val edgeScope = LLMEdgeScope(this, 1)
+        val client =
+            ImageClient.forTesting(
+                context = context,
+                scope = edgeScope,
+                config = LLMEdgeConfig(),
+                resolver = DefaultModelRepository(),
+            )
+
+        try {
+            client.generate(
+                ImageGenerationRequest(
+                    prompt = "cache key test 1",
+                    width = 64,
+                    height = 64,
+                    model = ModelSpec.localFile(modelFile),
+                    clipG = ModelSpec.localFile(clipG1),
+                ),
+            )
+
+            client.generate(
+                ImageGenerationRequest(
+                    prompt = "cache key test 2",
+                    width = 64,
+                    height = 64,
+                    model = ModelSpec.localFile(modelFile),
+                    clipG = ModelSpec.localFile(clipG2),
+                ),
+            )
+
+            // Should load twice because the cache keys are different due to different clipG specs
+            coVerify(exactly = 2) {
+                StableDiffusion.loadWithRuntimeBackend(
+                    any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            }
         } finally {
             client.close()
             edgeScope.close()

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -120,6 +120,58 @@ class ImageClientTest {
     }
 
     @Test
+    fun `image diffusion artifact routes to native model path when diffusionModelOnly is false`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val modelFile =
+            java.io.File.createTempFile("classic-image", ".gguf", context.filesDir).apply {
+                writeBytes(byteArrayOf(0x01))
+            }
+        val model =
+            ModelSpec.localFile(
+                modelFile,
+                ModelHints(artifactKind = ModelArtifactKind.DIFFUSION_MODEL),
+            )
+        var observedModelPath: String? = "unset"
+        var observedDiffusionModelPath: String? = "unset"
+        coEvery {
+            StableDiffusion.loadWithRuntimeBackend(
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+            )
+        } coAnswers {
+            observedModelPath = it.invocation.args[3] as String?
+            observedDiffusionModelPath = it.invocation.args[21] as String?
+            mockk(relaxed = true)
+        }
+
+        val loaded =
+            DiffusionRuntimeLoader(context, DefaultModelRepository()).load(
+                spec = DiffusionRuntimeSpec(role = DiffusionRuntimeRole.IMAGE, model = model, diffusionModelOnly = false),
+                options =
+                    DiffusionLoadOptions(
+                        subsystem = ComputeSubsystem.IMAGE,
+                        allowGpu = false,
+                        nThreads = 1,
+                        offloadToCpu = true,
+                        keepClipOnCpu = true,
+                        keepVaeOnCpu = true,
+                        flashAttn = true,
+                        preferPerformanceMode = false,
+                    ),
+                backend = ComputeBackend.CPU,
+            )
+        try {
+            assertEquals(modelFile.absolutePath, observedModelPath)
+            assertEquals(null, observedDiffusionModelPath)
+        } finally {
+            loaded.close()
+        }
+    }
+
+    @Test
     fun `sequential video generation loads text encoder before diffusion model`() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val baseDir = context.filesDir
@@ -1047,9 +1099,7 @@ class ImageClientTest {
                 metrics += requireNotNull(client.getLastGenerationMetrics()?.imageRequestMetrics)
             }
 
-            // Warm reuse: the sd.cpp context keeps its weights now that
-            // free_params_immediately is off, so the second request is a cache
-            // hit with no second load.
+            // Warm reuse makes the second request a cache hit with no second load.
             coVerify(exactly = 1) {
                 StableDiffusion.loadWithRuntimeBackend(
                     any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
@@ -43,4 +43,27 @@ class ImageRuntimeRequestPlannerTest {
         val cpuRequest = ImageRuntimeRequestPlanner.directVideoRequest(VideoGenerationRequest(prompt = "x"), cpuOnlyConfig)
         assertFalse(cpuRequest.options.allowGpu)
     }
+
+    @Test
+    fun `image request threads clip slots from request to spec`() {
+        val clipLSpec = io.aatricks.llmedge.model.ModelSpec.localFile(java.io.File("clip_l.safetensors"))
+        val clipGSpec = io.aatricks.llmedge.model.ModelSpec.localFile(java.io.File("clip_g.safetensors"))
+        val request = ImageRuntimeRequestPlanner.imageRequest(
+            ImageGenerationRequest(prompt = "x", clipL = clipLSpec, clipG = clipGSpec),
+            LLMEdgeConfig()
+        )
+        org.junit.Assert.assertEquals(clipLSpec, request.spec.clipL)
+        org.junit.Assert.assertEquals(clipGSpec, request.spec.clipG)
+        org.junit.Assert.assertNull(request.spec.vae)
+    }
+
+    @Test
+    fun `video request threads highNoiseDiffusionModel from request to spec`() {
+        val highNoiseSpec = io.aatricks.llmedge.model.ModelSpec.localFile(java.io.File("high_noise.safetensors"))
+        val request = ImageRuntimeRequestPlanner.directVideoRequest(
+            VideoGenerationRequest(prompt = "x", highNoiseDiffusionModel = highNoiseSpec),
+            LLMEdgeConfig()
+        )
+        org.junit.Assert.assertEquals(highNoiseSpec, request.spec.highNoiseDiffusionModel)
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/Sd3MediumTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/Sd3MediumTest.kt
@@ -1,0 +1,69 @@
+package io.aatricks.llmedge.image
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Sd3MediumTest {
+    @Test
+    fun testImageRequest() {
+        val request = Sd3Medium.imageRequest(
+            prompt = "A cute cat",
+            negative = "ugly",
+            width = 256,
+            height = 256,
+            steps = 28,
+            cfgScale = 4.5f,
+            seed = 42L,
+            flashAttention = true
+        )
+
+        assertEquals("A cute cat", request.prompt)
+        assertEquals("ugly", request.negative)
+        assertEquals(256, request.width)
+        assertEquals(256, request.height)
+        assertEquals(28, request.steps)
+        assertEquals(4.5f, request.cfgScale)
+        assertEquals(42L, request.seed)
+        assertTrue(request.flashAttention)
+        assertEquals(Sd3Medium.diffusionModel, request.model)
+        assertEquals(Sd3Medium.vae, request.vae)
+        assertEquals(Sd3Medium.clipL, request.clipL)
+        assertEquals(Sd3Medium.clipG, request.clipG)
+        assertNull(request.textEncoder)
+        assertTrue(request.splitDiffusionModel)
+        assertFalse(request.sequential)
+    }
+
+    @Test
+    fun testAllInOneImageRequest() {
+        val request = Sd3Medium.allInOneImageRequest(
+            prompt = "A cute cat",
+            negative = "ugly",
+            width = 256,
+            height = 256,
+            steps = 28,
+            cfgScale = 4.5f,
+            seed = 42L,
+            flashAttention = true
+        )
+
+        assertEquals("A cute cat", request.prompt)
+        assertEquals("ugly", request.negative)
+        assertEquals(256, request.width)
+        assertEquals(256, request.height)
+        assertEquals(28, request.steps)
+        assertEquals(4.5f, request.cfgScale)
+        assertEquals(42L, request.seed)
+        assertTrue(request.flashAttention)
+        assertEquals(Sd3Medium.allInOneModel, request.model)
+        assertNull(request.vae)
+        assertNull(request.clipL)
+        assertNull(request.clipG)
+        assertNull(request.textEncoder)
+        assertFalse(request.splitDiffusionModel)
+        assertFalse(request.sequential)
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IpcMarshallingTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IpcMarshallingTest.kt
@@ -117,4 +117,47 @@ class IpcMarshallingTest {
         assertEquals(metrics, decoded)
         assertEquals(metrics.imageRequestMetrics, decoded.imageRequestMetrics)
     }
+
+    @Test
+    fun `image request with custom clip specs survives codec and parcel round trip`() {
+        val request =
+            ImageGenerationRequest(
+                prompt = "a cute puppy",
+                negative = "low quality",
+                width = 512,
+                height = 512,
+                steps = 20,
+                cfgScale = 7.0f,
+                seed = 999L,
+                flashAttention = true,
+                forceSequentialLoad = false,
+                model = ModelSpec.LocalFile(File("/model.gguf")),
+                vae = ModelSpec.LocalFile(File("/vae.safetensors")),
+                clipL = ModelSpec.LocalFile(File("/clip_l.safetensors")),
+                clipG = ModelSpec.LocalFile(File("/clip_g.safetensors")),
+                splitDiffusionModel = true,
+                sequential = false,
+            )
+        val decoded = IpcCodecs.fromIpc(parcelRoundTrip(IpcCodecs.toIpc(request)))
+        assertEquals(request, decoded)
+    }
+
+    @Test
+    fun `video request with highNoiseDiffusionModel survives codec and parcel round trip`() {
+        val request =
+            io.aatricks.llmedge.image.VideoGenerationRequest(
+                prompt = "ocean waves",
+                negative = "still",
+                width = 256,
+                height = 256,
+                videoFrames = 16,
+                steps = 25,
+                cfgScale = 6.0f,
+                seed = 12345L,
+                highNoiseDiffusionModel = ModelSpec.LocalFile(File("/high_noise.safetensors")),
+                model = ModelSpec.LocalFile(File("/wan.gguf")),
+            )
+        val decoded = IpcCodecs.fromIpc(parcelRoundTrip(IpcCodecs.toIpc(request)))
+        assertEquals(request, decoded)
+    }
 }


### PR DESCRIPTION
stable-diffusion.cpp's context params grew a number of component path slots that the JNI never exposed (clip_l, clip_g, clip_vision, llm_vision, high_noise_diffusion_model, embeddings_connectors, audio_vae, control_net, photo_maker). Because of that, split-file models that need more than one text encoder couldn't be loaded at all — SD3 Medium being the obvious case (DiT + clip_l + clip_g + VAE).

Changes:

- `nativeCreate` takes the nine missing paths; Kotlin carries them in a single `StableDiffusionComponentPaths` value appended as the last parameter of `load`/`loadWithRuntimeBackend` so existing positional test stubs keep working. Future slots should go into that class rather than new parameters.
- `ImageGenerationRequest` gains clipL/clipG/clipVision/llmVision/controlNet/photoMaker/embeddingsConnectors specs, `VideoGenerationRequest` gains highNoiseDiffusionModel (Wan 2.2). All threaded through the planner, runtime cache key, asset validation, and worker IPC.
- Fixed the encoder-only routing heuristics: they now require every component slot to be empty, and the T5-only retry no longer matches filenames containing "clip" (a lone clip_l.safetensors used to get retried as a T5 encoder).
- New `Sd3Medium` presets: a T5-free split variant (~3.1 GB total: city96 Q4_0 DiT, Comfy-Org fp16 clip_l/clip_g, SD3.5 VAE) and a second-state all-in-one Q4_0 (~4.55 GB). Sequential low-RAM mode stays Flux2-only; SD3 defaults to 512x512, 28 steps, cfg 4.5.
- Tests: component-path capture and cache-key separation in ImageClientTest, planner/IPC round-trips, preset shape tests, and an Assume-gated host E2E (`Sd3MediumLinuxE2ETest`, env `LLMEDGE_TEST_SD3_*`).

Verified: NDK build green, `:llmedge:testDebugUnitTest` 339 tests / 0 failures, examples app builds. Still pending: S22 device run of the SD3 preset — the Shio-Koube VAE (diffusers tensor naming) is the one piece not yet exercised end to end; fallback is another VAE repo or the all-in-one file.

Note: PixArt Sigma was investigated and dropped — stable-diffusion.cpp has no PixArt architecture (upstream included), so it would mean porting the DiT natively.

The matching example-app preset selector (SD 1.5 / FLUX.2 / SD3 / MiniT2I) goes in a separate llmedge-examples PR that also depends on feature/minit2i-support.