### PR TITLE
Fix Chroma staged conditioning, quantize SD3 T5 encoder

### DIFF
--- a/llmedge/src/main/cpp/sd_jni_internal.h
+++ b/llmedge/src/main/cpp/sd_jni_internal.h
@@ -20,6 +20,7 @@ struct SdHandle {
     std::shared_ptr<ModelManager> model_manager;
     float flowShift = 0.0f;
     std::string loraModelDir;
+    std::string param_desc;
     int last_width = 0;
     int last_height = 0;
     JavaVM* jvm = nullptr;

--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -70,9 +70,10 @@ static SdHandle* try_create_t5_only_handle(
         const char* modelPath,
         bool offloadToCpu,
         bool useVulkan,
-        bool miniT2iConditionerOnly) {
+        bool miniT2iConditionerOnly,
+        bool chromaT5ConditionerOnly) {
 #ifdef SD_JNI_TESTING
-    (void)env; (void)modelPath; (void)offloadToCpu; (void)useVulkan; (void)miniT2iConditionerOnly;
+    (void)env; (void)modelPath; (void)offloadToCpu; (void)useVulkan; (void)miniT2iConditionerOnly; (void)chromaT5ConditionerOnly;
     return nullptr;
 #else
     if (!modelPath) {
@@ -80,7 +81,7 @@ static SdHandle* try_create_t5_only_handle(
     }
 
     ALOGI("Attempting %s-only context load for sequential prompt conditioning: %s",
-          miniT2iConditionerOnly ? "MiniT2I" : "T5", modelPath);
+          miniT2iConditionerOnly ? "MiniT2I" : (chromaT5ConditionerOnly ? "Chroma" : "T5"), modelPath);
 
     auto model_manager = std::make_shared<ModelManager>();
     model_manager->set_n_threads(sd_get_num_physical_cores_safe());
@@ -109,12 +110,20 @@ static SdHandle* try_create_t5_only_handle(
         return nullptr;
     }
 
-    ggml_backend_t params_backend = offloadToCpu ? sd_backend_cpu_init() : backend;
+    ggml_backend_t params_backend = (offloadToCpu && !sd_backend_is_cpu(backend)) ? sd_backend_cpu_init() : backend;
     Conditioner* conditioner = nullptr;
     if (miniT2iConditionerOnly) {
         conditioner = new MiniT2IConditioner(
             backend,
             model_manager->loader().get_tensor_storage_map(),
+            model_manager);
+    } else if (chromaT5ConditionerOnly) {
+        conditioner = new T5CLIPEmbedder(
+            backend,
+            model_manager->loader().get_tensor_storage_map(),
+            false, // use_mask
+            1,     // mask_pad
+            false, // is_umt5
             model_manager);
     } else {
         const bool is_umt5 = std::string(modelPath).find("umt5") != std::string::npos;
@@ -126,14 +135,16 @@ static SdHandle* try_create_t5_only_handle(
             is_umt5,
             model_manager);
     }
+    std::string param_desc = miniT2iConditionerOnly ? "MiniT2I encoder" : (chromaT5ConditionerOnly ? "Chroma encoder" : "T5 encoder");
     if (!model_manager->register_runner_params(
-            miniT2iConditionerOnly ? "MiniT2I encoder" : "T5 encoder",
+            param_desc,
             *conditioner,
             ModelManager::ResidencyMode::ParamBackend,
             backend,
             params_backend) ||
         !model_manager->validate_registered_tensors()) {
-        ALOGE("Failed to register tensors for %s context", miniT2iConditionerOnly ? "MiniT2I" : "T5");
+        ALOGE("Failed to register tensors for %s", param_desc.c_str());
+        model_manager->unregister_param_tensors(param_desc);
         delete conditioner;
         model_manager.reset();
         if (params_backend != backend) ggml_backend_free(params_backend);
@@ -151,12 +162,13 @@ static SdHandle* try_create_t5_only_handle(
     handle->backend = backend;
     handle->params_backend = params_backend == backend ? nullptr : params_backend;
     handle->model_manager = std::move(model_manager);
+    handle->param_desc = param_desc;
     if (env) {
         env->GetJavaVM(&handle->jvm);
         jni_thread_cache_init(handle->jvm);
     }
 
-    ALOGI("Created %s-only context for sequential prompt conditioning", miniT2iConditionerOnly ? "MiniT2I" : "T5");
+    ALOGI("Created context for %s for sequential prompt conditioning", param_desc.c_str());
     return handle;
 #endif
 }
@@ -560,7 +572,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
         jboolean flashAttn,
         jboolean jvaeDecodeOnly,
         jfloat flowShift,
-        jstring jLoraModelDir, jint jLoraApplyMode, jboolean jMiniT2iConditionerOnly,
+        jstring jLoraModelDir, jint jLoraApplyMode, jboolean jMiniT2iConditionerOnly, jboolean jChromaT5ConditionerOnly,
         jstring jWeightType,
         jstring jTensorTypeRules) {
     (void)clazz;
@@ -735,7 +747,10 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
                                   !controlNetPathValue.empty() ||
                                   !photoMakerPathValue.empty();
 
-    bool isSd3EncoderOnly = (diffusionModelPathValue.empty()) &&
+    bool isChromaT5ConditionerOnly = jChromaT5ConditionerOnly == JNI_TRUE;
+
+    bool isSd3EncoderOnly = !isChromaT5ConditionerOnly &&
+                            (diffusionModelPathValue.empty()) &&
                             (modelPath == nullptr || modelPath[0] == '\0') &&
                             (vaePath == nullptr || vaePath[0] == '\0') &&
                             (llmPathValue.empty()) &&
@@ -754,7 +769,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     bool isMiniT2iConditionerOnly = jMiniT2iConditionerOnly == JNI_TRUE;
 
     sd_ctx_t* ctx = nullptr;
-    if (!isLlmOnly && !isSd3EncoderOnly && !isMiniT2iConditionerOnly) {
+    if (!isLlmOnly && !isSd3EncoderOnly && !isMiniT2iConditionerOnly && !isChromaT5ConditionerOnly) {
         // Shared with the whisper loader: env mutation must be process-globally
         // serialized (concurrent setenv/getenv across threads is UB).
         std::lock_guard<std::mutex> lock(llmedge_process_env_mutex());
@@ -765,6 +780,18 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     }
 
     if (!ctx) {
+        if (isChromaT5ConditionerOnly) {
+            SdHandle* chromaHandle = try_create_t5_only_handle(
+                env, t5xxlPath, offloadToCpu == JNI_TRUE, useVulkan == JNI_TRUE, false, true);
+            if (chromaHandle) {
+                if (jModelPath) env->ReleaseStringUTFChars(jModelPath, modelPath);
+                if (jVaePath)   env->ReleaseStringUTFChars(jVaePath, vaePath);
+                if (jT5xxlPath) env->ReleaseStringUTFChars(jT5xxlPath, t5xxlPath);
+                if (jTaesdPath) env->ReleaseStringUTFChars(jTaesdPath, taesdPath);
+                if (jLoraModelDir) env->ReleaseStringUTFChars(jLoraModelDir, loraModelDir);
+                return reinterpret_cast<jlong>(chromaHandle);
+            }
+        }
         if (isSd3EncoderOnly) {
             SdHandle* sd3EncoderHandle = try_create_sd3_encoder_only_handle(env, clipLPathValue.c_str(), clipGPathValue.c_str(), t5xxlPath, offloadToCpu == JNI_TRUE, useVulkan == JNI_TRUE);
             if (sd3EncoderHandle) {
@@ -789,7 +816,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
         }
         if (isMiniT2iConditionerOnly) {
             SdHandle* miniT2iHandle = try_create_t5_only_handle(
-                env, modelPath, offloadToCpu == JNI_TRUE, useVulkan == JNI_TRUE, true);
+                env, modelPath, offloadToCpu == JNI_TRUE, useVulkan == JNI_TRUE, true, false);
             if (miniT2iHandle) {
                 if (jModelPath) env->ReleaseStringUTFChars(jModelPath, modelPath);
                 if (jVaePath)   env->ReleaseStringUTFChars(jVaePath, vaePath);
@@ -801,7 +828,7 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
         }
         if (isT5OnlyRequest) {
             SdHandle* t5OnlyHandle = try_create_t5_only_handle(
-                env, modelPath, offloadToCpu == JNI_TRUE, useVulkan == JNI_TRUE, false);
+                env, modelPath, offloadToCpu == JNI_TRUE, useVulkan == JNI_TRUE, false, false);
             if (t5OnlyHandle) {
                 if (jModelPath) env->ReleaseStringUTFChars(jModelPath, modelPath);
                 if (jVaePath)   env->ReleaseStringUTFChars(jVaePath, vaePath);
@@ -851,6 +878,11 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(JNIEnv* e
         handle->ctx = nullptr;
     }
 #ifndef SD_JNI_TESTING
+    if (handle->model_manager && !handle->param_desc.empty()) {
+        if (!handle->model_manager->unregister_param_tensors(handle->param_desc)) {
+            ALOGE("Failed to unregister parameter tensors for %s", handle->param_desc.c_str());
+        }
+    }
     if (handle->t5_ctx) {
         auto* t5 = static_cast<T5CLIPEmbedder*>(handle->t5_ctx);
         delete t5;

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ChromaRadiance.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ChromaRadiance.kt
@@ -51,6 +51,20 @@ object ChromaRadiance {
                 ),
         )
 
+    /** The FLUX VAE model. */
+    @JvmField
+    val fluxVae: ModelSpec =
+        ModelSpec.huggingFace(
+            repoId = "lodestones/Chroma",
+            filename = "ae.safetensors",
+            preferredQuantizations = emptyList(),
+            hints =
+                ModelHints(
+                    artifactKind = ModelArtifactKind.VAE,
+                    capabilities = setOf(ModelCapability.IMAGE),
+                ),
+        )
+
     /**
      * Builds an [ImageGenerationRequest] pre-wired for Chroma Radiance.
      */
@@ -108,6 +122,7 @@ object ChromaRadiance {
             seed = seed,
             flashAttention = flashAttention,
             model = mobileDiffusionModel,
+            vae = fluxVae,
             t5xxl = t5xxl,
             splitDiffusionModel = true,
             sequential = sequential,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
@@ -177,6 +177,8 @@ internal class DiffusionRuntimeLoader(
                     spec.model.hints.artifactKind == ModelArtifactKind.DIFFUSION_MODEL)
         val miniT2iConditionerOnly =
             spec.encoderOnly && spec.conditioningProfile == ImageConditioningProfile.MASKED_T5
+        val chromaT5ConditionerOnly =
+            spec.encoderOnly && spec.conditioningProfile == ImageConditioningProfile.CHROMA_T5
         try {
             return createManagedModel(
                 options = options,
@@ -200,6 +202,7 @@ internal class DiffusionRuntimeLoader(
                 splitDiffusionModel = spec.splitDiffusionModel,
                 encoderOnly = spec.encoderOnly,
                 miniT2iConditionerOnly = miniT2iConditionerOnly,
+                chromaT5ConditionerOnly = chromaT5ConditionerOnly,
             )
         } catch (error: Throwable) {
             if (!shouldRetryWithoutFlash(spec, options)) {
@@ -232,6 +235,7 @@ internal class DiffusionRuntimeLoader(
                     splitDiffusionModel = spec.splitDiffusionModel,
                     encoderOnly = spec.encoderOnly,
                     miniT2iConditionerOnly = miniT2iConditionerOnly,
+                    chromaT5ConditionerOnly = chromaT5ConditionerOnly,
                 )
             } catch (fallbackError: Throwable) {
                 fallbackError.addSuppressed(error)
@@ -262,17 +266,18 @@ internal class DiffusionRuntimeLoader(
         splitDiffusionModel: Boolean,
         encoderOnly: Boolean,
         miniT2iConditionerOnly: Boolean,
+        chromaT5ConditionerOnly: Boolean,
     ): ManagedDiffusionModel {
         AndroidLogAdapter.i(
             LOG_TAG,
             "Creating managed ${backend.name} runtime for ${resolvedModel.name} flash=$flashAttn sequential=${options.sequentialLoad}",
         )
         phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.LOADING, backend.name)
-        val isSd3EncoderOnly = encoderOnly && (
+        val isSd3EncoderOnly = encoderOnly && !chromaT5ConditionerOnly && (
             (resolvedClipL != null && resolvedClipG != null && resolvedT5xxl == null) ||
             (resolvedClipL == null && resolvedClipG == null && resolvedT5xxl != null)
         )
-        val componentPaths = if (encoderOnly && !isSd3EncoderOnly && !miniT2iConditionerOnly) {
+        val componentPaths = if (encoderOnly && !isSd3EncoderOnly && !miniT2iConditionerOnly && !chromaT5ConditionerOnly) {
             null
         } else {
             val paths = StableDiffusionComponentPaths(
@@ -286,6 +291,7 @@ internal class DiffusionRuntimeLoader(
                 controlNetPath = resolvedControlNet?.absolutePath,
                 photoMakerPath = resolvedPhotoMaker?.absolutePath,
                 miniT2iConditionerOnly = miniT2iConditionerOnly,
+                chromaT5ConditionerOnly = chromaT5ConditionerOnly,
                 weightType = options.weightType,
                 tensorTypeRules = options.tensorTypeRules,
             )
@@ -302,12 +308,16 @@ internal class DiffusionRuntimeLoader(
                         resolvedModel.absolutePath
                     },
                 vaePath = if (encoderOnly) null else resolvedVae?.absolutePath,
-                t5xxlPath = resolvedT5xxl?.absolutePath ?: (if (splitDiffusionModel || (encoderOnly && !isSd3EncoderOnly)) null else resolvedTextEncoder?.absolutePath),
+                t5xxlPath = if (chromaT5ConditionerOnly) {
+                    resolvedT5xxl?.absolutePath ?: resolvedModel.absolutePath
+                } else {
+                    resolvedT5xxl?.absolutePath ?: (if (splitDiffusionModel || (encoderOnly && !isSd3EncoderOnly)) null else resolvedTextEncoder?.absolutePath)
+                },
                 taesdPath = if (encoderOnly) null else resolvedTaehv?.absolutePath,
                 diffusionModelPath = if (splitDiffusionModel || diffusionModelOnly) resolvedModel.absolutePath else null,
                 llmPath =
                     when {
-                        encoderOnly && !isSd3EncoderOnly && !miniT2iConditionerOnly -> resolvedModel.absolutePath
+                        encoderOnly && !isSd3EncoderOnly && !miniT2iConditionerOnly && !chromaT5ConditionerOnly -> resolvedModel.absolutePath
                         splitDiffusionModel -> resolvedTextEncoder?.absolutePath
                         else -> null
                     },

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/Sd3Medium.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/Sd3Medium.kt
@@ -75,13 +75,12 @@ object Sd3Medium {
                 ),
         )
 
-    /** T5XXL FP8 text encoder (~4.89 GB). */
+    /** Quantized T5XXL text encoder (Q3_K_S GGUF, ~2.1 GB). */
     @JvmField
     val t5xxl: ModelSpec =
         ModelSpec.huggingFace(
-            repoId = "Comfy-Org/stable-diffusion-3.5-fp8",
-            filename = "text_encoders/t5xxl_fp8_e4m3fn.safetensors",
-            revision = "main",
+            repoId = "city96/t5-v1_1-xxl-encoder-gguf",
+            filename = "t5-v1_1-xxl-encoder-Q3_K_S.gguf",
             preferredQuantizations = emptyList(),
             hints =
                 ModelHints(

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
@@ -297,6 +297,7 @@ class StableDiffusion internal constructor(
                 request.loraModelDir,
                 request.loraApplyMode.id,
                 request.miniT2iConditionerOnly,
+                request.chromaT5ConditionerOnly,
                 request.weightType,
                 request.tensorTypeRules,
             )
@@ -330,6 +331,7 @@ class StableDiffusion internal constructor(
                 loraModelDir: String?,
                 loraApplyMode: Int,
                 miniT2iConditionerOnly: Boolean,
+                chromaT5ConditionerOnly: Boolean,
                 weightType: String?,
                 tensorTypeRules: String?,
         ): Long

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadRequest.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadRequest.kt
@@ -14,6 +14,7 @@ data class StableDiffusionComponentPaths(
     val photoMakerPath: String? = null,
     // Private encoder-only routing signal; this is not a model path.
     val miniT2iConditionerOnly: Boolean = false,
+    val chromaT5ConditionerOnly: Boolean = false,
     /** Weight quantization type to override on load (e.g. "q8_0"). */
     val weightType: String? = null,
     /** Per-tensor type rules pattern (e.g. ".*mask_token.*=f16"). */
@@ -31,7 +32,8 @@ data class StableDiffusionComponentPaths(
         photoMakerPath == null &&
         weightType == null &&
         tensorTypeRules == null &&
-        !miniT2iConditionerOnly
+        !miniT2iConditionerOnly &&
+        !chromaT5ConditionerOnly
 }
 
 internal data class StableDiffusionAssetRequest(
@@ -106,6 +108,7 @@ internal data class StableDiffusionNativeLoadRequest(
     val loraModelDir: String?,
     val loraApplyMode: LoraApplyMode,
     val miniT2iConditionerOnly: Boolean = false,
+    val chromaT5ConditionerOnly: Boolean = false,
     val weightType: String? = null,
     val tensorTypeRules: String? = null,
 )

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadSupport.kt
@@ -467,6 +467,7 @@ internal object StableDiffusionLoadSupport {
             loraModelDir = request.assets.loraModelDir,
             loraApplyMode = request.runtime.loraApplyMode,
             miniT2iConditionerOnly = resolved.componentPaths?.miniT2iConditionerOnly == true,
+            chromaT5ConditionerOnly = resolved.componentPaths?.chromaT5ConditionerOnly == true,
             weightType = resolved.componentPaths?.weightType,
             tensorTypeRules = resolved.componentPaths?.tensorTypeRules,
         )

--- a/llmedge/src/test/cpp/test_video_jni.cpp
+++ b/llmedge/src/test/cpp/test_video_jni.cpp
@@ -46,6 +46,7 @@ JNIEXPORT jlong JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion
     jint nThreads, jboolean enableOpenCl, jboolean useVulkan, jboolean offloadToCpu,
     jboolean keepClipOnCpu, jboolean keepVaeOnCpu, jboolean flashAttn, jboolean jvaeDecodeOnly,
     jfloat flowShift, jstring jLoraModelDir, jint jLoraApplyMode, jboolean jMiniT2iConditionerOnly,
+    jboolean jChromaT5ConditionerOnly,
     jstring jWeightType, jstring jTensorTypeRules);
 JNIEXPORT void JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeDestroy(JNIEnv* env, jobject thiz, jlong handlePtr);
 JNIEXPORT jobjectArray JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeTxt2Vid(
@@ -132,7 +133,7 @@ static bool test_nativeTxt2Vid_memory(JNIEnv* env) {
             env, nullptr, modelPath, nullptr, nullptr, nullptr, nullptr, nullptr,
             nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
             JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
-            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, nullptr, nullptr);
+            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, JNI_FALSE, nullptr, nullptr);
     env->DeleteLocalRef(modelPath);
     if (handle == 0) {
         std::cerr << "nativeCreate returned null handle" << std::endl;
@@ -212,7 +213,7 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
         env, nullptr, t5Path, nullptr, nullptr, nullptr, nullptr, nullptr,
         nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
         JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
-        std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, nullptr, nullptr);
+        std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, JNI_FALSE, nullptr, nullptr);
     env->DeleteLocalRef(t5Path);
     
     if (t5Handle == 0) {
@@ -258,7 +259,7 @@ static bool test_progressive_loading_e2e(JNIEnv* env) {
             env, nullptr, modelPath, vaePath, nullptr, nullptr, nullptr, nullptr,
             nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 4,
             JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
-            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, nullptr, nullptr);
+            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, JNI_FALSE, nullptr, nullptr);
     env->DeleteLocalRef(modelPath);
     env->DeleteLocalRef(vaePath);
     
@@ -306,7 +307,7 @@ static bool test_progress_callback_bridge(JNIEnv* env) {
             env, nullptr, modelPath, nullptr, nullptr, nullptr, nullptr, nullptr,
             nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 2,
             JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE, JNI_FALSE,
-            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, nullptr, nullptr);
+            std::numeric_limits<float>::infinity(), nullptr, 0, JNI_FALSE, JNI_FALSE, nullptr, nullptr);
     env->DeleteLocalRef(modelPath);
     if (handlePtr == 0) {
         std::cerr << "Failed to create handle for progress test" << std::endl;

--- a/llmedge/src/test/java/io/aatricks/llmedge/ChromaSequentialLinuxE2ETest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/ChromaSequentialLinuxE2ETest.kt
@@ -1,0 +1,112 @@
+package io.aatricks.llmedge
+
+import android.content.Context
+import android.graphics.Bitmap
+import io.aatricks.llmedge.image.diffusion.StableDiffusion
+import io.aatricks.llmedge.image.diffusion.StableDiffusionComponentPaths
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ChromaSequentialLinuxE2ETest {
+    private val libPathEnv = "LLMEDGE_BUILD_NATIVE_LIB_PATH"
+
+    private fun env(name: String): String? = System.getenv(name) ?: System.getProperty(name)
+
+    @Test
+    fun `desktop chroma sequential precompute then DiT-only generation`() = runBlocking {
+        val ditPath = env("LLMEDGE_TEST_CHROMA_DIT_PATH")
+        val t5Path = env("LLMEDGE_TEST_CHROMA_T5_PATH")
+        val vaePath = env("LLMEDGE_TEST_CHROMA_VAE_PATH")
+
+        Assume.assumeTrue("Chroma DiT path not set", !ditPath.isNullOrBlank())
+        Assume.assumeTrue("Chroma T5 path not set", !t5Path.isNullOrBlank())
+        Assume.assumeTrue("Chroma VAE path not set", !vaePath.isNullOrBlank())
+
+        DesktopNativeTestSupport.requireEnabledAndLoadLibrary(
+            envName = libPathEnv,
+            defaultRelativePath = "llmedge/build/native/linux-x86_64/libsdcpp.so",
+        )
+
+        val context = org.robolectric.RuntimeEnvironment.getApplication() as Context
+        val width = 128
+        val height = 128
+        val prompt = "a beautiful cherry blossom branch, digital art"
+        val negativePrompt = "blurry, low quality"
+
+        val encoderCtx = StableDiffusion.load(
+            context = context,
+            t5xxlPath = t5Path,
+            offloadToCpu = true,
+            keepClipOnCpu = true,
+            keepVaeOnCpu = true,
+            flashAttn = true,
+            allowVulkan = false,
+            componentPaths = StableDiffusionComponentPaths(chromaT5ConditionerOnly = true),
+        )
+
+        val cond = encoderCtx.precomputeCondition(prompt, "", width, height, -1)
+        val uncond = encoderCtx.precomputeCondition(negativePrompt, "", width, height, -1)
+        encoderCtx.close()
+
+        assertTrue("positive conditioning returned null", cond != null)
+        assertTrue("negative conditioning returned null", uncond != null)
+
+        val ditCtx = StableDiffusion.load(
+            context = context,
+            diffusionModelPath = ditPath,
+            vaePath = vaePath,
+            offloadToCpu = true,
+            keepClipOnCpu = true,
+            keepVaeOnCpu = true,
+            flashAttn = true,
+        )
+
+        val rgb = try {
+            ditCtx.txt2ImgWithPrecomputedCondition(
+                prompt = prompt,
+                negative = negativePrompt,
+                width = width,
+                height = height,
+                steps = 1,
+                cfg = 4.0f,
+                seed = 42L,
+                cond = cond,
+                uncond = uncond,
+            )
+        } finally {
+            ditCtx.close()
+        }
+
+        assertTrue("generation returned null", rgb != null)
+        assertEquals("output dimensions mismatch", width * height * 3, rgb!!.size)
+
+        val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val px = IntArray(width * height)
+        for (i in 0 until width * height) {
+            val r = rgb[i * 3].toInt() and 0xFF
+            val g = rgb[i * 3 + 1].toInt() and 0xFF
+            val b = rgb[i * 3 + 2].toInt() and 0xFF
+            px[i] = (0xFF shl 24) or (r shl 16) or (g shl 8) or b
+        }
+        bmp.setPixels(px, 0, width, 0, 0, width, height)
+
+        val uniqueColors = px.toSet().size
+        assertTrue("Image should not be blank (uniqueColors=$uniqueColors)", uniqueColors > 1)
+
+        val outDir = File("build/outputs/images")
+        outDir.mkdirs()
+        val out = File(outDir, "chroma_sequential_${width}x${height}_seed42.png")
+        FileOutputStream(out).use { bmp.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        println("[ChromaSequentialLinuxE2ETest sequential] uniqueColors=$uniqueColors output=${out.absolutePath}")
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ChromaRadianceTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ChromaRadianceTest.kt
@@ -54,7 +54,7 @@ class ChromaRadianceTest {
         assertEquals("silveroxides/Chroma1-HD-GGUF", ditSpec.repoId)
         assertEquals("Chroma1-HD-Q3_K_S.gguf", ditSpec.filename)
         assertEquals(ChromaRadiance.t5xxl, request.t5xxl)
-        assertNull(request.vae)
+        assertEquals(ChromaRadiance.fluxVae, request.vae)
         assertTrue(request.splitDiffusionModel)
         assertEquals(true, request.sequential)
     }
@@ -81,5 +81,17 @@ class ChromaRadianceTest {
         assertEquals(12345L, request.seed)
         assertTrue(!request.flashAttention)
         assertEquals(false, request.sequential)
+    }
+
+    @Test
+    fun testChromaVaeConfiguration() {
+        val mobileRequest = ChromaRadiance.mobileImageRequest(prompt = "A majestic dragon")
+        val vaeSpec = mobileRequest.vae as? ModelSpec.HuggingFace
+        org.junit.Assert.assertNotNull("Mobile image request VAE should not be null", vaeSpec)
+        assertEquals("lodestones/Chroma", vaeSpec?.repoId)
+        assertEquals("ae.safetensors", vaeSpec?.filename)
+
+        val radianceRequest = ChromaRadiance.imageRequest(prompt = "A majestic dragon")
+        assertNull("Radiance image request VAE should be null", radianceRequest.vae)
     }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -2801,4 +2801,75 @@ class ImageClientTest {
             StableDiffusion.resetNativeBridgeForTests()
         }
     }
+
+    @Test
+    fun `chroma T5 encoderOnly spec requires chromaT5ConditionerOnly signal keeping T5 in t5xxlPath and specifying Chroma mask_pad=1`(
+    ) = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val encoderFile =
+            java.io.File.createTempFile("chroma-t5", ".safetensors", context.filesDir).apply {
+                writeBytes(byteArrayOf(0x01))
+            }
+        var observedModelPath: String? = "unset"
+        var observedVaePath: String? = "unset"
+        var observedT5xxlPath: String? = "unset"
+        var observedDiffusionModelPath: String? = "unset"
+        var observedLlmPath: String? = "unset"
+        var observedComponentPaths: io.aatricks.llmedge.image.diffusion.StableDiffusionComponentPaths? = null
+
+        coEvery {
+            StableDiffusion.loadWithRuntimeBackend(
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+                any(),
+            )
+        } coAnswers {
+            val callArgs = it.invocation.args
+            observedModelPath = callArgs[3] as String?
+            observedVaePath = callArgs[4] as String?
+            observedT5xxlPath = callArgs[5] as String?
+            observedDiffusionModelPath = callArgs[21] as String?
+            observedLlmPath = callArgs[22] as String?
+            observedComponentPaths = callArgs[23] as io.aatricks.llmedge.image.diffusion.StableDiffusionComponentPaths?
+            val constructor = StableDiffusion::class.java.getDeclaredConstructor(Long::class.javaPrimitiveType)
+            constructor.isAccessible = true
+            constructor.newInstance(1L)
+        }
+
+        val loaded =
+            DiffusionRuntimeLoader(context, DefaultModelRepository()).load(
+                spec =
+                    DiffusionRuntimeSpec(
+                        role = DiffusionRuntimeRole.IMAGE,
+                        model = ModelSpec.localFile(encoderFile),
+                        encoderOnly = true,
+                        conditioningProfile = ImageConditioningProfile.CHROMA_T5,
+                    ),
+                options =
+                    DiffusionLoadOptions(
+                        subsystem = ComputeSubsystem.IMAGE,
+                        allowGpu = false,
+                        nThreads = 1,
+                        offloadToCpu = true,
+                        keepClipOnCpu = true,
+                        keepVaeOnCpu = true,
+                        flashAttn = true,
+                        preferPerformanceMode = false,
+                    ),
+                backend = ComputeBackend.CPU,
+            )
+        try {
+            assertEquals(null, observedModelPath)
+            assertEquals(encoderFile.absolutePath, observedT5xxlPath)
+            assertEquals(null, observedVaePath)
+            assertEquals(null, observedDiffusionModelPath)
+            assertEquals(null, observedLlmPath)
+            assertEquals(true, observedComponentPaths?.chromaT5ConditionerOnly)
+        } finally {
+            loaded.close()
+        }
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/Sd3MediumTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/Sd3MediumTest.kt
@@ -68,4 +68,11 @@ class Sd3MediumTest {
         assertFalse(request.splitDiffusionModel)
         assertNull(request.sequential)
     }
+
+    @Test
+    fun testT5xxlIsQuantizedGguf() {
+        val spec = Sd3Medium.t5xxl as io.aatricks.llmedge.model.ModelSpec.HuggingFace
+        assertEquals("city96/t5-v1_1-xxl-encoder-gguf", spec.repoId)
+        assertEquals("t5-v1_1-xxl-encoder-Q3_K_S.gguf", spec.filename)
+    }
 }


### PR DESCRIPTION
Fixes the Chroma staged pipeline found while testing on the WP55: the standalone T5 encoder was routed through the SD3 conditioner and produced the wrong conditioning shape, the mobile Chroma1-HD preset was missing its FLUX VAE, and closing the encoder context crashed in the model manager during the phase switch. The encoder now gets a dedicated Chroma T5 route (mask_pad=1) behind an explicit flag, and encoder-only teardown unregisters its tensors before the runner is destroyed.

Also swaps the SD3 Medium T5 encoder from the 4.9 GB fp8 safetensors to the 2.1 GB Q3_K_S GGUF already used by the Chroma presets.

Tested with the full unit suite (423 tests), the Android NDK build, and a sequential Chroma host run on macOS (encode, teardown, 128x128 generation), which is now a permanent opt-in E2E test.