### PR TITLE
Add a safer mobile Chroma preset

### DIFF
--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ChromaRadiance.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ChromaRadiance.kt
@@ -23,12 +23,26 @@ object ChromaRadiance {
                 ),
         )
 
-    /** T5XXL FP8 text encoder. */
+    /** The smaller Chroma1-HD Q3 DiT model intended for mobile devices. */
+    @JvmField
+    val mobileDiffusionModel: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "silveroxides/Chroma1-HD-GGUF",
+            filename = "Chroma1-HD-Q3_K_S.gguf",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.DIFFUSION_MODEL,
+                    capabilities = setOf(ModelCapability.IMAGE),
+                ),
+        )
+
+    /** Quantized T5XXL text encoder shared by the mobile and Radiance presets. */
     @JvmField
     val t5xxl: ModelSpec =
         ModelSpec.huggingFace(
-            repoId = "comfyanonymous/flux_text_encoders",
-            filename = "t5xxl_fp8_e4m3fn.safetensors",
+            repoId = "city96/t5-v1_1-xxl-encoder-gguf",
+            filename = "t5-v1_1-xxl-encoder-Q3_K_S.gguf",
             preferredQuantizations = emptyList(),
             hints =
                 ModelHints(
@@ -63,6 +77,37 @@ object ChromaRadiance {
             seed = seed,
             flashAttention = flashAttention,
             model = diffusionModel,
+            t5xxl = t5xxl,
+            splitDiffusionModel = true,
+            sequential = sequential,
+        )
+
+    /**
+     * Builds an [ImageGenerationRequest] pre-wired for the smaller Chroma1-HD Q3 model.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun mobileImageRequest(
+        prompt: String,
+        negative: String = "",
+        width: Int = 512,
+        height: Int = 512,
+        steps: Int = 20,
+        cfgScale: Float = 4.0f,
+        seed: Long = -1L,
+        flashAttention: Boolean = true,
+        sequential: Boolean? = true,
+    ): ImageGenerationRequest =
+        ImageGenerationRequest(
+            prompt = prompt,
+            negative = negative,
+            width = width,
+            height = height,
+            steps = steps,
+            cfgScale = cfgScale,
+            seed = seed,
+            flashAttention = flashAttention,
+            model = mobileDiffusionModel,
             t5xxl = t5xxl,
             splitDiffusionModel = true,
             sequential = sequential,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageExecutionPlanner.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageExecutionPlanner.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.content.Context
 import io.aatricks.llmedge.LLMEdgeConfig
 import io.aatricks.llmedge.core.AndroidLogAdapter
+import io.aatricks.llmedge.core.InsufficientMemoryException
 import io.aatricks.llmedge.model.ModelRepository
 import io.aatricks.llmedge.model.ModelSpec
 import kotlin.math.max
@@ -72,6 +73,8 @@ internal object ImageExecutionPlanner {
     private const val MEBIBYTE = 1024L * 1024L
     private const val MIN_DEVICE_RESERVE_BYTES = 256L * MEBIBYTE
     private const val MIN_WORKSPACE_BYTES = 128L * MEBIBYTE
+    // Android Chroma runs have reached roughly twice the staged estimate before the LMK fires.
+    private const val CHROMA_SEQUENTIAL_HEADROOM_MULTIPLIER = 2L
 
     fun recipeFor(params: ImageGenerationRequest): ImageExecutionRecipe {
         val diffusionPhase = buildList {
@@ -122,7 +125,12 @@ internal object ImageExecutionPlanner {
                     "This image request does not expose a splittable conditioning layout.",
                 )
             }
-            return ImageExecutionDecision(ImageExecutionMode.SEQUENTIAL, "FORCED_SEQUENTIAL", recipe)
+            return sequentialDecision(
+                reason = "FORCED_SEQUENTIAL",
+                recipe = recipe,
+                componentSizes = componentSizes,
+                memory = memory,
+            )
         }
         if (!recipe.supportsSequential) {
             return ImageExecutionDecision(ImageExecutionMode.DIRECT, "AUTO_DIRECT_NONSPLITTABLE", recipe)
@@ -136,7 +144,12 @@ internal object ImageExecutionPlanner {
         return if (directEstimate <= budget) {
             ImageExecutionDecision(ImageExecutionMode.DIRECT, "AUTO_DIRECT_FITS", recipe)
         } else {
-            ImageExecutionDecision(ImageExecutionMode.SEQUENTIAL, "AUTO_SEQUENTIAL_MEMORY", recipe)
+            sequentialDecision(
+                reason = "AUTO_SEQUENTIAL_MEMORY",
+                recipe = recipe,
+                componentSizes = componentSizes,
+                memory = memory,
+            )
         }
     }
 
@@ -152,6 +165,43 @@ internal object ImageExecutionPlanner {
         memory: ImageMemorySnapshot,
     ): Long =
         recipe.phases.maxOfOrNull { phase -> estimatePeakBytes(phase, componentSizes, memory) } ?: 0L
+
+    fun requiredSequentialPeakBytes(
+        recipe: ImageExecutionRecipe,
+        componentSizes: Map<ImageExecutionComponentKind, Long>,
+        memory: ImageMemorySnapshot,
+    ): Long {
+        val estimatedPeak = estimatedSequentialPeakBytes(recipe, componentSizes, memory)
+        return if (recipe.profile == ImageConditioningProfile.CHROMA_T5) {
+            saturatingMultiply(estimatedPeak, CHROMA_SEQUENTIAL_HEADROOM_MULTIPLIER)
+        } else {
+            estimatedPeak
+        }
+    }
+
+    private fun sequentialDecision(
+        reason: String,
+        recipe: ImageExecutionRecipe,
+        componentSizes: Map<ImageExecutionComponentKind, Long>,
+        memory: ImageMemorySnapshot,
+    ): ImageExecutionDecision {
+        if (recipe.components.any { it !in componentSizes }) {
+            return ImageExecutionDecision(ImageExecutionMode.SEQUENTIAL, reason, recipe)
+        }
+        if (memory.availableSystemBytes <= 0L || memory.totalSystemBytes <= 0L) {
+            return ImageExecutionDecision(ImageExecutionMode.SEQUENTIAL, reason, recipe)
+        }
+        val requiredBytes = requiredSequentialPeakBytes(recipe, componentSizes, memory)
+        val budget = safeBudgetBytes(memory)
+        if (requiredBytes > budget) {
+            throw InsufficientMemoryException(
+                requiredBytes = requiredBytes,
+                availableBytes = budget,
+                operation = "sequential image generation",
+            )
+        }
+        return ImageExecutionDecision(ImageExecutionMode.SEQUENTIAL, reason, recipe)
+    }
 
     private fun safeBudgetBytes(memory: ImageMemorySnapshot): Long {
         val reserve = max(MIN_DEVICE_RESERVE_BYTES, memory.totalSystemBytes.coerceAtLeast(0L) / 16L)
@@ -171,6 +221,9 @@ internal object ImageExecutionPlanner {
 
     private fun saturatingAdd(left: Long, right: Long): Long =
         if (Long.MAX_VALUE - left < right) Long.MAX_VALUE else left + right
+
+    private fun saturatingMultiply(value: Long, multiplier: Long): Long =
+        if (value > Long.MAX_VALUE / multiplier) Long.MAX_VALUE else value * multiplier
 }
 
 internal fun interface ImageExecutionPlanSelector {
@@ -193,7 +246,7 @@ internal class DefaultImageExecutionPlanSelector(
     ): ImageExecutionDecision {
         val recipe = ImageExecutionPlanner.recipeFor(params)
         val memory = memorySnapshotProvider()
-        if (params.sequential != null || !recipe.supportsSequential) {
+        if (params.sequential == false || !recipe.supportsSequential) {
             val decision = ImageExecutionPlanner.decide(
                 sequential = params.sequential,
                 recipe = recipe,
@@ -204,8 +257,8 @@ internal class DefaultImageExecutionPlanSelector(
             return decision
         }
 
-        // AUTO planning resolves the real artifacts before estimating their footprint. Keep an
-        // isolated worker in the resolving phase while a model download is in flight.
+        // Sequential planning resolves the real artifacts before estimating their footprint. Keep
+        // an isolated worker in the resolving phase while a model download is in flight.
         phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.RESOLVING_MODEL)
         val componentSizes = LinkedHashMap<ImageExecutionComponentKind, Long>()
         for ((component, spec) in componentSpecs(recipe, params, config)) {
@@ -225,7 +278,8 @@ internal class DefaultImageExecutionPlanSelector(
         val estimates =
             componentSizes?.let {
                 "directBytes=${ImageExecutionPlanner.estimatedDirectPeakBytes(decision.recipe, it, memory)} " +
-                    "sequentialBytes=${ImageExecutionPlanner.estimatedSequentialPeakBytes(decision.recipe, it, memory)}"
+                    "sequentialBytes=${ImageExecutionPlanner.estimatedSequentialPeakBytes(decision.recipe, it, memory)} " +
+                    "sequentialRequiredBytes=${ImageExecutionPlanner.requiredSequentialPeakBytes(decision.recipe, it, memory)}"
             } ?: "directBytes=not_calculated sequentialBytes=not_calculated"
         AndroidLogAdapter.i(
             "ImageExecutionPlanner",

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ChromaRadianceTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ChromaRadianceTest.kt
@@ -32,8 +32,8 @@ class ChromaRadianceTest {
         assertTrue(ditSpec.hints.capabilities.contains(ModelCapability.IMAGE))
 
         val t5Spec = request.t5xxl as ModelSpec.HuggingFace
-        assertEquals("comfyanonymous/flux_text_encoders", t5Spec.repoId)
-        assertEquals("t5xxl_fp8_e4m3fn.safetensors", t5Spec.filename)
+        assertEquals("city96/t5-v1_1-xxl-encoder-gguf", t5Spec.repoId)
+        assertEquals("t5-v1_1-xxl-encoder-Q3_K_S.gguf", t5Spec.filename)
         assertEquals(ModelArtifactKind.TEXT_ENCODER, t5Spec.hints.artifactKind)
         assertTrue(t5Spec.hints.capabilities.contains(ModelCapability.TEXT))
         assertTrue(t5Spec.hints.capabilities.contains(ModelCapability.IMAGE))
@@ -42,6 +42,19 @@ class ChromaRadianceTest {
         assertNull(request.clipL)
         assertNull(request.clipG)
         assertNull(request.textEncoder)
+        assertTrue(request.splitDiffusionModel)
+        assertEquals(true, request.sequential)
+    }
+
+    @Test
+    fun testMobileImageRequestDefaults() {
+        val request = ChromaRadiance.mobileImageRequest(prompt = "A majestic dragon")
+
+        val ditSpec = request.model as ModelSpec.HuggingFace
+        assertEquals("silveroxides/Chroma1-HD-GGUF", ditSpec.repoId)
+        assertEquals("Chroma1-HD-Q3_K_S.gguf", ditSpec.filename)
+        assertEquals(ChromaRadiance.t5xxl, request.t5xxl)
+        assertNull(request.vae)
         assertTrue(request.splitDiffusionModel)
         assertEquals(true, request.sequential)
     }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageExecutionPlannerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageExecutionPlannerTest.kt
@@ -3,6 +3,7 @@ package io.aatricks.llmedge.image
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import io.aatricks.llmedge.LLMEdgeConfig
+import io.aatricks.llmedge.core.InsufficientMemoryException
 import io.aatricks.llmedge.core.ProgressEvent
 import io.aatricks.llmedge.image.ipc.DiffusionPhases
 import io.aatricks.llmedge.model.ModelRepository
@@ -59,7 +60,7 @@ class ImageExecutionPlannerTest {
                     ImageExecutionComponentKind.DIFFUSION_MODEL to (4 * gib),
                 ),
                 memory = ImageMemorySnapshot(
-                    availableSystemBytes = 5 * gib,
+                    availableSystemBytes = 6 * gib,
                     lowMemoryThresholdBytes = gib / 2,
                     totalSystemBytes = 8 * gib,
                 ),
@@ -74,8 +75,8 @@ class ImageExecutionPlannerTest {
         val recipe = maskedT5Recipe()
         val sizes =
             mapOf(
-                ImageExecutionComponentKind.TEXT_ENCODER to (2 * gib),
-                ImageExecutionComponentKind.DIFFUSION_MODEL to (4 * gib),
+                ImageExecutionComponentKind.TEXT_ENCODER to gib,
+                ImageExecutionComponentKind.DIFFUSION_MODEL to gib,
             )
         val memory =
             ImageMemorySnapshot(
@@ -92,6 +93,52 @@ class ImageExecutionPlannerTest {
             ImageExecutionMode.SEQUENTIAL,
             ImageExecutionPlanner.decide(true, recipe, sizes, memory).mode,
         )
+    }
+
+    @Test
+    fun `forced Chroma staging rejects Radiance when safe sequential headroom is insufficient`() {
+        val memory =
+            ImageMemorySnapshot(
+                availableSystemBytes = 12_741L * 1024L * 1024L,
+                lowMemoryThresholdBytes = 512L * 1024L * 1024L,
+                totalSystemBytes = 15_632L * 1024L * 1024L,
+            )
+
+        val error =
+            runCatching {
+                ImageExecutionPlanner.decide(
+                    sequential = true,
+                    recipe = chromaRecipe(),
+                    componentSizes = mapOf(
+                        ImageExecutionComponentKind.T5XXL to 2_100_000_000L,
+                        ImageExecutionComponentKind.DIFFUSION_MODEL to 5_780_000_000L,
+                    ),
+                    memory = memory,
+                )
+            }.exceptionOrNull()
+
+        assertTrue(error is InsufficientMemoryException)
+    }
+
+    @Test
+    fun `forced Chroma staging allows the Q3 mobile model with 16GB system memory`() {
+        val decision =
+            ImageExecutionPlanner.decide(
+                sequential = true,
+                recipe = chromaRecipe(),
+                componentSizes = mapOf(
+                    ImageExecutionComponentKind.T5XXL to 2_100_000_000L,
+                    ImageExecutionComponentKind.DIFFUSION_MODEL to 4_290_000_000L,
+                ),
+                memory = ImageMemorySnapshot(
+                    availableSystemBytes = 12_741L * 1024L * 1024L,
+                    lowMemoryThresholdBytes = 512L * 1024L * 1024L,
+                    totalSystemBytes = 15_632L * 1024L * 1024L,
+                ),
+            )
+
+        assertEquals(ImageExecutionMode.SEQUENTIAL, decision.mode)
+        assertEquals("FORCED_SEQUENTIAL", decision.reason)
     }
 
     @Test
@@ -149,7 +196,7 @@ class ImageExecutionPlannerTest {
                     },
                 memorySnapshotProvider = {
                     ImageMemorySnapshot(
-                        availableSystemBytes = 5 * gib,
+                        availableSystemBytes = 6 * gib,
                         lowMemoryThresholdBytes = gib / 2,
                         totalSystemBytes = 8 * gib,
                     )
@@ -182,6 +229,52 @@ class ImageExecutionPlannerTest {
     }
 
     @Test
+    fun `default selector resolves forced sequential components before planning`() = runTest {
+        val dit = ModelSpec.LocalFile(File("dit.gguf"))
+        val encoder = ModelSpec.LocalFile(File("t5xxl.gguf"))
+        val resolved = File.createTempFile("planner", ".bin").apply { deleteOnExit() }
+        val requested = mutableListOf<ModelSpec>()
+        val selector =
+            DefaultImageExecutionPlanSelector(
+                context = ApplicationProvider.getApplicationContext<Context>(),
+                resolver =
+                    object : ModelRepository {
+                        override suspend fun resolve(
+                            context: Context,
+                            spec: ModelSpec,
+                            onProgress: ((ProgressEvent.Downloading) -> Unit)?,
+                        ): File {
+                            requested += spec
+                            return resolved
+                        }
+                    },
+                memorySnapshotProvider = {
+                    ImageMemorySnapshot(
+                        availableSystemBytes = 12_741L * 1024L * 1024L,
+                        lowMemoryThresholdBytes = 512L * 1024L * 1024L,
+                        totalSystemBytes = 15_632L * 1024L * 1024L,
+                    )
+                },
+                fileSizeProvider = { spec, _ -> if (spec === dit) 4_290_000_000L else 2_100_000_000L },
+            )
+
+        val decision =
+            selector.decide(
+                ImageGenerationRequest(
+                    prompt = "x",
+                    model = dit,
+                    t5xxl = encoder,
+                    splitDiffusionModel = true,
+                    sequential = true,
+                ),
+                LLMEdgeConfig(),
+            )
+
+        assertEquals(ImageExecutionMode.SEQUENTIAL, decision.mode)
+        assertEquals(listOf(encoder, dit), requested)
+    }
+
+    @Test
     fun `recipe inference recognizes Chroma Radiance topology`() {
         val request =
             ImageGenerationRequest(
@@ -208,6 +301,16 @@ class ImageExecutionPlannerTest {
             phases =
                 listOf(
                     listOf(ImageExecutionComponentKind.TEXT_ENCODER),
+                    listOf(ImageExecutionComponentKind.DIFFUSION_MODEL),
+                ),
+        )
+
+    private fun chromaRecipe(): ImageExecutionRecipe =
+        ImageExecutionRecipe(
+            profile = ImageConditioningProfile.CHROMA_T5,
+            phases =
+                listOf(
+                    listOf(ImageExecutionComponentKind.T5XXL),
                     listOf(ImageExecutionComponentKind.DIFFUSION_MODEL),
                 ),
         )


### PR DESCRIPTION
## What changed

- Added a Chroma1-HD Q3_K_S preset for phones while keeping Radiance Q4_K_S available for larger devices.
- Switched the shared T5XXL encoder from FP8 safetensors to Q3_K_S GGUF.
- Made forced sequential planning resolve the real model files before checking memory.
- Added a stricter Chroma headroom check so unsafe loads fail before the worker starts.

## Why

Radiance Q4_K_S exhausted memory on a 16GB WP55 even with sequential loading. The old forced path skipped file-size planning, so Android killed the worker after the process had already consumed most of the available memory.

The Q3 mobile preset fits the same 16GB memory snapshot used by the regression test. Radiance is rejected on that snapshot instead of risking another restart.

## Checks

- `LLMEDGE_SKIP_E2E_IN_UNIT=true ./gradlew :llmedge:testDebugUnitTest`
- 420 tests passed, 6 skipped
