### PR TITLE
Add Chroma Radiance and safer Wan video loading

### DIFF
--- a/llmedge/src/main/java/io/aatricks/llmedge/core/LLMEdgeException.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/core/LLMEdgeException.kt
@@ -34,6 +34,15 @@ class InvalidModelStateException(
 class InvalidGenerationParametersException(detail: String) :
     IllegalArgumentException(detail)
 
+class InsufficientMemoryException(
+    val requiredBytes: Long,
+    val availableBytes: Long,
+    operation: String,
+) : LLMEdgeException(
+    "Insufficient memory for $operation: requires approximately " +
+        "${requiredBytes / (1024L * 1024L)}MB with ${availableBytes / (1024L * 1024L)}MB safely available.",
+)
+
 class InvalidModelFileException(
     val modelPath: String,
     detail: String,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ChromaRadiance.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ChromaRadiance.kt
@@ -1,0 +1,70 @@
+package io.aatricks.llmedge.image
+
+import io.aatricks.llmedge.model.ModelArtifactKind
+import io.aatricks.llmedge.model.ModelCapability
+import io.aatricks.llmedge.model.ModelHints
+import io.aatricks.llmedge.model.ModelSpec
+
+/**
+ * Chroma Radiance presets for on-device generation.
+ */
+object ChromaRadiance {
+    /** The Chroma Radiance DiT model. */
+    @JvmField
+    val diffusionModel: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "silveroxides/Chroma1-Radiance-GGUF",
+            filename = "Chroma1-Radiance-v0.3/Chroma1-Radiance-v0.3-Q4_K_S.gguf",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.DIFFUSION_MODEL,
+                    capabilities = setOf(ModelCapability.IMAGE),
+                ),
+        )
+
+    /** T5XXL FP8 text encoder. */
+    @JvmField
+    val t5xxl: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "comfyanonymous/flux_text_encoders",
+            filename = "t5xxl_fp8_e4m3fn.safetensors",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.TEXT_ENCODER,
+                    capabilities = setOf(ModelCapability.TEXT, ModelCapability.IMAGE),
+                ),
+        )
+
+    /**
+     * Builds an [ImageGenerationRequest] pre-wired for Chroma Radiance.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun imageRequest(
+        prompt: String,
+        negative: String = "",
+        width: Int = 512,
+        height: Int = 512,
+        steps: Int = 20,
+        cfgScale: Float = 4.0f,
+        seed: Long = -1L,
+        flashAttention: Boolean = true,
+        sequential: Boolean? = true,
+    ): ImageGenerationRequest =
+        ImageGenerationRequest(
+            prompt = prompt,
+            negative = negative,
+            width = width,
+            height = height,
+            steps = steps,
+            cfgScale = cfgScale,
+            seed = seed,
+            flashAttention = flashAttention,
+            model = diffusionModel,
+            t5xxl = t5xxl,
+            splitDiffusionModel = true,
+            sequential = sequential,
+        )
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
@@ -72,6 +72,7 @@ data class VideoGenerationRequest(
     val seed: Long = -1L,
     val flowShift: Float = Float.POSITIVE_INFINITY,
     val flashAttention: Boolean = true,
+    /** True forces staged loading; false chooses direct or staged loading from resolved sizes and current memory headroom. */
     val forceSequentialLoad: Boolean = false,
     val initImage: Bitmap? = null,
     val strength: Float = 1.0f,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageExecutionPlanner.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageExecutionPlanner.kt
