### PR TITLE
Quarantine unstable vendor Vulkan drivers in the diffusion worker

### DIFF
--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadSupport.kt
@@ -315,6 +315,7 @@ internal object StableDiffusionLoadSupport {
 
         val handle =
             createHandleWithBackendFallback(
+                context = context,
                 resolved = resolved,
                 request = request,
                 loadPlan = loadPlan,
@@ -371,6 +372,7 @@ internal object StableDiffusionLoadSupport {
     }
 
     private fun createHandleWithBackendFallback(
+        context: Context,
         resolved: StableDiffusionResolvedAssets,
         request: StableDiffusionLoadRequest,
         loadPlan: StableDiffusionLoadHeuristics.LoadPlan,
@@ -387,6 +389,12 @@ internal object StableDiffusionLoadSupport {
                     if (backend != ComputeBackend.CPU) {
                         val detail = error?.message?.let { ": $it" } ?: ""
                         AndroidLogAdapter.w(LOG_TAG, "nativeCreate failed on $backend; retrying with CPU backend$detail")
+                    }
+                    // A failed Vulkan create may leave the vendor driver in a bad state even
+                    // though the CPU fallback proceeds. Breadcrumb it so the host quarantines
+                    // Vulkan for future sessions instead of re-poking the driver every time.
+                    if (backend == ComputeBackend.VULKAN) {
+                        VulkanCreateFailureMarker.record(context)
                     }
                 },
             ) { backend ->

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/VulkanCreateFailureMarker.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/VulkanCreateFailureMarker.kt
@@ -1,0 +1,30 @@
+package io.aatricks.llmedge.image.diffusion
+
+import android.content.Context
+import android.os.Build
+import java.io.File
+
+/**
+ * Cross-process breadcrumb written when a Vulkan `nativeCreate` attempt fails and the loader falls
+ * back to CPU. The load runs inside the worker process, which cannot safely share the host's
+ * verdict SharedPreferences, so the failure is recorded as a file (the same pattern as the worker
+ * crash breadcrumb) and converted into a persisted backend verdict by the host engine. Keyed to
+ * [Build.FINGERPRINT] so an OS/driver update discards the marker.
+ */
+internal object VulkanCreateFailureMarker {
+    fun file(context: Context): File = File(context.filesDir, "diffusion-vulkan-create-failed")
+
+    fun record(context: Context) {
+        runCatching { file(context).writeText(Build.FINGERPRINT) }
+    }
+
+    /** True when a marker from the current OS build exists; the marker is deleted either way. */
+    fun consume(context: Context): Boolean =
+        runCatching {
+            val marker = file(context)
+            if (!marker.isFile) return false
+            val fingerprint = marker.readText().trim()
+            marker.delete()
+            fingerprint == Build.FINGERPRINT
+        }.getOrDefault(false)
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
@@ -83,6 +83,11 @@ internal class DiffusionWorkerService : Service() {
                             subsystem to backend
                         },
                     )
+                    // Must run before the first native call: keeps unstable vendor Vulkan drivers
+                    // from ever loading in this process (probe included) once Vulkan is disallowed.
+                    WorkerVulkanGate.apply(
+                        WorkerVulkanGate.shouldDisable(config.useVulkan, config.blacklistSeed),
+                    )
                     bootstrap = newBootstrap
                     engine =
                         InProcessDiffusionEngine(

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
@@ -70,6 +70,7 @@ internal class IsolatedDiffusionEngine(
                 AndroidLogAdapter.w(LOG_TAG, "Seeded persisted backend verdicts: $persisted")
             }
         }
+        ingestVulkanCreateFailureMarker()
     }
 
     private class ActiveRequest(
@@ -179,8 +180,9 @@ internal class IsolatedDiffusionEngine(
     private suspend fun <T> runWithRecovery(
         subsystem: ComputeSubsystem,
         issue: suspend (forceCpu: Boolean) -> T,
-    ): T =
-        try {
+    ): T {
+        ingestVulkanCreateFailureMarker()
+        return try {
             issue(false)
         } catch (hang: GenerationHangException) {
             recordHangVerdict(subsystem, hang.backend)
@@ -192,11 +194,40 @@ internal class IsolatedDiffusionEngine(
                 }
             }
         } catch (crash: WorkerCrashedException) {
-            if (crash.backend == ComputeBackend.CPU.name) throw crash
-            markSessionBlacklist(subsystem, crash.backend)
-            AndroidLogAdapter.w(LOG_TAG, "Worker crashed (${crash.message}); retrying on CPU")
-            issue(true)
+            // A crash whose tombstone names a vulkan driver library taints the whole worker
+            // process — even when the session computed on CPU (the capacity probe or a failed
+            // Vulkan create attempt initialized the driver). Quarantine Vulkan and retry once in
+            // a fresh worker that never loads the driver.
+            val vulkanImplicated = crashImplicatesVulkanDriver(crash.crashSummary)
+            if (vulkanImplicated) {
+                recordHangVerdict(subsystem, ComputeBackend.VULKAN.name)
+            }
+            if (crash.backend == ComputeBackend.CPU.name) {
+                if (!vulkanImplicated) throw crash
+                AndroidLogAdapter.w(
+                    LOG_TAG,
+                    "CPU-session crash implicates the Vulkan driver (${crash.message}); retrying with Vulkan quarantined",
+                )
+                issue(true)
+            } else {
+                markSessionBlacklist(subsystem, crash.backend)
+                AndroidLogAdapter.w(LOG_TAG, "Worker crashed (${crash.message}); retrying on CPU")
+                issue(true)
+            }
         }
+    }
+
+    /** True when the tombstone summary names a vulkan driver library (e.g. vulkan.mtk.so, libvulkan.so). */
+    private fun crashImplicatesVulkanDriver(crashSummary: String?): Boolean =
+        crashSummary != null && VULKAN_DRIVER_LIBRARY.containsMatchIn(crashSummary)
+
+    /** Converts a worker-side "Vulkan create failed" breadcrumb into a persisted verdict. */
+    private fun ingestVulkanCreateFailureMarker() {
+        if (!io.aatricks.llmedge.image.diffusion.VulkanCreateFailureMarker.consume(context)) return
+        AndroidLogAdapter.w(LOG_TAG, "Worker reported a failed Vulkan create attempt; quarantining Vulkan")
+        recordHangVerdict(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN.name)
+        recordHangVerdict(ComputeSubsystem.VIDEO, ComputeBackend.VULKAN.name)
+    }
 
     private suspend fun issueImageRequest(
         params: ImageGenerationRequest,
@@ -412,5 +443,6 @@ internal class IsolatedDiffusionEngine(
 
     companion object {
         private const val LOG_TAG = "IsolatedDiffusion"
+        private val VULKAN_DRIVER_LIBRARY = Regex("(?i)(lib)?vulkan[\\w.]*\\.so")
     }
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerVulkanGate.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerVulkanGate.kt
@@ -1,0 +1,36 @@
+package io.aatricks.llmedge.image.ipc
+
+import io.aatricks.llmedge.core.AndroidLogAdapter
+import io.aatricks.llmedge.runtime.ComputeBackend
+
+/**
+ * Process-wide Vulkan kill switch for the diffusion worker. Some vendor Vulkan drivers (observed:
+ * MediaTek mt6855) can SIGSEGV the process merely from being initialized — even when every session
+ * computes on CPU — so once Vulkan is disallowed for this worker (by config or by a persisted
+ * verdict), `GGML_DISABLE_VULKAN` is set before any native call. That single env var gates the
+ * device-capacity probe, ggml's backend registry, and sd.cpp's backend resolution, so the vendor
+ * driver is never loaded.
+ */
+internal object WorkerVulkanGate {
+    private const val ENV_VAR = "GGML_DISABLE_VULKAN"
+    private const val LOG_TAG = "WorkerVulkanGate"
+
+    /** Any Vulkan verdict disables the driver for the whole worker: it is process-poison, not per-subsystem. */
+    fun shouldDisable(
+        useVulkan: Boolean,
+        blacklistSeed: List<String>,
+    ): Boolean = !useVulkan || blacklistSeed.any { it.endsWith(":${ComputeBackend.VULKAN.name}") }
+
+    fun apply(disable: Boolean) {
+        runCatching {
+            if (disable) {
+                android.system.Os.setenv(ENV_VAR, "1", true)
+                AndroidLogAdapter.i(LOG_TAG, "Vulkan disabled process-wide for this worker")
+            } else {
+                android.system.Os.unsetenv(ENV_VAR)
+            }
+        }.onFailure { error ->
+            AndroidLogAdapter.w(LOG_TAG, "Failed to update $ENV_VAR: ${error.message}")
+        }
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/diffusion/VulkanCreateFailureMarkerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/diffusion/VulkanCreateFailureMarkerTest.kt
@@ -1,0 +1,31 @@
+package io.aatricks.llmedge.image.diffusion
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class VulkanCreateFailureMarkerTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `record then consume returns true once and deletes the marker`() {
+        VulkanCreateFailureMarker.record(context)
+        assertTrue(VulkanCreateFailureMarker.consume(context))
+        assertFalse(VulkanCreateFailureMarker.file(context).exists())
+        assertFalse(VulkanCreateFailureMarker.consume(context))
+    }
+
+    @Test
+    fun `marker from a previous OS build is discarded`() {
+        VulkanCreateFailureMarker.file(context).writeText("some-old-fingerprint")
+        assertFalse(VulkanCreateFailureMarker.consume(context))
+        assertFalse(VulkanCreateFailureMarker.file(context).exists())
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngineTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngineTest.kt
@@ -209,6 +209,108 @@ class IsolatedDiffusionEngineTest {
     }
 
     @Test
+    fun `CPU-session crash implicating the vulkan driver retries once with vulkan quarantined`() = runTest {
+        val params = ImageGenerationRequest(prompt = "hello")
+
+        every {
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+        } returns io.aatricks.llmedge.core.WorkerCrashedException(
+            backend = "CPU",
+            exitReason = 5,
+            crashSummary = "phase=GENERATING; SIGSEGV | /vendor/lib64/hw/mt6855/vulkan.mtk.so | base.apk!libsdcpp.so",
+        )
+
+        val initConfigs = mutableListOf<WorkerInitConfig>()
+        coEvery { connectionManager.connect(any()) } answers {
+            initConfigs.add(firstArg())
+            connection
+        }
+
+        val requestSlots = mutableListOf<IpcImageRequest>()
+        every {
+            worker.generateImage(any(), any())
+        } answers {
+            val callback = secondArg<IDiffusionResultCallback>()
+            requestSlots.add(firstArg())
+            if (requestSlots.size == 1) {
+                connection.onDeath?.invoke()
+            } else {
+                val shm = SharedMemory.create("test", 12)
+                callback.onCompleted(IpcImageResult(IpcFrameBuffer(shm, 1, 1, 1), null))
+            }
+        }
+        val mockBitmap = mockk<android.graphics.Bitmap>(relaxed = true)
+        every { PixelCodec.decodeBitmap(any()) } returns mockBitmap
+
+        val result = engine.generate(params)
+
+        assertEquals(mockBitmap, result)
+        assertEquals(2, requestSlots.size)
+        assertEquals(false, initConfigs[1].useVulkan)
+        assertTrue(
+            "expected persisted IMAGE:VULKAN verdict",
+            BackendVerdictStore(context).load().contains(
+                io.aatricks.llmedge.runtime.ComputeSubsystem.IMAGE to
+                    io.aatricks.llmedge.runtime.ComputeBackend.VULKAN,
+            ),
+        )
+    }
+
+    @Test
+    fun `CPU-session crash without vulkan driver evidence is not retried`() = runTest {
+        val params = ImageGenerationRequest(prompt = "hello")
+
+        every {
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+        } returns io.aatricks.llmedge.core.WorkerCrashedException(
+            backend = "CPU",
+            exitReason = 5,
+            // The prior-hang marker names VULKAN without implicating the driver in this crash.
+            crashSummary = "phase=GENERATING; gpu-disabled-after-prior-hang(IMAGE:VULKAN)",
+        )
+
+        val requestSlots = mutableListOf<IpcImageRequest>()
+        every {
+            worker.generateImage(any(), any())
+        } answers {
+            requestSlots.add(firstArg())
+            connection.onDeath?.invoke()
+        }
+
+        val error = runCatching { engine.generate(params) }.exceptionOrNull()
+
+        assertTrue(error is io.aatricks.llmedge.core.WorkerCrashedException)
+        assertEquals(1, requestSlots.size)
+        assertTrue(BackendVerdictStore(context).load().isEmpty())
+    }
+
+    @Test
+    fun `vulkan create-failure marker from the worker becomes a persisted verdict`() = runTest {
+        io.aatricks.llmedge.image.diffusion.VulkanCreateFailureMarker.record(context)
+
+        val freshEngine = IsolatedDiffusionEngine(
+            context = context,
+            edgeScope = scope,
+            config = LLMEdgeConfig(),
+            connectionManager = connectionManager,
+        )
+
+        val verdicts = BackendVerdictStore(context).load()
+        assertTrue(
+            "expected IMAGE:VULKAN verdict from marker, got $verdicts",
+            verdicts.contains(
+                io.aatricks.llmedge.runtime.ComputeSubsystem.IMAGE to
+                    io.aatricks.llmedge.runtime.ComputeBackend.VULKAN,
+            ),
+        )
+        assertTrue(
+            "marker file should be consumed",
+            !io.aatricks.llmedge.image.diffusion.VulkanCreateFailureMarker.file(context).exists(),
+        )
+        freshEngine.close()
+    }
+
+    @Test
     fun `forced direct request does not retry after worker OOM during loading`() = runTest {
         val params =
             ImageGenerationRequest(

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerVulkanGateTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerVulkanGateTest.kt
@@ -1,0 +1,37 @@
+package io.aatricks.llmedge.image.ipc
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WorkerVulkanGateTest {
+    @Test
+    fun `vulkan stays enabled with no verdicts`() {
+        assertFalse(WorkerVulkanGate.shouldDisable(useVulkan = true, blacklistSeed = emptyList()))
+    }
+
+    @Test
+    fun `config disable wins`() {
+        assertTrue(WorkerVulkanGate.shouldDisable(useVulkan = false, blacklistSeed = emptyList()))
+    }
+
+    @Test
+    fun `a vulkan verdict disables the driver for the whole worker`() {
+        assertTrue(
+            WorkerVulkanGate.shouldDisable(
+                useVulkan = true,
+                blacklistSeed = listOf("IMAGE:VULKAN"),
+            ),
+        )
+    }
+
+    @Test
+    fun `non-vulkan verdicts do not disable vulkan`() {
+        assertFalse(
+            WorkerVulkanGate.shouldDisable(
+                useVulkan = true,
+                blacklistSeed = listOf("IMAGE:OPENCL"),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Field logs from an OUKITEL WP55 (Dimensity 7025, MediaTek vulkan.mtk.so) show the diffusion worker dying with SIGSEGV inside the vendor Vulkan driver during teardown, even though the session ran on the CPU backend. The driver gets initialized anyway - by the capacity probe or by a failed Vulkan create attempt before the CPU fallback - and on this driver that alone is enough to eventually crash the process.

This adds three layers of containment:

- Once Vulkan is disallowed for a worker (config or persisted verdict), the worker sets GGML_DISABLE_VULKAN before its first native call. That single env var gates the device probe, ggml's backend registry, and sd.cpp backend resolution, so the vendor driver never loads.
- A failed Vulkan nativeCreate writes a fingerprint-keyed marker file (same pattern as the crash breadcrumb); the host converts it into persisted IMAGE and VIDEO Vulkan verdicts so later sessions stop poking the driver.
- A worker crash whose tombstone names a Vulkan driver library now records a Vulkan verdict even when the session backend was CPU, and the request is retried once in a fresh quarantined worker. That exact case was previously rethrown with no verdict and no retry. The prior-hang marker text does not trigger this - only actual driver library frames do.

Verdicts remain keyed to Build.FINGERPRINT, so an OS or driver update clears the quarantine and re-tests Vulkan.

Nine new tests cover the quarantine retry, the no-evidence no-retry case, marker round-trip and staleness, and the gate decisions. Full unit suite passes (432 tests).