### PR TITLE
Stabilize diffusion on mobile devices

### DIFF
--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/image/MiniT2IQuantVulkanE2ETest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/image/MiniT2IQuantVulkanE2ETest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 Aatricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aatricks.llmedge.image
+
+import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.aatricks.llmedge.huggingface.HuggingFaceHub
+import io.aatricks.llmedge.image.diffusion.GenerateParams
+import io.aatricks.llmedge.image.diffusion.StableDiffusion
+import io.aatricks.llmedge.image.diffusion.StableDiffusionComponentPaths
+import io.aatricks.llmedge.model.ModelSpec
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+@RunWith(AndroidJUnit4::class)
+class MiniT2IQuantVulkanE2ETest {
+
+    @Test
+    fun testMiniT2IQuantVulkanE2E() = runBlocking {
+        val enabled = InstrumentationRegistry.getArguments().getString("llmedge.minit2iQuantE2E") == "1"
+        assumeTrue("Skipping MiniT2I quant Vulkan E2E test; enable with -e llmedge.minit2iQuantE2E 1", enabled)
+
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+        // Resolve assets via MiniT2I.largeImageRequest
+        val request = MiniT2I.largeImageRequest(
+            prompt = "a red apple on a table, detailed",
+            width = 256,
+            height = 256,
+            steps = 1
+        )
+
+        val textEncoderSpec = request.textEncoder as ModelSpec.HuggingFace
+        val diffusionModelSpec = request.model as ModelSpec.HuggingFace
+
+        // Download/resume files from HuggingFace
+        val textEncoderResult = HuggingFaceHub.ensureModelOnDisk(
+            context = targetContext,
+            modelId = textEncoderSpec.repoId,
+            filename = textEncoderSpec.filename,
+            preferSystemDownloader = false
+        )
+
+        val diffusionResult = HuggingFaceHub.ensureRepoFileOnDisk(
+            context = targetContext,
+            modelId = diffusionModelSpec.repoId,
+            revision = diffusionModelSpec.revision,
+            filename = diffusionModelSpec.filename,
+            preferSystemDownloader = false
+        )
+
+        val textEncoderFile = textEncoderResult.file
+        val diffusionModelFile = diffusionResult.file
+
+        assertTrue("Text encoder file should exist", textEncoderFile.exists() && textEncoderFile.length() > 0)
+        assertTrue("Diffusion model file should exist", diffusionModelFile.exists() && diffusionModelFile.length() > 0)
+
+        // Load model with Vulkan, Q8_0 weights and tensor rules
+        val sd = StableDiffusion.load(
+            context = targetContext,
+            diffusionModelPath = diffusionModelFile.absolutePath,
+            vaePath = null,
+            t5xxlPath = textEncoderFile.absolutePath,
+            nThreads = 4,
+            forceVulkan = true,
+            componentPaths = StableDiffusionComponentPaths(
+                weightType = "q8_0",
+                tensorTypeRules = ".*mask_token.*=f16"
+            )
+        )
+
+        val bmp = try {
+            sd.txt2img(
+                GenerateParams(
+                    prompt = request.prompt,
+                    width = request.width,
+                    height = request.height,
+                    steps = request.steps,
+                    cfgScale = request.cfgScale,
+                    seed = 42L
+                )
+            )
+        } finally {
+            sd.close()
+        }
+
+        assertNotNull("Generated bitmap should not be null", bmp)
+        assertTrue("Generated bitmap should not be empty", bmp.width > 0 && bmp.height > 0)
+
+        // Write output to filesDir as minit2i-quant-e2e.png
+        val outFile = File(targetContext.filesDir, "minit2i-quant-e2e.png")
+        FileOutputStream(outFile).use { out ->
+            bmp.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+        assertTrue("Output image should exist and be non-empty", outFile.exists() && outFile.length() > 0)
+    }
+}

--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -560,7 +560,9 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
         jboolean flashAttn,
         jboolean jvaeDecodeOnly,
         jfloat flowShift,
-        jstring jLoraModelDir, jint jLoraApplyMode, jboolean jMiniT2iConditionerOnly) {
+        jstring jLoraModelDir, jint jLoraApplyMode, jboolean jMiniT2iConditionerOnly,
+        jstring jWeightType,
+        jstring jTensorTypeRules) {
     (void)clazz;
     const char* modelPath = jModelPath ? env->GetStringUTFChars(jModelPath, nullptr) : nullptr;
     const char* vaePath   = jVaePath   ? env->GetStringUTFChars(jVaePath,   nullptr) : nullptr;
@@ -568,6 +570,11 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     const char* taesdPath = jTaesdPath ? env->GetStringUTFChars(jTaesdPath, nullptr) : nullptr;
     const char* loraModelDir = jLoraModelDir ? env->GetStringUTFChars(jLoraModelDir, nullptr) : nullptr;
     const std::string loraModelDirValue = loraModelDir ? loraModelDir : "";
+
+    const char* weightTypeRaw = jWeightType ? env->GetStringUTFChars(jWeightType, nullptr) : nullptr;
+    const char* tensorTypeRulesRaw = jTensorTypeRules ? env->GetStringUTFChars(jTensorTypeRules, nullptr) : nullptr;
+    const std::string tensorTypeRulesValue = tensorTypeRulesRaw ? tensorTypeRulesRaw : "";
+    if (jTensorTypeRules && tensorTypeRulesRaw) env->ReleaseStringUTFChars(jTensorTypeRules, tensorTypeRulesRaw);
 
     // FLUX.2 / split-model loading: the diffusion transformer goes in diffusion_model_path
     // (not model_path) and the Qwen3 text encoder in llm_path. Copy into std::string so the
@@ -635,6 +642,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     ALOGI("  controlNetPath=%s", controlNetPathValue.empty() ? "NULL" : controlNetPathValue.c_str());
     ALOGI("  photoMakerPath=%s", photoMakerPathValue.empty() ? "NULL" : photoMakerPathValue.c_str());
     ALOGI("  loraModelDir=%s, loraApplyMode=%d", loraModelDirValue.empty() ? "NULL" : loraModelDirValue.c_str(), static_cast<int>(jLoraApplyMode));
+    ALOGI("  weightType=%s, tensorTypeRules=%s", weightTypeRaw && weightTypeRaw[0] != '\0' ? weightTypeRaw : "DEFAULT", tensorTypeRulesValue.empty() ? "NULL" : tensorTypeRulesValue.c_str());
     ALOGI("  enableOpenCl=%s, useVulkan=%s, offloadToCpu=%s, keepClipOnCpu=%s, keepVaeOnCpu=%s, flashAttn=%s, vaeDecodeOnly=%s",
           enableOpenCl ? "true" : "false",
           useVulkan ? "true" : "false",
@@ -693,6 +701,19 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     p.n_threads = nThreads > 0 ? nThreads : sd_get_num_physical_cores_safe();
     p.diffusion_flash_attn = flashAttn;
     p.lora_apply_mode = static_cast<enum lora_apply_mode_t>(jLoraApplyMode);
+
+    if (weightTypeRaw && weightTypeRaw[0] != '\0') {
+        enum sd_type_t parsedType = str_to_sd_type(weightTypeRaw);
+        if (parsedType == SD_TYPE_COUNT) {
+            ALOGW("Invalid weightType '%s' requested, keeping default", weightTypeRaw);
+        } else {
+            p.wtype = parsedType;
+        }
+    }
+    if (jWeightType && weightTypeRaw) {
+        env->ReleaseStringUTFChars(jWeightType, weightTypeRaw);
+    }
+    p.tensor_type_rules = tensorTypeRulesValue.empty() ? nullptr : tensorTypeRulesValue.c_str();
 
     std::string backendSpec;
     if (keepClipOnCpu == JNI_TRUE) backendSpec = "te=cpu";

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
@@ -1,6 +1,7 @@
 package io.aatricks.llmedge.image
 
 import io.aatricks.llmedge.LLMEdgeConfig
+import io.aatricks.llmedge.model.ModelSpec
 import io.aatricks.llmedge.runtime.ComputeSubsystem
 import io.aatricks.llmedge.runtime.CpuTopology
 
@@ -22,15 +23,23 @@ internal sealed interface DiffusionExecutionPlan {
 }
 
 internal object ImageRuntimeRequestPlanner {
+    private fun isMiniT2ILarge(model: ModelSpec?): Boolean {
+        return model is ModelSpec.HuggingFace &&
+            model.repoId == "MiniT2I/MiniT2I" &&
+            model.filename == "minit2i-l-16/transformer/diffusion_pytorch_model.safetensors"
+    }
+
     fun imageRequest(
         params: ImageGenerationRequest,
         config: LLMEdgeConfig,
-    ): PlannedDiffusionRuntimeRequest =
-        PlannedDiffusionRuntimeRequest(
+    ): PlannedDiffusionRuntimeRequest {
+        val modelSpec = params.model ?: config.models.image
+        val isLarge = isMiniT2ILarge(modelSpec)
+        return PlannedDiffusionRuntimeRequest(
             spec =
                 DiffusionRuntimeSpec(
                     role = DiffusionRuntimeRole.IMAGE,
-                    model = params.model ?: config.models.image,
+                    model = modelSpec,
                     vae = params.vae,
                     textEncoder = params.textEncoder,
                     t5xxl = params.t5xxl,
@@ -67,8 +76,11 @@ internal object ImageRuntimeRequestPlanner {
                     preferPerformanceMode = config.image.preferPerformanceMode,
                     loraModelDir = params.loraModelDir,
                     loraApplyMode = params.loraApplyMode,
+                    weightType = if (isLarge) "q8_0" else null,
+                    tensorTypeRules = if (isLarge) ".*mask_token.*=f16" else null,
                 ),
         )
+    }
 
     /**
      * Two-phase plan for FLUX.2 sequential low-memory generation: phase 1 loads ONLY the Qwen3
@@ -169,7 +181,13 @@ internal object ImageRuntimeRequestPlanner {
         )
         // The conditioning runtime is gone before diffusion begins, so keep diffusion weights
         // on a supported GPU instead of mirroring its multi-GB parameters in system RAM.
-        val diffusionOptions = baseOptions.copy(offloadToCpu = false)
+        val isMiniT2ILarge = isMiniT2ILarge(ditModel)
+        val isMaskedT5Profile = profile == ImageConditioningProfile.MASKED_T5
+        val diffusionOptions = baseOptions.copy(
+            offloadToCpu = false,
+            weightType = if (isMiniT2ILarge && isMaskedT5Profile) "q8_0" else null,
+            tensorTypeRules = if (isMiniT2ILarge && isMaskedT5Profile) ".*mask_token.*=f16" else null,
+        )
         return DiffusionExecutionPlan.Sequential(
             conditioningRequest =
                 PlannedDiffusionRuntimeRequest(

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
@@ -66,6 +66,8 @@ internal data class DiffusionLoadOptions(
     val flowShift: Float = Float.POSITIVE_INFINITY,
     val loraModelDir: String? = null,
     val loraApplyMode: LoraApplyMode = LoraApplyMode.AUTO,
+    val weightType: String? = null,
+    val tensorTypeRules: String? = null,
 )
 
 internal class ManagedDiffusionModel(
@@ -284,6 +286,8 @@ internal class DiffusionRuntimeLoader(
                 controlNetPath = resolvedControlNet?.absolutePath,
                 photoMakerPath = resolvedPhotoMaker?.absolutePath,
                 miniT2iConditionerOnly = miniT2iConditionerOnly,
+                weightType = options.weightType,
+                tensorTypeRules = options.tensorTypeRules,
             )
             if (paths.isAllNull()) null else paths
         }
@@ -385,6 +389,8 @@ internal fun createDiffusionRuntimePool(
                         "flowShift=${options.flowShift}",
                         "loraDir=${options.loraModelDir}",
                         "loraMode=${options.loraApplyMode.id}",
+                        "weightType=${options.weightType}",
+                        "tensorTypeRules=${options.tensorTypeRules}",
                     )
                 },
                 loadRuntime = DiffusionRuntimeLoader(context, resolver, phaseListener)::load,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
@@ -297,6 +297,8 @@ class StableDiffusion internal constructor(
                 request.loraModelDir,
                 request.loraApplyMode.id,
                 request.miniT2iConditionerOnly,
+                request.weightType,
+                request.tensorTypeRules,
             )
 
         @JvmStatic
@@ -328,6 +330,8 @@ class StableDiffusion internal constructor(
                 loraModelDir: String?,
                 loraApplyMode: Int,
                 miniT2iConditionerOnly: Boolean,
+                weightType: String?,
+                tensorTypeRules: String?,
         ): Long
 
         @JvmStatic

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadRequest.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadRequest.kt
@@ -14,6 +14,10 @@ data class StableDiffusionComponentPaths(
     val photoMakerPath: String? = null,
     // Private encoder-only routing signal; this is not a model path.
     val miniT2iConditionerOnly: Boolean = false,
+    /** Weight quantization type to override on load (e.g. "q8_0"). */
+    val weightType: String? = null,
+    /** Per-tensor type rules pattern (e.g. ".*mask_token.*=f16"). */
+    val tensorTypeRules: String? = null,
 ) {
     fun isAllNull(): Boolean =
         clipLPath == null &&
@@ -25,6 +29,8 @@ data class StableDiffusionComponentPaths(
         audioVaePath == null &&
         controlNetPath == null &&
         photoMakerPath == null &&
+        weightType == null &&
+        tensorTypeRules == null &&
         !miniT2iConditionerOnly
 }
 
@@ -100,4 +106,6 @@ internal data class StableDiffusionNativeLoadRequest(
     val loraModelDir: String?,
     val loraApplyMode: LoraApplyMode,
     val miniT2iConditionerOnly: Boolean = false,
+    val weightType: String? = null,
+    val tensorTypeRules: String? = null,
 )

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadSupport.kt
@@ -467,6 +467,8 @@ internal object StableDiffusionLoadSupport {
             loraModelDir = request.assets.loraModelDir,
             loraApplyMode = request.runtime.loraApplyMode,
             miniT2iConditionerOnly = resolved.componentPaths?.miniT2iConditionerOnly == true,
+            weightType = resolved.componentPaths?.weightType,
+            tensorTypeRules = resolved.componentPaths?.tensorTypeRules,
         )
 
     private fun nativeCreateOrThrow(

--- a/llmedge/src/main/java/io/aatricks/llmedge/runtime/CpuTopology.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/runtime/CpuTopology.kt
@@ -161,14 +161,20 @@ object CpuTopology {
                 }
             }
             TaskType.DIFFUSION -> {
-                // Revert to prior behavior: use all available CPU cores for maximum throughput.
-                // This restores the faster generation speed observed before the facade refactor.
-                Runtime.getRuntime().availableProcessors().coerceAtLeast(2)
+                selectDiffusionThreadCount(coreInfo, Runtime.getRuntime().availableProcessors())
             }
             TaskType.LIGHT_TASK -> {
                 // Use 1-2 cores for quick operations
                 2
             }
+        }
+    }
+
+    internal fun selectDiffusionThreadCount(coreInfo: CoreInfo, availableProcessors: Int): Int {
+        return if (coreInfo.efficiencyCores > 0) {
+            (availableProcessors - 1).coerceAtLeast(2)
+        } else {
+            availableProcessors.coerceAtLeast(2)
         }
     }
 

--- a/llmedge/src/test/cpp/test_video_jni.cpp
+++ b/llmedge/src/test/cpp/test_video_jni.cpp
@@ -45,7 +45,8 @@ JNIEXPORT jlong JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion
     jstring jAudioVaePath, jstring jControlNetPath, jstring jPhotoMakerPath,
     jint nThreads, jboolean enableOpenCl, jboolean useVulkan, jboolean offloadToCpu,
     jboolean keepClipOnCpu, jboolean keepVaeOnCpu, jboolean flashAttn, jboolean jvaeDecodeOnly,
-    jfloat flowShift, jstring jLoraModelDir, jint jLoraApplyMode, jboolean jMiniT2iConditionerOnly);
+    jfloat flowShift, jstring jLoraModelDir, jint jLoraApplyMode, jboolean jMiniT2iConditionerOnly,
+    jstring jWeightType, jstring jTensorTypeRules);
 JNIEXPORT void JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(JNIEnv* env, jobject thiz, jlong handlePtr);
 JNIEXPORT jobjectArray JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Vid(
     JNIEnv* env, jobject thiz, jlong handlePtr,
@@ -131,7 +132,7 @@ static bool test_nativeTxt2Vid_memory(JNIEnv* env) {
             env, nullptr, modelPath, nullptr, nullptr, nullptr, nullptr, nullptr,
             nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
             JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
-            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE);
+            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, nullptr, nullptr);
     env->DeleteLocalRef(modelPath);
     if (handle == 0) {
         std::cerr << "nativeCreate returned null handle" << std::endl;
@@ -208,10 +209,10 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
     std::cout << "Step 1: Loading T5-only context..." << std::endl;
     jstring t5Path = env->NewStringUTF("stub-t5.gguf");
         jlong t5Handle = Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
-            env, nullptr, t5Path, nullptr, nullptr, nullptr, nullptr, nullptr,
-            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
-            JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
-            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE);
+        env, nullptr, t5Path, nullptr, nullptr, nullptr, nullptr, nullptr,
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
+        JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
+        std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, nullptr, nullptr);
     env->DeleteLocalRef(t5Path);
     
     if (t5Handle == 0) {
@@ -257,7 +258,7 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
             env, nullptr, modelPath, vaePath, nullptr, nullptr, nullptr, nullptr,
             nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
             JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
-            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE);
+            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, nullptr, nullptr);
     env->DeleteLocalRef(modelPath);
     env->DeleteLocalRef(vaePath);
     