@@ -17,6 +17,7 @@ internal enum class ImageConditioningProfile {
     LLM,
     SD3_CLIP_T5,
     MASKED_T5,
+    CHROMA_T5,
 }
 
 internal enum class ImageExecutionComponentKind {
@@ -91,6 +92,11 @@ internal object ImageExecutionPlanner {
                         listOf(ImageExecutionComponentKind.T5XXL),
                         diffusionPhase,
                     ),
+                )
+            params.splitDiffusionModel && params.t5xxl != null && params.clipL == null && params.clipG == null ->
+                ImageExecutionRecipe(
+                    profile = ImageConditioningProfile.CHROMA_T5,
+                    phases = listOf(listOf(ImageExecutionComponentKind.T5XXL), diffusionPhase),
                 )
             params.splitDiffusionModel && params.textEncoder != null ->
                 ImageExecutionRecipe(

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageGenerationExecutor.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageGenerationExecutor.kt
@@ -62,12 +62,14 @@ internal class ImageGenerationExecutor(
     ): Bitmap {
         state.resetForRequest()
         val isSd3 = profile == ImageConditioningProfile.SD3_CLIP_T5
+        val isChroma = profile == ImageConditioningProfile.CHROMA_T5
         val plan = ImageRuntimeRequestPlanner.imageSequentialPlan(params, config, profile)
         val requestId = imageRequestIds.incrementAndGet()
         val modelName =
             when (profile) {
                 ImageConditioningProfile.LLM -> "LLM"
                 ImageConditioningProfile.SD3_CLIP_T5 -> "SD3"
+                ImageConditioningProfile.CHROMA_T5 -> "Chroma"
                 ImageConditioningProfile.MASKED_T5 -> "masked-T5"
                 ImageConditioningProfile.NONE -> error("Sequential image execution requires a conditioning profile")
             }
@@ -125,6 +127,31 @@ internal class ImageGenerationExecutor(
 
             cond = if (condCLIP != null && condT5 != null) combineSD3Condition(condCLIP, condT5) else null
             uncond = if (uncondCLIP != null && uncondT5 != null) combineSD3Condition(uncondCLIP, uncondT5) else null
+        } else if (isChroma) {
+            val condChroma = requestExecutor.withRuntimeModel(
+                spec = plan.conditioningRequest.spec,
+                options = plan.conditioningRequest.options,
+                retryMessage = "Retrying $modelName sequential conditioning positive on the next backend for",
+            ) { model, _, acquire ->
+                phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.GENERATING, acquire.backend.name)
+                model.precomputeCondition(params.prompt, "", params.width, params.height, -1)
+            }
+            val uncondChroma = requestExecutor.withRuntimeModel(
+                spec = plan.conditioningRequest.spec,
+                options = plan.conditioningRequest.options,
+                retryMessage = "Retrying $modelName sequential conditioning negative on the next backend for",
+            ) { model, _, _ ->
+                model.precomputeCondition(params.negative, "", params.width, params.height, -1)
+            }
+
+            requestExecutor.invalidateRuntime(
+                plan.conditioningRequest.spec,
+                plan.conditioningRequest.options,
+            )
+            AndroidLogAdapter.i(logTag, "$modelName sequential: Chroma encoder runtime invalidated before diffusion phase")
+
+            cond = condChroma
+            uncond = uncondChroma
         } else {
             val condAndUncond = requestExecutor.withRuntimeModel(
                 spec = plan.conditioningRequest.spec,
@@ -159,7 +186,7 @@ internal class ImageGenerationExecutor(
             val rgb =
                 model.txt2ImgWithPrecomputedCondition(
                     prompt = params.prompt,
-                    negative = if (isSd3) params.negative else "",
+                    negative = if (isSd3 || isChroma) params.negative else "",
                     width = params.width,
                     height = params.height,
                     steps = params.steps,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
@@ -96,6 +96,7 @@ internal object ImageRuntimeRequestPlanner {
             "Sequential image generation requires a splittable conditioning profile"
         }
         val isSd3 = profile == ImageConditioningProfile.SD3_CLIP_T5
+        val isChromaT5 = profile == ImageConditioningProfile.CHROMA_T5
         val isMaskedT5 = profile == ImageConditioningProfile.MASKED_T5
         val ditModel = params.model ?: config.models.image
         val baseOptions =
@@ -134,6 +135,18 @@ internal object ImageRuntimeRequestPlanner {
                 clipG = null,
                 encoderOnly = true,
             )
+        } else if (isChromaT5) {
+            val t5xxl = params.t5xxl ?: error("Chroma sequential conditioning requires a t5xxl model")
+            conditioningSpec = DiffusionRuntimeSpec(
+                role = DiffusionRuntimeRole.IMAGE,
+                model = t5xxl,
+                t5xxl = t5xxl,
+                clipL = null,
+                clipG = null,
+                encoderOnly = true,
+                conditioningProfile = profile,
+            )
+            conditioningSpec2 = null
         } else {
             val encoderSpec = params.textEncoder ?: error("sequential image generation requires a textEncoder")
             conditioningSpec = DiffusionRuntimeSpec(
@@ -146,7 +159,7 @@ internal object ImageRuntimeRequestPlanner {
         }
         val diffusionSpec =
             when {
-                isSd3 ->
+                isSd3 || isChromaT5 ->
                     DiffusionRuntimeSpec(
                         role = DiffusionRuntimeRole.IMAGE,
                         model = ditModel,
@@ -192,7 +205,7 @@ internal object ImageRuntimeRequestPlanner {
             conditioningRequest =
                 PlannedDiffusionRuntimeRequest(
                     spec = conditioningSpec,
-                    options = conditioningOptions,
+                    options = if (isChromaT5) t5ConditioningOptions else conditioningOptions,
                 ),
             conditioningRequest2 = conditioningSpec2?.let {
                 PlannedDiffusionRuntimeRequest(
@@ -233,8 +246,9 @@ internal object ImageRuntimeRequestPlanner {
     fun videoPlan(
         params: VideoGenerationRequest,
         config: LLMEdgeConfig,
+        sequentialLoad: Boolean = params.forceSequentialLoad,
     ): DiffusionExecutionPlan =
-        if (params.forceSequentialLoad) {
+        if (sequentialLoad) {
             DiffusionExecutionPlan.Sequential(
                 conditioningRequest = sequentialVideoConditioningRequest(params, config),
                 diffusionRequest = sequentialVideoDiffusionRequest(params, config),

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/VideoExecutionPlanner.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/VideoExecutionPlanner.kt
@@ -1,0 +1,220 @@
+package io.aatricks.llmedge.image
+
+import android.app.ActivityManager
+import android.content.Context
+import io.aatricks.llmedge.LLMEdgeConfig
+import io.aatricks.llmedge.core.AndroidLogAdapter
+import io.aatricks.llmedge.core.InsufficientMemoryException
+import io.aatricks.llmedge.model.ModelRepository
+import io.aatricks.llmedge.model.ModelSpec
+import kotlin.math.max
+
+internal data class VideoComponentSizes(
+    val diffusionBytes: Long,
+    val vaeBytes: Long,
+    val textEncoderBytes: Long,
+    val highNoiseDiffusionBytes: Long = 0L,
+)
+
+internal data class VideoMemorySnapshot(
+    val availableSystemBytes: Long,
+    val lowMemoryThresholdBytes: Long,
+    val totalSystemBytes: Long,
+)
+
+internal data class VideoExecutionDecision(
+    val mode: ImageExecutionMode,
+    val reason: String,
+    val directPeakBytes: Long,
+    val sequentialPeakBytes: Long,
+    val safeBudgetBytes: Long,
+)
+
+internal object VideoExecutionPlanner {
+    private const val MEBIBYTE = 1024L * 1024L
+    private const val MIN_DEVICE_RESERVE_BYTES = 512L * MEBIBYTE
+    private const val MIN_WORKSPACE_BYTES = 256L * MEBIBYTE
+
+    fun decide(
+        forceSequentialLoad: Boolean,
+        sizes: VideoComponentSizes,
+        memory: VideoMemorySnapshot,
+    ): VideoExecutionDecision {
+        val budget = safeBudgetBytes(memory)
+        val directPeak =
+            estimatePeakBytes(
+                sizes.diffusionBytes,
+                sizes.vaeBytes,
+                sizes.textEncoderBytes,
+                sizes.highNoiseDiffusionBytes,
+                memory = memory,
+            )
+        val sequentialPeak =
+            max(
+                estimatePeakBytes(sizes.textEncoderBytes, memory = memory),
+                estimatePeakBytes(
+                    sizes.diffusionBytes,
+                    sizes.vaeBytes,
+                    sizes.highNoiseDiffusionBytes,
+                    memory = memory,
+                ),
+            )
+        if (memory.availableSystemBytes <= 0L || memory.totalSystemBytes <= 0L) {
+            return VideoExecutionDecision(
+                mode = if (forceSequentialLoad) ImageExecutionMode.SEQUENTIAL else ImageExecutionMode.DIRECT,
+                reason = if (forceSequentialLoad) "FORCED_SEQUENTIAL" else "AUTO_DIRECT_MEMORY_UNAVAILABLE",
+                directPeakBytes = directPeak,
+                sequentialPeakBytes = sequentialPeak,
+                safeBudgetBytes = budget,
+            )
+        }
+        if (sequentialPeak > budget) {
+            throw InsufficientMemoryException(
+                requiredBytes = sequentialPeak,
+                availableBytes = budget,
+                operation = "sequential video loading",
+            )
+        }
+        if (forceSequentialLoad) {
+            return VideoExecutionDecision(
+                mode = ImageExecutionMode.SEQUENTIAL,
+                reason = "FORCED_SEQUENTIAL",
+                directPeakBytes = directPeak,
+                sequentialPeakBytes = sequentialPeak,
+                safeBudgetBytes = budget,
+            )
+        }
+        val directWithSafetyMargin = saturatingMultiply(directPeak, 2L)
+        return if (directWithSafetyMargin <= budget) {
+            VideoExecutionDecision(
+                mode = ImageExecutionMode.DIRECT,
+                reason = "AUTO_DIRECT_HEADROOM",
+                directPeakBytes = directPeak,
+                sequentialPeakBytes = sequentialPeak,
+                safeBudgetBytes = budget,
+            )
+        } else {
+            VideoExecutionDecision(
+                mode = ImageExecutionMode.SEQUENTIAL,
+                reason = "AUTO_SEQUENTIAL_MEMORY",
+                directPeakBytes = directPeak,
+                sequentialPeakBytes = sequentialPeak,
+                safeBudgetBytes = budget,
+            )
+        }
+    }
+
+    private fun safeBudgetBytes(memory: VideoMemorySnapshot): Long {
+        val reserve = max(MIN_DEVICE_RESERVE_BYTES, memory.totalSystemBytes.coerceAtLeast(0L) / 8L)
+        return (memory.availableSystemBytes - memory.lowMemoryThresholdBytes - reserve).coerceAtLeast(0L)
+    }
+
+    private fun estimatePeakBytes(
+        vararg components: Long,
+        memory: VideoMemorySnapshot,
+    ): Long {
+        val parameterBytes = components.fold(0L) { total, size -> saturatingAdd(total, size.coerceAtLeast(0L)) }
+        val loadOverhead = parameterBytes / 8L
+        val workspace = max(MIN_WORKSPACE_BYTES, memory.totalSystemBytes.coerceAtLeast(0L) / 32L)
+        return saturatingAdd(saturatingAdd(parameterBytes, loadOverhead), workspace)
+    }
+
+    private fun saturatingAdd(left: Long, right: Long): Long =
+        if (Long.MAX_VALUE - left < right) Long.MAX_VALUE else left + right
+
+    private fun saturatingMultiply(value: Long, multiplier: Long): Long =
+        if (value > Long.MAX_VALUE / multiplier) Long.MAX_VALUE else value * multiplier
+}
+
+internal fun interface VideoExecutionPlanSelector {
+    suspend fun decide(
+        params: VideoGenerationRequest,
+        config: LLMEdgeConfig,
+    ): VideoExecutionDecision
+}
+
+internal class DefaultVideoExecutionPlanSelector(
+    private val context: Context,
+    private val resolver: ModelRepository,
+    private val memorySnapshotProvider: () -> VideoMemorySnapshot = { captureVideoMemorySnapshot(context) },
+    private val fileSizeProvider: (ModelSpec, java.io.File) -> Long = { _, file -> file.length() },
+    private val phaseListener: DiffusionPhaseListener? = null,
+) : VideoExecutionPlanSelector {
+    override suspend fun decide(
+        params: VideoGenerationRequest,
+        config: LLMEdgeConfig,
+    ): VideoExecutionDecision {
+        phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.RESOLVING_MODEL)
+        val model = params.model ?: config.models.video.diffusion
+        val decoder = params.taehv ?: params.vae ?: config.models.video.vae
+        val textEncoder = params.textEncoder ?: config.models.video.textEncoder
+        val modelBytes = resolveSize(model)
+        val decoderBytes = resolveSize(decoder)
+        val textEncoderBytes = resolveSize(textEncoder)
+        val highNoiseBytes = params.highNoiseDiffusionModel?.let { resolveSize(it) } ?: 0L
+        val memory = memorySnapshotProvider()
+        val sizes =
+            VideoComponentSizes(
+                diffusionBytes = modelBytes,
+                vaeBytes = decoderBytes,
+                textEncoderBytes = textEncoderBytes,
+                highNoiseDiffusionBytes = highNoiseBytes,
+            )
+        return try {
+            VideoExecutionPlanner.decide(params.forceSequentialLoad, sizes, memory).also { decision ->
+                logDecision(decision, sizes, memory)
+            }
+        } catch (error: InsufficientMemoryException) {
+            logRefusal(sizes, memory, error)
+            throw error
+        }
+    }
+
+    private suspend fun resolveSize(spec: ModelSpec): Long {
+        val file = resolver.resolve(context, spec)
+        return fileSizeProvider(spec, file).coerceAtLeast(0L)
+    }
+
+    private fun logDecision(
+        decision: VideoExecutionDecision,
+        sizes: VideoComponentSizes,
+        memory: VideoMemorySnapshot,
+    ) {
+        AndroidLogAdapter.i(
+            LOG_TAG,
+            "mode=${decision.mode} reason=${decision.reason} sizes=$sizes " +
+                "directBytes=${decision.directPeakBytes} sequentialBytes=${decision.sequentialPeakBytes} " +
+                "budgetBytes=${decision.safeBudgetBytes} availableBytes=${memory.availableSystemBytes} " +
+                "thresholdBytes=${memory.lowMemoryThresholdBytes} totalBytes=${memory.totalSystemBytes}",
+        )
+    }
+
+    private fun logRefusal(
+        sizes: VideoComponentSizes,
+        memory: VideoMemorySnapshot,
+        error: InsufficientMemoryException,
+    ) {
+        AndroidLogAdapter.w(
+            LOG_TAG,
+            "mode=REFUSED reason=SEQUENTIAL_EXCEEDS_BUDGET sizes=$sizes " +
+                "requiredBytes=${error.requiredBytes} budgetBytes=${error.availableBytes} " +
+                "availableBytes=${memory.availableSystemBytes} thresholdBytes=${memory.lowMemoryThresholdBytes} " +
+                "totalBytes=${memory.totalSystemBytes}",
+        )
+    }
+
+    private companion object {
+        const val LOG_TAG = "VideoExecutionPlanner"
+    }
+}
+
+private fun captureVideoMemorySnapshot(context: Context): VideoMemorySnapshot {
+    val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    val memoryInfo = ActivityManager.MemoryInfo()
+    activityManager.getMemoryInfo(memoryInfo)
+    return VideoMemorySnapshot(
+        availableSystemBytes = memoryInfo.availMem,
+        lowMemoryThresholdBytes = memoryInfo.threshold,
+        totalSystemBytes = memoryInfo.totalMem,
+    )
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/VideoGenerationExecutor.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/VideoGenerationExecutor.kt
@@ -21,6 +21,7 @@ internal class VideoGenerationExecutor(
     private val generationMutex: Mutex,
     private val state: ImageClientState,
     private val requestExecutor: DiffusionRequestExecutor,
+    private val executionPlanSelector: VideoExecutionPlanSelector,
     private val phaseListener: DiffusionPhaseListener? = null,
 ) {
     fun generate(params: VideoGenerationRequest): Flow<GenerationStreamEvent> =
@@ -32,7 +33,15 @@ internal class VideoGenerationExecutor(
                         val frames =
                             generationMutex.withLock {
                                 state.lastGenerationMetrics = null
-                                when (val plan = ImageRuntimeRequestPlanner.videoPlan(params, config)) {
+                                val decision = executionPlanSelector.decide(params, config)
+                                when (
+                                    val plan =
+                                        ImageRuntimeRequestPlanner.videoPlan(
+                                            params,
+                                            config,
+                                            sequentialLoad = decision.mode == ImageExecutionMode.SEQUENTIAL,
+                                        )
+                                ) {
                                     is DiffusionExecutionPlan.Direct -> {
                                         generateDirect(params, plan.request) { message, current, total ->
                                             emitProgress(producer, message, current, total)

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/InProcessDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/InProcessDiffusionEngine.kt
@@ -7,6 +7,7 @@ import io.aatricks.llmedge.core.LLMEdgeScope
 import io.aatricks.llmedge.image.DiffusionPhaseListener
 import io.aatricks.llmedge.image.DiffusionRequestExecutor
 import io.aatricks.llmedge.image.DefaultImageExecutionPlanSelector
+import io.aatricks.llmedge.image.DefaultVideoExecutionPlanSelector
 import io.aatricks.llmedge.image.GenerationStreamEvent
 import io.aatricks.llmedge.image.ImageClientState
 import io.aatricks.llmedge.image.ImageGenerationExecutor
@@ -53,6 +54,7 @@ internal class InProcessDiffusionEngine(
             generationMutex = generationMutex,
             state = state,
             requestExecutor = requestExecutor,
+            executionPlanSelector = DefaultVideoExecutionPlanSelector(appContext, modelRepository, phaseListener = phaseListener),
             phaseListener = phaseListener,
         )
 

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ChromaRadianceTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ChromaRadianceTest.kt
@@ -1,0 +1,72 @@
+package io.aatricks.llmedge.image
+
+import io.aatricks.llmedge.model.ModelArtifactKind
+import io.aatricks.llmedge.model.ModelCapability
+import io.aatricks.llmedge.model.ModelSpec
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChromaRadianceTest {
+    @Test
+    fun testImageRequestDefaults() {
+        val request = ChromaRadiance.imageRequest(
+            prompt = "A majestic dragon"
+        )
+
+        assertEquals("A majestic dragon", request.prompt)
+        assertEquals("", request.negative)
+        assertEquals(512, request.width)
+        assertEquals(512, request.height)
+        assertEquals(20, request.steps)
+        assertEquals(4.0f, request.cfgScale)
+        assertEquals(-1L, request.seed)
+        assertTrue(request.flashAttention)
+
+        // Model Specs
+        val ditSpec = request.model as ModelSpec.HuggingFace
+        assertEquals("silveroxides/Chroma1-Radiance-GGUF", ditSpec.repoId)
+        assertEquals("Chroma1-Radiance-v0.3/Chroma1-Radiance-v0.3-Q4_K_S.gguf", ditSpec.filename)
+        assertEquals(ModelArtifactKind.DIFFUSION_MODEL, ditSpec.hints.artifactKind)
+        assertTrue(ditSpec.hints.capabilities.contains(ModelCapability.IMAGE))
+
+        val t5Spec = request.t5xxl as ModelSpec.HuggingFace
+        assertEquals("comfyanonymous/flux_text_encoders", t5Spec.repoId)
+        assertEquals("t5xxl_fp8_e4m3fn.safetensors", t5Spec.filename)
+        assertEquals(ModelArtifactKind.TEXT_ENCODER, t5Spec.hints.artifactKind)
+        assertTrue(t5Spec.hints.capabilities.contains(ModelCapability.TEXT))
+        assertTrue(t5Spec.hints.capabilities.contains(ModelCapability.IMAGE))
+
+        assertNull(request.vae)
+        assertNull(request.clipL)
+        assertNull(request.clipG)
+        assertNull(request.textEncoder)
+        assertTrue(request.splitDiffusionModel)
+        assertEquals(true, request.sequential)
+    }
+
+    @Test
+    fun testImageRequestOverrides() {
+        val request = ChromaRadiance.imageRequest(
+            prompt = "A majestic dragon",
+            negative = "low quality",
+            width = 256,
+            height = 256,
+            steps = 30,
+            cfgScale = 5.0f,
+            seed = 12345L,
+            flashAttention = false,
+            sequential = false
+        )
+
+        assertEquals("low quality", request.negative)
+        assertEquals(256, request.width)
+        assertEquals(256, request.height)
+        assertEquals(30, request.steps)
+        assertEquals(5.0f, request.cfgScale)
+        assertEquals(12345L, request.seed)
+        assertTrue(!request.flashAttention)
+        assertEquals(false, request.sequential)
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -2688,4 +2688,117 @@ class ImageClientTest {
             StableDiffusion.resetNativeBridgeForTests()
         }
     }
+
+    @Test
+    fun `Chroma sequential image execution precomputes positive and negative conditions and passes both to diffusion`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val baseDir = context.filesDir
+        val ditFile = java.io.File.createTempFile("chroma-dit", ".gguf", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+        val t5File = java.io.File.createTempFile("chroma-t5", ".safetensors", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+
+        val events = mutableListOf<String>()
+        var observedCond: PrecomputedCondition? = null
+        var observedUncond: PrecomputedCondition? = null
+        var t5ModelClosedBeforeDitLoad = false
+        var t5ModelClosed = false
+
+        val t5Model = mockk<StableDiffusion>(relaxed = true)
+        val ditModel = mockk<StableDiffusion>(relaxed = true)
+
+        val condChroma = PrecomputedCondition(
+            cCrossAttn = floatArrayOf(5.0f),
+            cCrossAttnDims = intArrayOf(1, 1),
+        )
+        val uncondChroma = PrecomputedCondition(
+            cCrossAttn = floatArrayOf(6.0f),
+            cCrossAttnDims = intArrayOf(1, 1),
+        )
+
+        coEvery { t5Model.precomputeCondition(any(), any(), any(), any(), any()) } coAnswers {
+            val promptArg = arg<String>(0)
+            events.add("t5.precompute($promptArg)")
+            if (promptArg == "test prompt") condChroma else uncondChroma
+        }
+
+        every { t5Model.close() } answers {
+            t5ModelClosed = true
+            events.add("t5.close()")
+        }
+
+        every { ditModel.txt2ImgWithPrecomputedCondition(
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+        ) } answers {
+            val callArgs = it.invocation.args
+            observedCond = callArgs[8] as PrecomputedCondition?
+            observedUncond = callArgs[9] as PrecomputedCondition?
+            events.add("txt2ImgWithPrecomputedCondition")
+            ByteArray(256 * 256 * 3) { 0 }
+        }
+
+        coEvery {
+            StableDiffusion.loadWithRuntimeBackend(
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+                any(),
+            )
+        } coAnswers {
+            val callArgs = it.invocation.args
+            val isT5 = callArgs[5] as? String? != null
+            if (isT5) {
+                events.add("load(T5)")
+                t5Model
+            } else {
+                events.add("load(diffusion)")
+                if (t5ModelClosed) {
+                    t5ModelClosedBeforeDitLoad = true
+                }
+                ditModel
+            }
+        }
+
+        val edgeScope = LLMEdgeScope(this, 1)
+        val client =
+            ImageClient.forTesting(
+                context = context,
+                scope = edgeScope,
+                config = LLMEdgeConfig(),
+                resolver = DefaultModelRepository(),
+            )
+
+        try {
+            client.generate(
+                ImageGenerationRequest(
+                    prompt = "test prompt",
+                    width = 256,
+                    height = 256,
+                    sequential = true,
+                    splitDiffusionModel = true,
+                    model = ModelSpec.localFile(ditFile),
+                    t5xxl = ModelSpec.localFile(t5File),
+                ),
+            )
+
+            val expectedEvents = listOf(
+                "load(T5)",
+                "t5.precompute(test prompt)",
+                "t5.precompute()",
+                "t5.close()",
+                "load(diffusion)",
+                "txt2ImgWithPrecomputedCondition"
+            )
+            assertEquals(expectedEvents, events)
+            assertTrue("T5 encoder must be closed before DiT model is loaded", t5ModelClosedBeforeDitLoad)
+            org.junit.Assert.assertSame(condChroma, observedCond)
+            org.junit.Assert.assertSame(uncondChroma, observedUncond)
+        } finally {
+            client.close()
+            edgeScope.close()
+            ditFile.delete()
+            t5File.delete()
+            StableDiffusion.resetNativeBridgeForTests()
+        }
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageExecutionPlannerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageExecutionPlannerTest.kt
@@ -181,6 +181,27 @@ class ImageExecutionPlannerTest {
         assertEquals(listOf(DiffusionPhases.RESOLVING_MODEL), phases)
     }
 
+    @Test
+    fun `recipe inference recognizes Chroma Radiance topology`() {
+        val request =
+            ImageGenerationRequest(
+                prompt = "x",
+                model = io.aatricks.llmedge.model.ModelSpec.LocalFile(File("dit.safetensors")),
+                t5xxl = io.aatricks.llmedge.model.ModelSpec.LocalFile(File("t5xxl.safetensors")),
+                splitDiffusionModel = true,
+            )
+
+        val recipe = ImageExecutionPlanner.recipeFor(request)
+        assertEquals(ImageConditioningProfile.CHROMA_T5, recipe.profile)
+        assertEquals(
+            listOf(
+                listOf(ImageExecutionComponentKind.T5XXL),
+                listOf(ImageExecutionComponentKind.DIFFUSION_MODEL)
+            ),
+            recipe.phases
+        )
+    }
+
     private fun maskedT5Recipe(): ImageExecutionRecipe =
         ImageExecutionRecipe(
             profile = ImageConditioningProfile.MASKED_T5,

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
@@ -234,4 +234,37 @@ class ImageRuntimeRequestPlannerTest {
         org.junit.Assert.assertNull(sequentialPlan.diffusionRequest.options.weightType)
         org.junit.Assert.assertNull(sequentialPlan.diffusionRequest.options.tensorTypeRules)
     }
+
+    @Test
+    fun `Chroma Radiance sequential planner has two phases with exact inclusion and exclusion`() {
+        val t5xxlSpec = ModelSpec.LocalFile(File("t5xxl.safetensors"))
+        val ditModelSpec = ModelSpec.LocalFile(File("dit.safetensors"))
+
+        val params = ImageGenerationRequest(
+            prompt = "x",
+            model = ditModelSpec,
+            t5xxl = t5xxlSpec,
+            splitDiffusionModel = true,
+            sequential = true
+        )
+        val plan = ImageRuntimeRequestPlanner.imageSequentialPlan(params, LLMEdgeConfig())
+
+        // Phase 1: T5-only (T5 present, CLIPs absent, GPU-eligible when Vulkan enabled)
+        assertTrue(plan.conditioningRequest.spec.encoderOnly)
+        assertTrue(plan.conditioningRequest.options.allowGpu)
+        org.junit.Assert.assertNull(plan.conditioningRequest.spec.clipL)
+        org.junit.Assert.assertNull(plan.conditioningRequest.spec.clipG)
+        org.junit.Assert.assertEquals(t5xxlSpec, plan.conditioningRequest.spec.t5xxl)
+        org.junit.Assert.assertEquals(t5xxlSpec, plan.conditioningRequest.spec.model)
+        org.junit.Assert.assertNull(plan.conditioningRequest.spec.vae)
+        org.junit.Assert.assertNull(plan.conditioningRequest2)
+
+        // Phase 2: DiT (DiT present, CLIP/T5/VAE absent)
+        org.junit.Assert.assertEquals(ditModelSpec, plan.diffusionRequest.spec.model)
+        org.junit.Assert.assertNull(plan.diffusionRequest.spec.vae)
+        org.junit.Assert.assertNull(plan.diffusionRequest.spec.clipL)
+        org.junit.Assert.assertNull(plan.diffusionRequest.spec.clipG)
+        org.junit.Assert.assertNull(plan.diffusionRequest.spec.t5xxl)
+        assertTrue(plan.diffusionRequest.spec.splitDiffusionModel)
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/VideoExecutionPlannerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/VideoExecutionPlannerTest.kt
@@ -1,0 +1,222 @@
+package io.aatricks.llmedge.image
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.aatricks.llmedge.LLMEdgeConfig
+import io.aatricks.llmedge.core.InsufficientMemoryException
+import io.aatricks.llmedge.core.LLMEdgeScope
+import io.aatricks.llmedge.core.ProgressEvent
+import io.aatricks.llmedge.image.ipc.DiffusionPhases
+import io.aatricks.llmedge.model.ModelRegistry
+import io.aatricks.llmedge.model.ModelRepository
+import io.aatricks.llmedge.model.ModelSpec
+import io.aatricks.llmedge.model.VideoModels
+import io.mockk.Called
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.File
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class VideoExecutionPlannerTest {
+    private val gib = 1024L * 1024L * 1024L
+
+    @Test
+    fun `forced sequential remains sequential when it fits`() {
+        val decision =
+            VideoExecutionPlanner.decide(
+                forceSequentialLoad = true,
+                sizes = VideoComponentSizes(diffusionBytes = gib, vaeBytes = gib / 4, textEncoderBytes = gib),
+                memory = VideoMemorySnapshot(availableSystemBytes = 8 * gib, lowMemoryThresholdBytes = gib / 2, totalSystemBytes = 12 * gib),
+            )
+
+        assertEquals(ImageExecutionMode.SEQUENTIAL, decision.mode)
+        assertEquals("FORCED_SEQUENTIAL", decision.reason)
+    }
+
+    @Test
+    fun `automatic planner keeps video direct with two times headroom`() {
+        val decision =
+            VideoExecutionPlanner.decide(
+                forceSequentialLoad = false,
+                sizes = VideoComponentSizes(diffusionBytes = gib, vaeBytes = gib / 4, textEncoderBytes = gib),
+                memory = VideoMemorySnapshot(availableSystemBytes = 8 * gib, lowMemoryThresholdBytes = gib / 2, totalSystemBytes = 12 * gib),
+            )
+
+        assertEquals(ImageExecutionMode.DIRECT, decision.mode)
+        assertEquals("AUTO_DIRECT_HEADROOM", decision.reason)
+    }
+
+    @Test
+    fun `automatic planner stages video when direct lacks two times headroom`() {
+        val decision =
+            VideoExecutionPlanner.decide(
+                forceSequentialLoad = false,
+                sizes = VideoComponentSizes(diffusionBytes = 2 * gib, vaeBytes = gib / 2, textEncoderBytes = 2 * gib),
+                memory = VideoMemorySnapshot(availableSystemBytes = 8 * gib, lowMemoryThresholdBytes = gib / 2, totalSystemBytes = 12 * gib),
+            )
+
+        assertEquals(ImageExecutionMode.SEQUENTIAL, decision.mode)
+        assertEquals("AUTO_SEQUENTIAL_MEMORY", decision.reason)
+    }
+
+    @Test
+    fun `automatic planner refuses before loading when sequential peak exceeds budget`() {
+        val error =
+            runCatching {
+                VideoExecutionPlanner.decide(
+                    forceSequentialLoad = false,
+                    sizes = VideoComponentSizes(diffusionBytes = 3 * gib, vaeBytes = gib, textEncoderBytes = 3 * gib),
+                    memory = VideoMemorySnapshot(availableSystemBytes = 4 * gib, lowMemoryThresholdBytes = gib / 2, totalSystemBytes = 8 * gib),
+                )
+            }.exceptionOrNull()
+
+        assertTrue(error is InsufficientMemoryException)
+        assertTrue(error?.message.orEmpty().contains("sequential video loading"))
+    }
+
+    @Test
+    fun `forced sequential planner refuses when sequential peak exceeds budget`() {
+        val error =
+            runCatching {
+                VideoExecutionPlanner.decide(
+                    forceSequentialLoad = true,
+                    sizes = VideoComponentSizes(diffusionBytes = 3 * gib, vaeBytes = gib, textEncoderBytes = 3 * gib),
+                    memory = VideoMemorySnapshot(availableSystemBytes = 4 * gib, lowMemoryThresholdBytes = gib / 2, totalSystemBytes = 8 * gib),
+                )
+            }.exceptionOrNull()
+
+        assertTrue(error is InsufficientMemoryException)
+    }
+
+    @Test
+    fun `planner refuses S22 Wan Q3 load with only boundary headroom`() {
+        val error =
+            runCatching {
+                VideoExecutionPlanner.decide(
+                    forceSequentialLoad = false,
+                    sizes =
+                        VideoComponentSizes(
+                            diffusionBytes = 654_903_520,
+                            vaeBytes = 253_815_318,
+                            textEncoderBytes = 2_858_489_696,
+                        ),
+                    memory =
+                        VideoMemorySnapshot(
+                            availableSystemBytes = 4_373_471_232,
+                            lowMemoryThresholdBytes = 408_944_640,
+                            totalSystemBytes = 7_624_486_912,
+                        ),
+                )
+            }.exceptionOrNull()
+
+        assertTrue(error is InsufficientMemoryException)
+    }
+
+    @Test
+    fun `executor planning refusal prevents runtime acquisition`() = runTest {
+        val scope = LLMEdgeScope(this, 1)
+        val requestExecutor = mockk<DiffusionRequestExecutor>(relaxed = true)
+        val executor =
+            VideoGenerationExecutor(
+                scope = scope,
+                config = LLMEdgeConfig(),
+                generationMutex = Mutex(),
+                state = ImageClientState(),
+                requestExecutor = requestExecutor,
+                executionPlanSelector =
+                    VideoExecutionPlanSelector { _, _ ->
+                        throw InsufficientMemoryException(
+                            requiredBytes = 4 * gib,
+                            availableBytes = 3 * gib,
+                            operation = "sequential video loading",
+                        )
+                    },
+            )
+
+        try {
+            val error = runCatching { executor.generate(VideoGenerationRequest(prompt = "x")).collect() }.exceptionOrNull()
+
+            assertTrue(error is InsufficientMemoryException)
+            verify { requestExecutor wasNot Called }
+        } finally {
+            scope.close()
+        }
+    }
+
+    @Test
+    fun `automatic planner preserves direct loading when memory telemetry is unavailable`() {
+        val decision =
+            VideoExecutionPlanner.decide(
+                forceSequentialLoad = false,
+                sizes = VideoComponentSizes(diffusionBytes = gib, vaeBytes = gib / 4, textEncoderBytes = gib),
+                memory = VideoMemorySnapshot(availableSystemBytes = 0L, lowMemoryThresholdBytes = 0L, totalSystemBytes = 0L),
+            )
+
+        assertEquals(ImageExecutionMode.DIRECT, decision.mode)
+        assertEquals("AUTO_DIRECT_MEMORY_UNAVAILABLE", decision.reason)
+    }
+
+    @Test
+    fun `default selector resolves components and uses resolved file lengths`() = runTest {
+        val model = ModelSpec.localFile(File("model.gguf"))
+        val vae = ModelSpec.localFile(File("vae.safetensors"))
+        val encoder = ModelSpec.localFile(File("encoder.gguf"))
+        val files =
+            mapOf(
+                model to tempFileOfSize("model", 10),
+                vae to tempFileOfSize("vae", 20),
+                encoder to tempFileOfSize("encoder", 30),
+            )
+        val requested = mutableListOf<ModelSpec>()
+        val phases = mutableListOf<String>()
+        val config = LLMEdgeConfig(models = ModelRegistry(video = VideoModels(model, vae, encoder)))
+        val selector =
+            DefaultVideoExecutionPlanSelector(
+                context = ApplicationProvider.getApplicationContext<Context>(),
+                resolver =
+                    object : ModelRepository {
+                        override suspend fun resolve(
+                            context: Context,
+                            spec: ModelSpec,
+                            onProgress: ((ProgressEvent.Downloading) -> Unit)?,
+                        ): File {
+                            requested += spec
+                            return files.getValue(spec)
+                        }
+                    },
+                memorySnapshotProvider = {
+                    VideoMemorySnapshot(availableSystemBytes = 8 * gib, lowMemoryThresholdBytes = 0, totalSystemBytes = 8 * gib)
+                },
+                phaseListener =
+                    object : DiffusionPhaseListener {
+                        override fun onPhase(phase: String, backend: String?) {
+                            phases += phase
+                        }
+
+                        override fun onStep(step: Int, totalSteps: Int) = Unit
+                    },
+            )
+
+        val decision = selector.decide(VideoGenerationRequest(prompt = "x"), config)
+
+        assertEquals(listOf(model, vae, encoder), requested)
+        assertEquals(listOf(DiffusionPhases.RESOLVING_MODEL), phases)
+        assertEquals(60L + 7L + 256L * 1024L * 1024L, decision.directPeakBytes)
+    }
+
+    private fun tempFileOfSize(prefix: String, size: Int): File =
+        File.createTempFile(prefix, ".bin").apply {
+            writeBytes(ByteArray(size))
+            deleteOnExit()
+        }
+}


### PR DESCRIPTION
## What changed

- Added Chroma Radiance model definitions and split T5 conditioning support.
- Added model-size-aware Wan video planning for direct and sequential loading.
- Refuse loads before native model acquisition when the sequential peak exceeds the safe memory budget.
- Added regression coverage for Chroma conditioning and the S22 low-memory boundary.

## Why

Chroma Radiance is supported by stable-diffusion.cpp but was not exposed through the SDK helpers. Wan loading also relied on a broad device-memory heuristic, which could approve a load with almost no headroom and let Android kill the worker.

## Validation

- `:llmedge:testDebugUnitTest` — 416 tests, 0 failures, 6 skipped.
- S22 test with the Q3 Wan preset refused the unsafe load before runtime acquisition; the worker stayed alive.