@@ -305,7 +306,7 @@ static bool test_progress_callback_bridge(JNIEnv* env) {
             env, nullptr, modelPath, nullptr, nullptr, nullptr, nullptr, nullptr,
             nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 2,
             JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
-            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE);
+            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, nullptr, nullptr);
     env->DeleteLocalRef(modelPath);
     if (handlePtr == 0) {
         std::cerr << "Failed to create handle for progress test" << std::endl;

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -13,6 +13,14 @@ import io.aatricks.llmedge.image.diffusion.SampleMethod
 import io.aatricks.llmedge.image.diffusion.Scheduler
 import io.aatricks.llmedge.image.diffusion.VideoModelMetadata
 import io.aatricks.llmedge.image.diffusion.VideoProgressCallback
+import io.aatricks.llmedge.image.diffusion.StableDiffusionLoadRequest
+import io.aatricks.llmedge.image.diffusion.StableDiffusionNativeLoadRequest
+import io.aatricks.llmedge.image.diffusion.StableDiffusionAssetRequest
+import io.aatricks.llmedge.image.diffusion.StableDiffusionRuntimeRequest
+import io.aatricks.llmedge.image.diffusion.StableDiffusionBackendRequest
+import io.aatricks.llmedge.image.diffusion.LoraApplyMode
+import io.aatricks.llmedge.image.diffusion.StableDiffusionComponentPaths
+import io.aatricks.llmedge.image.diffusion.internal.StableDiffusionLoader
 import io.aatricks.llmedge.core.LLMEdgeScope
 import io.aatricks.llmedge.model.DefaultModelRepository
 import io.aatricks.llmedge.model.ModelArtifactKind
@@ -2126,6 +2134,62 @@ class ImageClientTest {
     }
 
     @Test
+    fun `StableDiffusionLoader load propagates weightType and tensorTypeRules`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val baseDir = context.filesDir
+        val dummyFile = java.io.File.createTempFile("dummy", ".gguf", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+        var observedRequest: io.aatricks.llmedge.image.diffusion.StableDiffusionNativeLoadRequest? = null
+
+        mockkObject(StableDiffusion.Companion)
+        every {
+            StableDiffusion.Companion.supportNativeCreate(any())
+        } answers {
+            observedRequest = it.invocation.args[0] as io.aatricks.llmedge.image.diffusion.StableDiffusionNativeLoadRequest
+            1L
+        }
+
+        try {
+            val loadRequest = StableDiffusionLoadRequest(
+                assets = StableDiffusionAssetRequest(
+                    modelPath = dummyFile.absolutePath,
+                    componentPaths = StableDiffusionComponentPaths(
+                        weightType = "q8_0",
+                        tensorTypeRules = ".*mask_token.*=f16",
+                    ),
+                ),
+                runtime = StableDiffusionRuntimeRequest(
+                    nThreads = 1,
+                    offloadToCpu = false,
+                    keepClipOnCpu = false,
+                    keepVaeOnCpu = false,
+                    flashAttn = true,
+                    vaeDecodeOnly = true,
+                    sequentialLoad = false,
+                    preferPerformanceMode = false,
+                    flowShift = Float.POSITIVE_INFINITY,
+                    loraApplyMode = LoraApplyMode.AUTO,
+                ),
+                backend = StableDiffusionBackendRequest(
+                    allowOpenCl = false,
+                    allowVulkan = false,
+                    forceVulkan = false,
+                    allowBackendFallbackToCpu = true,
+                ),
+            )
+
+            val loaded = StableDiffusionLoader.load(context, loadRequest)
+            loaded.close()
+
+            assertNotNull(observedRequest)
+            assertEquals("q8_0", observedRequest?.weightType)
+            assertEquals(".*mask_token.*=f16", observedRequest?.tensorTypeRules)
+        } finally {
+            dummyFile.delete()
+            StableDiffusion.resetNativeBridgeForTests()
+        }
+    }
+
+    @Test
     fun `pure condition combination yields the expected arrays and dims and rejects mismatches`() {
         val condA = PrecomputedCondition(
             cCrossAttn = floatArrayOf(1.0f, 2.0f),
@@ -2570,6 +2634,58 @@ class ImageClientTest {
         } finally {
             runtimePool.close()
             scope.close()
+        }
+    }
+
+    @Test
+    fun `createDiffusionRuntimePool cache key differentiates quantized and default runtimes`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val dummyFile = java.io.File(context.filesDir, "dummy_model.safetensors").apply { writeBytes(byteArrayOf(0x01)) }
+        val fakeRepo = object : io.aatricks.llmedge.model.ModelRepository {
+            override suspend fun resolve(
+                context: Context,
+                spec: ModelSpec,
+                onProgress: ((io.aatricks.llmedge.core.ProgressEvent.Downloading) -> Unit)?,
+            ): java.io.File = dummyFile
+        }
+
+        mockkObject(StableDiffusion.Companion)
+        val capturedRequests = mutableListOf<StableDiffusionNativeLoadRequest>()
+        every {
+            StableDiffusion.Companion.supportNativeCreate(capture(capturedRequests))
+        } returns 1L
+
+        val config = LLMEdgeConfig()
+        val scope = LLMEdgeScope(this, 1)
+        val runtimePool = createDiffusionRuntimePool(context, scope, config, fakeRepo)
+
+        try {
+            val largeRequestDirect = ImageRuntimeRequestPlanner.imageRequest(MiniT2I.largeImageRequest("x"), config)
+            val standardRequestDirect = ImageRuntimeRequestPlanner.imageRequest(MiniT2I.imageRequest("x"), config)
+
+            val resultLarge = runtimePool.coordinator.acquireDetailed(largeRequestDirect.spec, largeRequestDirect.options)
+            val resultStandard = runtimePool.coordinator.acquireDetailed(standardRequestDirect.spec, standardRequestDirect.options)
+
+            assertTrue(resultLarge.keyPrefix.contains("weightType=q8_0"))
+            assertTrue(resultLarge.keyPrefix.contains("tensorTypeRules=.*mask_token.*=f16"))
+
+            assertTrue(resultStandard.keyPrefix.contains("weightType=null"))
+            assertTrue(resultStandard.keyPrefix.contains("tensorTypeRules=null"))
+
+            org.junit.Assert.assertNotEquals(resultLarge.keyPrefix, resultStandard.keyPrefix)
+
+            val largeReq = capturedRequests.find { it.weightType == "q8_0" }
+            val standardReq = capturedRequests.find { it.weightType == null }
+
+            org.junit.Assert.assertNotNull(largeReq)
+            org.junit.Assert.assertNotNull(standardReq)
+            assertEquals(".*mask_token.*=f16", largeReq?.tensorTypeRules)
+            org.junit.Assert.assertNull(standardReq?.tensorTypeRules)
+        } finally {
+            runtimePool.close()
+            scope.close()
+            dummyFile.delete()
+            StableDiffusion.resetNativeBridgeForTests()
         }
     }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
@@ -181,4 +181,57 @@ class ImageRuntimeRequestPlannerTest {
         org.junit.Assert.assertNull(plan.diffusionRequest.spec.textEncoder)
         assertFalse(plan.diffusionRequest.options.offloadToCpu)
     }
+
+    @Test
+    fun `MiniT2I large request selects correct quant options in direct planning`() {
+        val config = LLMEdgeConfig()
+        val request = MiniT2I.largeImageRequest("test prompt")
+        val plan = ImageRuntimeRequestPlanner.imageRequest(request, config)
+        org.junit.Assert.assertEquals("q8_0", plan.options.weightType)
+        org.junit.Assert.assertEquals(".*mask_token.*=f16", plan.options.tensorTypeRules)
+    }
+
+    @Test
+    fun `MiniT2I large request selects correct quant options in sequential diffusion planning`() {
+        val config = LLMEdgeConfig()
+        val request = MiniT2I.largeImageRequest("test prompt")
+        val plan = ImageRuntimeRequestPlanner.imageSequentialPlan(request, config)
+        org.junit.Assert.assertEquals("q8_0", plan.diffusionRequest.options.weightType)
+        org.junit.Assert.assertEquals(".*mask_token.*=f16", plan.diffusionRequest.options.tensorTypeRules)
+    }
+
+    @Test
+    fun `MiniT2I large sequential conditioning options remain null`() {
+        val config = LLMEdgeConfig()
+        val request = MiniT2I.largeImageRequest("test prompt")
+        val plan = ImageRuntimeRequestPlanner.imageSequentialPlan(request, config)
+        org.junit.Assert.assertNull(plan.conditioningRequest.options.weightType)
+        org.junit.Assert.assertNull(plan.conditioningRequest.options.tensorTypeRules)
+    }
+
+    @Test
+    fun `MiniT2I equivalent HF spec selects correct quant options`() {
+        val config = LLMEdgeConfig()
+        val spec = ModelSpec.huggingFace(
+            repoId = "MiniT2I/MiniT2I",
+            filename = "minit2i-l-16/transformer/diffusion_pytorch_model.safetensors"
+        )
+        val request = MiniT2I.largeImageRequest("test prompt").copy(model = spec)
+        val plan = ImageRuntimeRequestPlanner.imageRequest(request, config)
+        org.junit.Assert.assertEquals("q8_0", plan.options.weightType)
+        org.junit.Assert.assertEquals(".*mask_token.*=f16", plan.options.tensorTypeRules)
+    }
+
+    @Test
+    fun `MiniT2I small or default request options remain null`() {
+        val config = LLMEdgeConfig()
+        val request = MiniT2I.imageRequest("test prompt")
+        val plan = ImageRuntimeRequestPlanner.imageRequest(request, config)
+        org.junit.Assert.assertNull(plan.options.weightType)
+        org.junit.Assert.assertNull(plan.options.tensorTypeRules)
+
+        val sequentialPlan = ImageRuntimeRequestPlanner.imageSequentialPlan(request, config)
+        org.junit.Assert.assertNull(sequentialPlan.diffusionRequest.options.weightType)
+        org.junit.Assert.assertNull(sequentialPlan.diffusionRequest.options.tensorTypeRules)
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/runtime/CpuTopologyTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/runtime/CpuTopologyTest.kt
@@ -1,0 +1,38 @@
+package io.aatricks.llmedge.runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CpuTopologyTest {
+
+    @Test
+    fun `homogeneous topology keeps all available processors with a floor of 2`() {
+        val homogeneousCoreInfo = CpuTopology.CoreInfo(
+            totalCores = 8,
+            performanceCores = 8,
+            efficiencyCores = 0,
+            maxFrequencies = listOf(2000L, 2000L, 2000L, 2000L, 2000L, 2000L, 2000L, 2000L)
+        )
+
+        assertEquals(8, CpuTopology.selectDiffusionThreadCount(homogeneousCoreInfo, 8))
+        assertEquals(4, CpuTopology.selectDiffusionThreadCount(homogeneousCoreInfo, 4))
+        assertEquals(2, CpuTopology.selectDiffusionThreadCount(homogeneousCoreInfo, 2))
+        assertEquals(2, CpuTopology.selectDiffusionThreadCount(homogeneousCoreInfo, 1))
+    }
+
+    @Test
+    fun `heterogeneous topology with efficiency cores reserves exactly one available processor with a floor of 2`() {
+        val heterogeneousCoreInfo = CpuTopology.CoreInfo(
+            totalCores = 8,
+            performanceCores = 4,
+            efficiencyCores = 4,
+            maxFrequencies = listOf(2800L, 2800L, 2800L, 2800L, 1800L, 1800L, 1800L, 1800L)
+        )
+
+        assertEquals(7, CpuTopology.selectDiffusionThreadCount(heterogeneousCoreInfo, 8))
+        assertEquals(3, CpuTopology.selectDiffusionThreadCount(heterogeneousCoreInfo, 4))
+        assertEquals(2, CpuTopology.selectDiffusionThreadCount(heterogeneousCoreInfo, 3))
+        assertEquals(2, CpuTopology.selectDiffusionThreadCount(heterogeneousCoreInfo, 2))
+        assertEquals(2, CpuTopology.selectDiffusionThreadCount(heterogeneousCoreInfo, 1))
+    }
+}


### PR DESCRIPTION
## Summary
- load MiniT2I Large with Q8_0 while keeping mask tokens in F16
- reserve one CPU core for Android runtime work on heterogeneous devices
- add unit and S22 Vulkan regression coverage

## Checks
- `:llmedge:testDebugUnitTest`
- `:llmedge:assembleDebugAndroidTest`
- examples debug APK build
- MiniT2I Large 256x256 generation on S22 Vulkan