### PR TITLE
Image progress streaming, ESRGAN upscaler, and per-tile upscale progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Acknowledgments to Shubham Panchal and upstream projects are listed in [`CREDITS
 - **Optimized Inference**: Native KV cache reuse for compact chats, default batched blocking and streaming text generation, separate prompt vs generation thread tuning, and Kotlin-managed `ChatSession` replay for reasoning-heavy models
 - **Speech-to-Text (STT)**: Whisper.cpp integration with timestamp support, language detection, streaming transcription, and SRT generation
 - **Text-to-Speech (TTS)**: Bark.cpp integration with ARM optimizations
-- **Image Generation**: Stable Diffusion with EasyCache and LoRA support, plus FLUX.2 Klein 4B (distilled DiT, the architecture behind PrismML's binary/ternary Bonsai Image)
+- **Image Generation**: Stable Diffusion with EasyCache and LoRA support, plus FLUX.2 Klein 4B (distilled DiT, the architecture behind PrismML's binary/ternary Bonsai Image); per-step progress streaming and ESRGAN upscaling (Remacri)
 - **Video Generation**: Wan 2.1 models (4-64 frames) with sequential loading
 - **On-device RAG**: PDF indexing, embeddings, vector search, Q&A
 - **OCR**: Google ML Kit text extraction
@@ -528,6 +528,54 @@ imageView.setImageBitmap(bitmap)
 - **LoRA**: Apply fine-tuned weights on the fly without merging models.
 
 For explicit runtime ownership or custom native-load experiments, the `StableDiffusion` class remains available in the expert API layer.
+
+#### Streaming progress
+
+`generate` blocks until the bitmap is ready. To drive a progress bar, use `generateStream`, which emits one `Progress` event per denoising step and a final `Completed` event carrying the image:
+
+```kotlin
+edge.image.generateStream(request).collect { event ->
+    when (event) {
+        is GenerationStreamEvent.Progress ->
+            progressBar.progress = event.update.current * 100 / event.update.total
+        is GenerationStreamEvent.Completed ->
+            imageView.setImageBitmap(event.frames.first())
+    }
+}
+```
+
+Cancelling the collection cancels the generation. Step events only cover the sampling loop; model loading happens before the first event, so keep the bar indeterminate until then. The example app derives a remaining-time estimate from the delay between events (`StepEtaEstimator` in llmedge-examples).
+
+#### Image upscaling (ESRGAN)
+
+`edge.image.upscale` runs an ESRGAN model over a bitmap and returns the enlarged result. Old-architecture ESRGAN checkpoints load directly; 4x_foolhardy_Remacri is the tested reference:
+
+```kotlin
+val esrgan = edge.models.resolve(
+    ModelSpec.huggingFace(
+        repoId = "LyliaEngine/4x_foolhardy_Remacri",
+        filename = "4x_foolhardy_Remacri.safetensors",
+        hints = ModelHints(
+            artifactKind = ModelArtifactKind.REPO_FILE,
+            capabilities = setOf(ModelCapability.IMAGE),
+        ),
+    ),
+)
+
+val upscaled = edge.image.upscale(
+    UpscaleRequest(input = bitmap, model = ModelSpec.localFile(esrgan)),
+) { tile, totalTiles ->
+    // fires once per processed tile
+}
+```
+
+Details worth knowing:
+
+- `factor = 0` (the default) uses the scale baked into the model. Remacri is 4x.
+- The upscaler runs on CPU unless the request sets `useVulkan = true`. Large inputs are processed in 128px tiles, and the progress callback reports tile counts, not steps.
+- Input is capped at 1024×1024. A 4x pass over a 1024px image already produces a 16 MP bitmap, which is near the practical memory limit on mid-range phones.
+- In isolated worker mode the upscale runs in the `:llmedge_sd` process with the same watchdog and crash recovery as image generation.
+- The ESRGAN context is created and freed per call, so expect a short model-load pause (the weights are ~64 MB) before the first tile.
 
 #### MiniT2I
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -144,6 +144,50 @@ val bitmap = edge.image.generate(
 - **LoRA Support**: `ImageGenerationRequest` accepts `loraModelDir` and `loraApplyMode` for on-the-fly fine-tuning.
 - **Flash Attention**: Automatically enabled for compatible image dimensions.
 
+#### Streaming progress
+
+`generate` blocks until the bitmap is ready. `generateStream` emits a `Progress` event per denoising step and finishes with `Completed`:
+
+```kotlin
+edge.image.generateStream(request).collect { event ->
+    when (event) {
+        is GenerationStreamEvent.Progress ->
+            progressBar.progress = event.update.current * 100 / event.update.total
+        is GenerationStreamEvent.Completed ->
+            imageView.setImageBitmap(event.frames.first())
+    }
+}
+```
+
+Cancelling the collection cancels the generation. The step events cover the sampling loop only; model loading happens before the first event arrives. The example app turns the inter-event timing into a remaining-time label (`StepEtaEstimator`).
+
+#### Image upscaling (ESRGAN)
+
+`edge.image.upscale` enlarges a bitmap with an ESRGAN model. 4x_foolhardy_Remacri is the tested reference; other old-architecture ESRGAN checkpoints load the same way.
+
+```kotlin
+val esrgan = edge.models.resolve(
+    ModelSpec.huggingFace(
+        repoId = "LyliaEngine/4x_foolhardy_Remacri",
+        filename = "4x_foolhardy_Remacri.safetensors",
+        hints = ModelHints(
+            artifactKind = ModelArtifactKind.REPO_FILE,
+            capabilities = setOf(ModelCapability.IMAGE),
+        ),
+    ),
+)
+
+val upscaled = edge.image.upscale(
+    UpscaleRequest(input = bitmap, model = ModelSpec.localFile(esrgan)),
+) { tile, totalTiles ->
+    // fires once per processed tile
+}
+```
+
+`factor = 0` uses the model's native scale (4x for Remacri). The upscaler defaults to CPU; set `useVulkan = true` to opt into the GPU path. Inputs above 1024×1024 are rejected because the 4x output would not fit comfortably in memory on most devices. In isolated worker mode the call runs inside the `:llmedge_sd` process, so a native crash is contained and retried on CPU like any other diffusion request. The ESRGAN context is created and freed per call.
+
+The example app has two entry points: the image generation screen upscales its last result, and the standalone upscaler screen takes any picture from the device.
+
 ### Video Generation (Wan 2.1)
 
 Handles the complex multi-model loading (Diffusion, VAE, T5) and sequential processing required for video generation on mobile.

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IDiffusionWorker.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IDiffusionWorker.aidl
@@ -6,6 +6,7 @@ import io.aatricks.llmedge.image.ipc.IpcImageRequest;
 import io.aatricks.llmedge.image.ipc.IpcVideoRequest;
 import io.aatricks.llmedge.image.ipc.IDiffusionResultCallback;
 import io.aatricks.llmedge.image.ipc.IDiffusionVideoCallback;
+import io.aatricks.llmedge.image.ipc.IpcUpscaleRequest;
 
 interface IDiffusionWorker {
     int getPid();
@@ -16,4 +17,5 @@ interface IDiffusionWorker {
     oneway void cancelGeneration();
     // Debug builds only (FLAG_DEBUGGABLE); throws SecurityException otherwise.
     void installFaultInjection(in Bundle args);
+    oneway void upscaleImage(in IpcUpscaleRequest request, IDiffusionResultCallback callback);
 }

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcUpscaleRequest.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcUpscaleRequest.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable IpcUpscaleRequest;

--- a/llmedge/src/main/cpp/cmake/llmedge-stable-diffusion.cmake
+++ b/llmedge/src/main/cpp/cmake/llmedge-stable-diffusion.cmake
@@ -243,6 +243,7 @@ add_library(${LLMEDGE_TARGET_SDCPP} SHARED
         ${LLMEDGE_CPP_ROOT}/sdcpp_jni.cpp
         ${LLMEDGE_CPP_ROOT}/sdcpp_jni_load.cpp
         ${LLMEDGE_CPP_ROOT}/sdcpp_jni_video.cpp
+        ${LLMEDGE_CPP_ROOT}/sdcpp_jni_upscale.cpp
         ${LLMEDGE_CPP_ROOT}/jni_thread_cache.cpp
 )
 

--- a/llmedge/src/main/cpp/sdcpp_jni_upscale.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_upscale.cpp
@@ -1,0 +1,91 @@
+#include "sdcpp_jni_shared.h"
+#include "jni_utils.h"
+
+extern "C" JNIEXPORT jintArray JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeUpscale(
+        JNIEnv* env, jclass clazz, jstring esrganPath, jint nThreads, jint tileSize, jstring backend,
+        jintArray argbPixels, jint width, jint height, jint factor, jintArray outDims) {
+    (void)clazz;
+    std::string pathStr = "";
+    if (esrganPath) {
+        pathStr = llmedge_jstring_to_utf8(env, esrganPath);
+    }
+    std::string backendStr = "cpu";
+    if (backend) {
+        backendStr = llmedge_jstring_to_utf8(env, backend);
+    }
+
+    const int pixelCount = width * height;
+    jint* pixels = env->GetIntArrayElements(argbPixels, nullptr);
+    if (!pixels) {
+        throwJavaException(env, "java/lang/IllegalArgumentException", "Failed to get input ARGB pixels");
+        return nullptr;
+    }
+
+    uint8_t* rgbData = static_cast<uint8_t*>(malloc(pixelCount * 3));
+    if (!rgbData) {
+        env->ReleaseIntArrayElements(argbPixels, pixels, JNI_ABORT);
+        throwJavaException(env, "java/lang/OutOfMemoryError", "Failed to allocate memory for upscaler input");
+        return nullptr;
+    }
+
+    for (int i = 0; i < pixelCount; ++i) {
+        jint val = pixels[i];
+        rgbData[3 * i + 0] = static_cast<uint8_t>((val >> 16) & 0xFF);
+        rgbData[3 * i + 1] = static_cast<uint8_t>((val >> 8) & 0xFF);
+        rgbData[3 * i + 2] = static_cast<uint8_t>(val & 0xFF);
+    }
+    env->ReleaseIntArrayElements(argbPixels, pixels, JNI_ABORT);
+
+    upscaler_ctx_t* ctx = new_upscaler_ctx(pathStr.c_str(), false, nThreads, tileSize, backendStr.c_str(), backendStr.c_str());
+    if (!ctx) {
+        free(rgbData);
+        throwJavaException(env, "java/lang/RuntimeException", "Failed to create upscaler context");
+        return nullptr;
+    }
+
+    sd_image_t input;
+    input.width = static_cast<uint32_t>(width);
+    input.height = static_cast<uint32_t>(height);
+    input.channel = 3;
+    input.data = rgbData;
+
+    int effectiveFactor = (factor == 0) ? get_upscale_factor(ctx) : factor;
+
+    sd_image_t* images_out = nullptr;
+    int num_images_out = 0;
+    bool success = upscale(ctx, input, static_cast<uint32_t>(effectiveFactor), &images_out, &num_images_out);
+
+    free(rgbData);
+
+    if (!success || num_images_out < 1) {
+        if (images_out) {
+            free_sd_images(images_out, num_images_out);
+        }
+        free_upscaler_ctx(ctx);
+        throwJavaException(env, "java/lang/RuntimeException", "Upscale operation failed");
+        return nullptr;
+    }
+
+    jintArray result = rgb_to_argb_int_array(env, images_out[0].data, images_out[0].width, images_out[0].height, images_out[0].channel);
+    if (!result) {
+        free_sd_images(images_out, num_images_out);
+        free_upscaler_ctx(ctx);
+        if (!env->ExceptionCheck()) {
+            throwJavaException(env, "java/lang/OutOfMemoryError", "Failed to allocate ARGB destination array");
+        }
+        return nullptr;
+    }
+
+    if (outDims) {
+        jsize outDimsLen = env->GetArrayLength(outDims);
+        if (outDimsLen >= 2) {
+            jint dims[2] = { static_cast<jint>(images_out[0].width), static_cast<jint>(images_out[0].height) };
+            env->SetIntArrayRegion(outDims, 0, 2, dims);
+        }
+    }
+
+    free_sd_images(images_out, num_images_out);
+    free_upscaler_ctx(ctx);
+
+    return result;
+}

--- a/llmedge/src/main/cpp/sdcpp_jni_upscale.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_upscale.cpp
@@ -1,9 +1,31 @@
 #include "sdcpp_jni_shared.h"
 #include "jni_utils.h"
 
+struct UpscaleProgressContext {
+    JNIEnv* env;
+    jobject cb;
+    jmethodID mid;
+};
+
+static void upscale_progress_wrapper(int step, int steps, float time, void* data) {
+    auto* ctx = static_cast<UpscaleProgressContext*>(data);
+    if (!ctx || !ctx->env || !ctx->cb || !ctx->mid) {
+        return;
+    }
+    ctx->env->CallVoidMethod(ctx->cb, ctx->mid,
+                             static_cast<jint>(step),
+                             static_cast<jint>(steps),
+                             static_cast<jint>(0),
+                             static_cast<jint>(0),
+                             static_cast<jfloat>(time));
+    if (ctx->env->ExceptionCheck()) {
+        ctx->env->ExceptionClear();
+    }
+}
+
 extern "C" JNIEXPORT jintArray JNICALL Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeUpscale(
         JNIEnv* env, jclass clazz, jstring esrganPath, jint nThreads, jint tileSize, jstring backend,
-        jintArray argbPixels, jint width, jint height, jint factor, jintArray outDims) {
+        jintArray argbPixels, jint width, jint height, jint factor, jintArray outDims, jobject progressCallback) {
     (void)clazz;
     std::string pathStr = "";
     if (esrganPath) {
@@ -51,6 +73,26 @@ extern "C" JNIEXPORT jintArray JNICALL Java_io_aatricks_llmedge_image_diffusion_
 
     int effectiveFactor = (factor == 0) ? get_upscale_factor(ctx) : factor;
 
+    bool callbackInstalled = false;
+    UpscaleProgressContext cbCtx{env, progressCallback, nullptr};
+    if (progressCallback) {
+        jmethodID mid = llmedge_get_callback_method(
+                env,
+                progressCallback,
+                "onProgress",
+                "(IIIIF)V",
+                "java/lang/NoSuchMethodError",
+                "onProgress method not found");
+        if (!mid) {
+            free(rgbData);
+            free_upscaler_ctx(ctx);
+            return nullptr;
+        }
+        cbCtx.mid = mid;
+        sd_set_progress_callback(upscale_progress_wrapper, &cbCtx);
+        callbackInstalled = true;
+    }
+
     sd_image_t* images_out = nullptr;
     int num_images_out = 0;
     bool success = upscale(ctx, input, static_cast<uint32_t>(effectiveFactor), &images_out, &num_images_out);
@@ -61,6 +103,9 @@ extern "C" JNIEXPORT jintArray JNICALL Java_io_aatricks_llmedge_image_diffusion_
         if (images_out) {
             free_sd_images(images_out, num_images_out);
         }
+        if (callbackInstalled) {
+            sd_set_progress_callback(nullptr, nullptr);
+        }
         free_upscaler_ctx(ctx);
         throwJavaException(env, "java/lang/RuntimeException", "Upscale operation failed");
         return nullptr;
@@ -69,6 +114,9 @@ extern "C" JNIEXPORT jintArray JNICALL Java_io_aatricks_llmedge_image_diffusion_
     jintArray result = rgb_to_argb_int_array(env, images_out[0].data, images_out[0].width, images_out[0].height, images_out[0].channel);
     if (!result) {
         free_sd_images(images_out, num_images_out);
+        if (callbackInstalled) {
+            sd_set_progress_callback(nullptr, nullptr);
+        }
         free_upscaler_ctx(ctx);
         if (!env->ExceptionCheck()) {
             throwJavaException(env, "java/lang/OutOfMemoryError", "Failed to allocate ARGB destination array");
@@ -84,6 +132,9 @@ extern "C" JNIEXPORT jintArray JNICALL Java_io_aatricks_llmedge_image_diffusion_
         }
     }
 
+    if (callbackInstalled) {
+        sd_set_progress_callback(nullptr, nullptr);
+    }
     free_sd_images(images_out, num_images_out);
     free_upscaler_ctx(ctx);
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
@@ -177,6 +177,18 @@ class ImageClient internal constructor(
         params: VideoGenerationRequest,
     ): Flow<GenerationStreamEvent> = engine.generateVideo(params)
 
+    /**
+     * Stream progress and the final image for text-to-image generation.
+     *
+     * Cancel the collection to stop generation.
+     *
+     * @throws io.aatricks.llmedge.core.LLMEdgeException when model resolution, loading, or native
+     * generation fails.
+     */
+    fun generateStream(
+        params: ImageGenerationRequest,
+    ): Flow<GenerationStreamEvent> = engine.generateStream(params)
+
     /** Request cancellation for the active generation, if any. */
     fun cancelGeneration() {
         engine.cancelGeneration()

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
@@ -204,11 +204,11 @@ class ImageClient internal constructor(
      * @throws IllegalArgumentException if the input image dimensions exceed 1024x1024
      * @throws io.aatricks.llmedge.core.LLMEdgeException if the upscaling process fails
      */
-    suspend fun upscale(request: UpscaleRequest): Bitmap {
+    suspend fun upscale(request: UpscaleRequest, onProgress: ((current: Int, total: Int) -> Unit)? = null): Bitmap {
         require(request.input.width <= 1024 && request.input.height <= 1024) {
             "Input image dimensions must not exceed 1024x1024 (got ${request.input.width}x${request.input.height})"
         }
-        return engine.upscale(request)
+        return engine.upscale(request, onProgress)
     }
 
     /** Request cancellation for the active generation, if any. */

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
@@ -61,6 +61,13 @@ data class ImageGenerationRequest(
     val sequential: Boolean? = null,
 )
 
+data class UpscaleRequest(
+    val input: Bitmap,
+    val model: ModelSpec,
+    val factor: Int = 0,
+    val useVulkan: Boolean = false,
+)
+
 data class VideoGenerationRequest(
     val prompt: String,
     val negative: String = "",
@@ -188,6 +195,21 @@ class ImageClient internal constructor(
     fun generateStream(
         params: ImageGenerationRequest,
     ): Flow<GenerationStreamEvent> = engine.generateStream(params)
+
+    /**
+     * Upscales an input image using an ESRGAN model.
+     *
+     * @param request the upscaling request details
+     * @return the upscaled Bitmap
+     * @throws IllegalArgumentException if the input image dimensions exceed 1024x1024
+     * @throws io.aatricks.llmedge.core.LLMEdgeException if the upscaling process fails
+     */
+    suspend fun upscale(request: UpscaleRequest): Bitmap {
+        require(request.input.width <= 1024 && request.input.height <= 1024) {
+            "Input image dimensions must not exceed 1024x1024 (got ${request.input.width}x${request.input.height})"
+        }
+        return engine.upscale(request)
+    }
 
     /** Request cancellation for the active generation, if any. */
     fun cancelGeneration() {

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageGenerationExecutor.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageGenerationExecutor.kt
@@ -27,23 +27,26 @@ internal class ImageGenerationExecutor(
     private val logTag: String,
     private val phaseListener: DiffusionPhaseListener? = null,
 ) {
-    suspend fun generate(params: ImageGenerationRequest): Bitmap =
+    suspend fun generate(
+        params: ImageGenerationRequest,
+        onProgress: ((step: Int, totalSteps: Int) -> Unit)? = null
+    ): Bitmap =
         generationMutex.withLock {
             val decision = executionPlanSelector.decide(params, config)
             if (decision.mode == ImageExecutionMode.SEQUENTIAL) {
-                return@withLock generateSequential(params, decision.recipe.profile)
+                return@withLock generateSequential(params, decision.recipe.profile, onProgress)
             }
 
             val directRequest = ImageRuntimeRequestPlanner.imageRequest(params, config)
             try {
-                generateDirect(params, directRequest)
+                generateDirect(params, directRequest, onProgress)
             } catch (error: ModelLoadException) {
                 if (params.sequential != null || !decision.recipe.supportsSequential) {
                     throw error
                 }
                 requestExecutor.invalidateRuntime(directRequest.spec, directRequest.options)
                 AndroidLogAdapter.w(logTag, "Automatic direct image load failed; retrying staged ${decision.recipe.profile} execution")
-                generateSequential(params, decision.recipe.profile)
+                generateSequential(params, decision.recipe.profile, onProgress)
             }
         }
 
@@ -59,6 +62,7 @@ internal class ImageGenerationExecutor(
     private suspend fun generateSequential(
         params: ImageGenerationRequest,
         profile: ImageConditioningProfile,
+        onProgress: ((step: Int, totalSteps: Int) -> Unit)? = null,
     ): Bitmap {
         state.resetForRequest()
         val isSd3 = profile == ImageConditioningProfile.SD3_CLIP_T5
@@ -178,24 +182,31 @@ internal class ImageGenerationExecutor(
             retryMessage = "Retrying $modelName sequential diffusion on the next backend for",
         ) { model, _, acquire ->
             phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.GENERATING, acquire.backend.name)
-            phaseListener?.let { listener ->
+            if (phaseListener != null || onProgress != null) {
                 model.setProgressCallback { step, totalSteps, _, _, _ ->
-                    listener.onStep(step, totalSteps)
+                    phaseListener?.onStep(step, totalSteps)
+                    onProgress?.invoke(step, totalSteps)
                 }
             }
-            val rgb =
-                model.txt2ImgWithPrecomputedCondition(
-                    prompt = params.prompt,
-                    negative = if (isSd3 || isChroma) params.negative else "",
-                    width = params.width,
-                    height = params.height,
-                    steps = params.steps,
-                    cfg = params.cfgScale,
-                    seed = params.seed,
-                    cond = cond,
-                    uncond = uncond,
-                ) ?: throw IllegalStateException("$modelName sequential generation returned null")
-            rgbToBitmap(rgb, params.width, params.height)
+            try {
+                val rgb =
+                    model.txt2ImgWithPrecomputedCondition(
+                        prompt = params.prompt,
+                        negative = if (isSd3 || isChroma) params.negative else "",
+                        width = params.width,
+                        height = params.height,
+                        steps = params.steps,
+                        cfg = params.cfgScale,
+                        seed = params.seed,
+                        cond = cond,
+                        uncond = uncond,
+                    ) ?: throw IllegalStateException("$modelName sequential generation returned null")
+                rgbToBitmap(rgb, params.width, params.height)
+            } finally {
+                if (phaseListener != null || onProgress != null) {
+                    model.setProgressCallback(null)
+                }
+            }
         }
     }
 
@@ -279,6 +290,7 @@ internal class ImageGenerationExecutor(
     private suspend fun generateDirect(
         params: ImageGenerationRequest,
         request: PlannedDiffusionRuntimeRequest,
+        onProgress: ((step: Int, totalSteps: Int) -> Unit)? = null,
     ): Bitmap {
         state.resetForRequest()
         val requestId = imageRequestIds.incrementAndGet()
@@ -329,9 +341,10 @@ internal class ImageGenerationExecutor(
                     "ImageClient dispatching to StableDiffusion.txt2img",
                 )
                 phaseListener?.onPhase(io.aatricks.llmedge.image.ipc.DiffusionPhases.GENERATING, acquire.backend.name)
-                phaseListener?.let { listener ->
+                if (phaseListener != null || onProgress != null) {
                     model.setProgressCallback { step, totalSteps, _, _, _ ->
-                        listener.onStep(step, totalSteps)
+                        phaseListener?.onStep(step, totalSteps)
+                        onProgress?.invoke(step, totalSteps)
                     }
                 }
                 val generationStartNanos = System.nanoTime()
@@ -350,7 +363,7 @@ internal class ImageGenerationExecutor(
                             ),
                         )
                     } finally {
-                        if (phaseListener != null) model.setProgressCallback(null)
+                        if (phaseListener != null || onProgress != null) model.setProgressCallback(null)
                     }
                 val generateMs = elapsedMillis(generationStartNanos)
                 val requestMetrics =

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
@@ -635,6 +635,7 @@ class StableDiffusion internal constructor(
             height: Int,
             factor: Int,
             outDims: IntArray,
+            progress: VideoProgressCallback?,
         ): IntArray?
 
         internal fun upscaleImage(
@@ -643,7 +644,8 @@ class StableDiffusion internal constructor(
             factor: Int,
             nThreads: Int,
             tileSize: Int,
-            backend: String
+            backend: String,
+            onProgress: VideoProgressCallback? = null,
         ): Bitmap {
             val width = input.width
             val height = input.height
@@ -662,7 +664,8 @@ class StableDiffusion internal constructor(
                 width = width,
                 height = height,
                 factor = factor,
-                outDims = outDims
+                outDims = outDims,
+                progress = onProgress
             ) ?: throw InferenceFailedException("upscale", "native upscale failed or returned null result")
 
             val outW = outDims[0]

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
@@ -623,6 +623,54 @@ class StableDiffusion internal constructor(
         internal fun supportNativeBridgeOverriddenForTests(): Boolean =
             StableDiffusionCompanionSupport.supportNativeBridgeOverriddenForTests()
 
+        @JvmStatic
+        @JvmName("nativeUpscale")
+        internal external fun nativeUpscale(
+            esrganPath: String,
+            nThreads: Int,
+            tileSize: Int,
+            backend: String,
+            pixels: IntArray,
+            width: Int,
+            height: Int,
+            factor: Int,
+            outDims: IntArray,
+        ): IntArray?
+
+        internal fun upscaleImage(
+            modelPath: String,
+            input: Bitmap,
+            factor: Int,
+            nThreads: Int,
+            tileSize: Int,
+            backend: String
+        ): Bitmap {
+            val width = input.width
+            val height = input.height
+            val pixels = IntArray(width * height)
+            input.getPixels(pixels, 0, width, 0, 0, width, height)
+            val outDims = IntArray(2)
+
+            val dummyInstance = StableDiffusion(0)
+            val bridge = StableDiffusionCompanionSupport.createNativeBridge(dummyInstance)
+            val resultPixels = bridge.upscale(
+                esrganPath = modelPath,
+                nThreads = nThreads,
+                tileSize = tileSize,
+                backend = backend,
+                pixels = pixels,
+                width = width,
+                height = height,
+                factor = factor,
+                outDims = outDims
+            ) ?: throw InferenceFailedException("upscale", "native upscale failed or returned null result")
+
+            val outW = outDims[0]
+            val outH = outDims[1]
+            val outBitmap = Bitmap.createBitmap(outW, outH, Bitmap.Config.ARGB_8888)
+            outBitmap.setPixels(resultPixels, 0, outW, 0, 0, outW, outH)
+            return outBitmap
+        }
     }
 
     internal fun updateModelMetadata(metadata: VideoModelMetadata?) {

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionNativeBridgeContract.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionNativeBridgeContract.kt
@@ -215,4 +215,28 @@ internal interface StableDiffusionNativeBridgeContract {
         factor: Int,
         outDims: IntArray,
     ): IntArray? = throw UnsatisfiedLinkError("nativeUpscale")
+
+    fun upscale(
+        esrganPath: String,
+        nThreads: Int,
+        tileSize: Int,
+        backend: String,
+        pixels: IntArray,
+        width: Int,
+        height: Int,
+        factor: Int,
+        outDims: IntArray,
+        progress: VideoProgressCallback?,
+    ): IntArray? =
+        upscale(
+            esrganPath = esrganPath,
+            nThreads = nThreads,
+            tileSize = tileSize,
+            backend = backend,
+            pixels = pixels,
+            width = width,
+            height = height,
+            factor = factor,
+            outDims = outDims,
+        )
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionNativeBridgeContract.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionNativeBridgeContract.kt
@@ -203,4 +203,16 @@ internal interface StableDiffusionNativeBridgeContract {
             easyCacheStartPercent,
             easyCacheEndPercent,
         )
+
+    fun upscale(
+        esrganPath: String,
+        nThreads: Int,
+        tileSize: Int,
+        backend: String,
+        pixels: IntArray,
+        width: Int,
+        height: Int,
+        factor: Int,
+        outDims: IntArray,
+    ): IntArray? = throw UnsatisfiedLinkError("nativeUpscale")
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionNativeBridgeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionNativeBridgeSupport.kt
@@ -280,6 +280,31 @@ internal object StableDiffusionNativeBridgeSupport {
                 factor: Int,
                 outDims: IntArray,
             ): IntArray? =
+                upscale(
+                    esrganPath = esrganPath,
+                    nThreads = nThreads,
+                    tileSize = tileSize,
+                    backend = backend,
+                    pixels = pixels,
+                    width = width,
+                    height = height,
+                    factor = factor,
+                    outDims = outDims,
+                    progress = null,
+                )
+
+            override fun upscale(
+                esrganPath: String,
+                nThreads: Int,
+                tileSize: Int,
+                backend: String,
+                pixels: IntArray,
+                width: Int,
+                height: Int,
+                factor: Int,
+                outDims: IntArray,
+                progress: VideoProgressCallback?,
+            ): IntArray? =
                 StableDiffusion.nativeUpscale(
                     esrganPath = esrganPath,
                     nThreads = nThreads,
@@ -289,7 +314,8 @@ internal object StableDiffusionNativeBridgeSupport {
                     width = width,
                     height = height,
                     factor = factor,
-                    outDims = outDims
+                    outDims = outDims,
+                    progress = progress,
                 )
         }
     }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionNativeBridgeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionNativeBridgeSupport.kt
@@ -268,6 +268,29 @@ internal object StableDiffusionNativeBridgeSupport {
                     easyCacheStartPercent,
                     easyCacheEndPercent,
                 )
+
+            override fun upscale(
+                esrganPath: String,
+                nThreads: Int,
+                tileSize: Int,
+                backend: String,
+                pixels: IntArray,
+                width: Int,
+                height: Int,
+                factor: Int,
+                outDims: IntArray,
+            ): IntArray? =
+                StableDiffusion.nativeUpscale(
+                    esrganPath = esrganPath,
+                    nThreads = nThreads,
+                    tileSize = tileSize,
+                    backend = backend,
+                    pixels = pixels,
+                    width = width,
+                    height = height,
+                    factor = factor,
+                    outDims = outDims
+                )
         }
     }
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionEngine.kt
@@ -16,6 +16,8 @@ import io.aatricks.llmedge.image.diffusion.ImageGenerationTraceEvent
 internal interface DiffusionEngine : AutoCloseable {
     suspend fun generate(params: ImageGenerationRequest): Bitmap
 
+    fun generateStream(params: ImageGenerationRequest): kotlinx.coroutines.flow.Flow<GenerationStreamEvent>
+
     fun generateVideo(params: VideoGenerationRequest): kotlinx.coroutines.flow.Flow<GenerationStreamEvent>
 
     fun cancelGeneration()

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionEngine.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import io.aatricks.llmedge.image.GenerationStreamEvent
 import io.aatricks.llmedge.image.ImageGenerationRequest
 import io.aatricks.llmedge.image.VideoGenerationRequest
+import io.aatricks.llmedge.image.UpscaleRequest
 import io.aatricks.llmedge.image.diffusion.GenerationMetrics
 import io.aatricks.llmedge.image.diffusion.ImageGenerationTraceEvent
 
@@ -19,6 +20,8 @@ internal interface DiffusionEngine : AutoCloseable {
     fun generateStream(params: ImageGenerationRequest): kotlinx.coroutines.flow.Flow<GenerationStreamEvent>
 
     fun generateVideo(params: VideoGenerationRequest): kotlinx.coroutines.flow.Flow<GenerationStreamEvent>
+
+    suspend fun upscale(request: UpscaleRequest): Bitmap
 
     fun cancelGeneration()
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionEngine.kt
@@ -21,7 +21,7 @@ internal interface DiffusionEngine : AutoCloseable {
 
     fun generateVideo(params: VideoGenerationRequest): kotlinx.coroutines.flow.Flow<GenerationStreamEvent>
 
-    suspend fun upscale(request: UpscaleRequest): Bitmap
+    suspend fun upscale(request: UpscaleRequest, onProgress: ((current: Int, total: Int) -> Unit)? = null): Bitmap
 
     fun cancelGeneration()
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
@@ -200,6 +200,42 @@ internal class DiffusionWorkerService : Service() {
                 faultInjection = args
                 AndroidLogAdapter.w(LOG_TAG, "Fault injection installed: ${args.getString(FAULT_MODE)}")
             }
+
+            override fun upscaleImage(
+                request: IpcUpscaleRequest,
+                callback: IDiffusionResultCallback,
+            ) {
+                val activeEngine = engine
+                serviceScope.launch {
+                    phaseSink = { update -> runCatching { callback.onPhase(update) } }
+                    if (simulateFaultIfRequested()) return@launch
+                    if (activeEngine == null) {
+                        runCatching { callback.onFailed(failure(IllegalStateException("worker not initialized"))) }
+                        phaseSink = null
+                        runCatching { request.input.memory.close() }
+                        return@launch
+                    }
+                    try {
+                        phaseRelay.onPhase(DiffusionPhases.LOADING, null)
+                        val kotlinRequest = IpcCodecs.fromIpc(request)
+                        val useVulkan = request.useVulkan && !BackendRuntimePolicy.isBlacklisted(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
+                        val backendName = if (useVulkan) "vulkan" else "cpu"
+                        phaseRelay.onPhase(DiffusionPhases.GENERATING, backendName)
+                        val bitmap = activeEngine.upscale(kotlinRequest)
+                        val frame = PixelCodec.encodeBitmap(bitmap, "llmedge_upscale_result")
+                        try {
+                            callback.onCompleted(IpcImageResult(frame = frame, metrics = null))
+                        } finally {
+                            frame.memory.close()
+                        }
+                    } catch (t: Throwable) {
+                        runCatching { callback.onFailed(failure(t)) }
+                    } finally {
+                        phaseSink = null
+                        runCatching { request.input.memory.close() }
+                    }
+                }
+            }
         }
 
     /** Returns true when a fault was simulated instead of generating. */

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
@@ -221,7 +221,9 @@ internal class DiffusionWorkerService : Service() {
                         val useVulkan = request.useVulkan && !BackendRuntimePolicy.isBlacklisted(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
                         val backendName = if (useVulkan) "vulkan" else "cpu"
                         phaseRelay.onPhase(DiffusionPhases.GENERATING, backendName)
-                        val bitmap = activeEngine.upscale(kotlinRequest)
+                        val bitmap = activeEngine.upscale(kotlinRequest) { step, total ->
+                            phaseRelay.onStep(step, total)
+                        }
                         val frame = PixelCodec.encodeBitmap(bitmap, "llmedge_upscale_result")
                         try {
                             callback.onCompleted(IpcImageResult(frame = frame, metrics = null))

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/InProcessDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/InProcessDiffusionEngine.kt
@@ -19,19 +19,27 @@ import io.aatricks.llmedge.image.diffusion.GenerationMetrics
 import io.aatricks.llmedge.image.diffusion.ImageGenerationTraceEvent
 import io.aatricks.llmedge.model.ModelRepository
 import io.aatricks.llmedge.core.ProgressEvent
+import io.aatricks.llmedge.image.UpscaleRequest
+import io.aatricks.llmedge.image.diffusion.StableDiffusion
+import io.aatricks.llmedge.runtime.ComputeSubsystem
+import io.aatricks.llmedge.runtime.ComputeBackend
+import io.aatricks.llmedge.runtime.BackendRuntimePolicy
+import io.aatricks.llmedge.runtime.CpuTopology
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 
 /** The historical in-process diffusion stack, extracted verbatim from ImageClient. */
 internal class InProcessDiffusionEngine(
-    appContext: Context,
+    private val appContext: Context,
     private val edgeScope: LLMEdgeScope,
-    config: LLMEdgeConfig,
-    modelRepository: ModelRepository,
+    private val config: LLMEdgeConfig,
+    private val modelRepository: ModelRepository,
     logTag: String = "ImageClient",
     phaseListener: DiffusionPhaseListener? = null,
 ) : DiffusionEngine {
@@ -86,6 +94,27 @@ internal class InProcessDiffusionEngine(
 
     override fun generateVideo(params: VideoGenerationRequest): Flow<GenerationStreamEvent> =
         videoGenerationExecutor.generate(params)
+
+    override suspend fun upscale(request: UpscaleRequest): Bitmap {
+        val resolvedModel = modelRepository.resolve(appContext, request.model)
+        val useVulkan = request.useVulkan && !BackendRuntimePolicy.isBlacklisted(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
+        val backend = if (useVulkan) "vulkan" else "cpu"
+        val nThreads = CpuTopology.getOptimalThreadCount(CpuTopology.TaskType.DIFFUSION)
+        val tileSize = 128
+
+        return generationMutex.withLock {
+            withContext(StableDiffusion.diffusionDispatcher) {
+                StableDiffusion.upscaleImage(
+                    modelPath = resolvedModel.absolutePath,
+                    input = request.input,
+                    factor = request.factor,
+                    nThreads = nThreads,
+                    tileSize = tileSize,
+                    backend = backend,
+                )
+            }
+        }
+    }
 
     override fun cancelGeneration() {
         state.activeModel?.cancelGeneration()

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/InProcessDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/InProcessDiffusionEngine.kt
@@ -95,7 +95,7 @@ internal class InProcessDiffusionEngine(
     override fun generateVideo(params: VideoGenerationRequest): Flow<GenerationStreamEvent> =
         videoGenerationExecutor.generate(params)
 
-    override suspend fun upscale(request: UpscaleRequest): Bitmap {
+    override suspend fun upscale(request: UpscaleRequest, onProgress: ((current: Int, total: Int) -> Unit)?): Bitmap {
         val resolvedModel = modelRepository.resolve(appContext, request.model)
         val useVulkan = request.useVulkan && !BackendRuntimePolicy.isBlacklisted(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
         val backend = if (useVulkan) "vulkan" else "cpu"
@@ -104,6 +104,11 @@ internal class InProcessDiffusionEngine(
 
         return generationMutex.withLock {
             withContext(StableDiffusion.diffusionDispatcher) {
+                val progressCallback = onProgress?.let {
+                    io.aatricks.llmedge.image.diffusion.VideoProgressCallback { step, total, _, _, _ ->
+                        it.invoke(step, total)
+                    }
+                }
                 StableDiffusion.upscaleImage(
                     modelPath = resolvedModel.absolutePath,
                     input = request.input,
@@ -111,6 +116,7 @@ internal class InProcessDiffusionEngine(
                     nThreads = nThreads,
                     tileSize = tileSize,
                     backend = backend,
+                    onProgress = progressCallback,
                 )
             }
         }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/InProcessDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/InProcessDiffusionEngine.kt
@@ -18,14 +18,18 @@ import io.aatricks.llmedge.image.createDiffusionRuntimePool
 import io.aatricks.llmedge.image.diffusion.GenerationMetrics
 import io.aatricks.llmedge.image.diffusion.ImageGenerationTraceEvent
 import io.aatricks.llmedge.model.ModelRepository
+import io.aatricks.llmedge.core.ProgressEvent
 import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 
 /** The historical in-process diffusion stack, extracted verbatim from ImageClient. */
 internal class InProcessDiffusionEngine(
     appContext: Context,
-    edgeScope: LLMEdgeScope,
+    private val edgeScope: LLMEdgeScope,
     config: LLMEdgeConfig,
     modelRepository: ModelRepository,
     logTag: String = "ImageClient",
@@ -59,6 +63,26 @@ internal class InProcessDiffusionEngine(
         )
 
     override suspend fun generate(params: ImageGenerationRequest): Bitmap = imageGenerationExecutor.generate(params)
+
+    override fun generateStream(params: ImageGenerationRequest): Flow<GenerationStreamEvent> =
+        callbackFlow {
+            val job =
+                edgeScope.coroutineScope.launch {
+                    try {
+                        val bitmap = imageGenerationExecutor.generate(params) { step, totalSteps ->
+                            trySend(GenerationStreamEvent.Progress(ProgressEvent.Step("Sampling", step, totalSteps)))
+                        }
+                        trySend(GenerationStreamEvent.Completed(listOf(bitmap)))
+                        close()
+                    } catch (t: Throwable) {
+                        close(t)
+                    }
+                }
+            awaitClose {
+                job.cancel()
+                cancelGeneration()
+            }
+        }
 
     override fun generateVideo(params: VideoGenerationRequest): Flow<GenerationStreamEvent> =
         videoGenerationExecutor.generate(params)

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcCodecs.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcCodecs.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.os.SharedMemory
 import io.aatricks.llmedge.image.ImageGenerationRequest
 import io.aatricks.llmedge.image.VideoGenerationRequest
+import io.aatricks.llmedge.image.UpscaleRequest
 import io.aatricks.llmedge.image.diffusion.EasyCacheParams
 import io.aatricks.llmedge.image.diffusion.GenerationMetrics
 import io.aatricks.llmedge.image.diffusion.ImageRequestMetrics
@@ -22,6 +23,22 @@ import java.io.File
 internal object IpcCodecs {
     private const val TYPE_LOCAL = "local"
     private const val TYPE_HF = "hf"
+
+    fun toIpc(request: UpscaleRequest): IpcUpscaleRequest =
+        IpcUpscaleRequest(
+            model = toIpc(request.model),
+            input = PixelCodec.encodeBitmap(request.input, "llmedge_upscale_input"),
+            factor = request.factor,
+            useVulkan = request.useVulkan,
+        )
+
+    fun fromIpc(request: IpcUpscaleRequest): UpscaleRequest =
+        UpscaleRequest(
+            model = fromIpc(request.model),
+            input = PixelCodec.decodeBitmap(request.input),
+            factor = request.factor,
+            useVulkan = request.useVulkan,
+        )
 
     fun toIpc(spec: ModelSpec): IpcModelSpec =
         when (spec) {

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcTypes.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcTypes.kt
@@ -147,6 +147,14 @@ internal data class IpcVideoResult(
 ) : Parcelable
 
 @Parcelize
+internal data class IpcUpscaleRequest(
+    val model: IpcModelSpec,
+    val input: IpcFrameBuffer,
+    val factor: Int,
+    val useVulkan: Boolean,
+) : Parcelable
+
+@Parcelize
 internal data class PhaseUpdate(
     /** One of [DiffusionPhases]. */
     val phase: String,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
@@ -15,6 +15,7 @@ import io.aatricks.llmedge.image.GenerationStreamEvent
 import io.aatricks.llmedge.image.ImageExecutionPlanner
 import io.aatricks.llmedge.image.ImageGenerationRequest
 import io.aatricks.llmedge.image.VideoGenerationRequest
+import io.aatricks.llmedge.image.UpscaleRequest
 import io.aatricks.llmedge.image.diffusion.GenerationMetrics
 import io.aatricks.llmedge.image.diffusion.ImageGenerationTraceEvent
 import io.aatricks.llmedge.runtime.BackendRuntimePolicy
@@ -120,6 +121,17 @@ internal class IsolatedDiffusionEngine(
         params.sequential == null &&
             ImageExecutionPlanner.recipeFor(params).supportsSequential &&
             lastPhase == DiffusionPhases.LOADING
+
+    override suspend fun upscale(request: UpscaleRequest): Bitmap =
+        generationMutex.withLock {
+            val phaseTracker = ImageRequestPhaseTracker()
+            val result =
+                runWithRecovery(ComputeSubsystem.IMAGE) { forceCpu ->
+                    issueUpscaleRequest(request, forceCpu, phaseTracker)
+                }
+            lastMetrics = result.metrics?.let(IpcCodecs::fromIpc)
+            PixelCodec.decodeBitmap(result.frame)
+        }
 
     override fun generateStream(params: ImageGenerationRequest): Flow<GenerationStreamEvent> =
         callbackFlow {
@@ -284,6 +296,38 @@ internal class IsolatedDiffusionEngine(
                     }
                 }
             connection.worker.generateImage(IpcCodecs.toIpc(params), callback)
+        }
+    }
+
+    private suspend fun issueUpscaleRequest(
+        request: UpscaleRequest,
+        forceCpu: Boolean,
+        phaseTracker: ImageRequestPhaseTracker? = null,
+    ): IpcImageResult {
+        val deferred = CompletableDeferred<IpcImageResult>()
+        val finalRequest = if (forceCpu) request.copy(useVulkan = false) else request
+        val ipcRequest = IpcCodecs.toIpc(finalRequest)
+        try {
+            return runRequest(deferred, forceCpu) { connection, watchdog ->
+                val callback =
+                    object : IDiffusionResultCallback.Stub() {
+                        override fun onPhase(update: PhaseUpdate) {
+                            phaseTracker?.lastPhase = update.phase
+                            dispatchPhase(watchdog, update)
+                        }
+
+                        override fun onCompleted(result: IpcImageResult) {
+                            deferred.complete(result)
+                        }
+
+                        override fun onFailed(failure: IpcFailure) {
+                            deferred.completeExceptionally(mapFailure("upscale", failure))
+                        }
+                    }
+                connection.worker.upscaleImage(ipcRequest, callback)
+            }
+        } finally {
+            ipcRequest.input.memory.close()
         }
     }
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
@@ -83,12 +83,18 @@ internal class IsolatedDiffusionEngine(
     }
 
     override suspend fun generate(params: ImageGenerationRequest): Bitmap =
+        generateBitmapInternal(params, null)
+
+    private suspend fun generateBitmapInternal(
+        params: ImageGenerationRequest,
+        onStep: ((Int, Int) -> Unit)?,
+    ): Bitmap =
         generationMutex.withLock {
             val phaseTracker = ImageRequestPhaseTracker()
             try {
                 val result =
                     runWithRecovery(ComputeSubsystem.IMAGE) { forceCpu ->
-                        issueImageRequest(params, forceCpu, phaseTracker)
+                        issueImageRequest(params, forceCpu, phaseTracker, onStep)
                     }
                 lastMetrics = result.metrics?.let(IpcCodecs::fromIpc)
                 PixelCodec.decodeBitmap(result.frame)
@@ -97,7 +103,7 @@ internal class IsolatedDiffusionEngine(
                     AndroidLogAdapter.w(LOG_TAG, "Worker OOM-killed while loading; retrying staged image generation")
                     val result =
                         runWithRecovery(ComputeSubsystem.IMAGE) { forceCpu ->
-                            issueImageRequest(params.copy(sequential = true), forceCpu)
+                            issueImageRequest(params.copy(sequential = true), forceCpu, onStep = onStep)
                         }
                     lastMetrics = result.metrics?.let(IpcCodecs::fromIpc)
                     PixelCodec.decodeBitmap(result.frame)
@@ -114,6 +120,28 @@ internal class IsolatedDiffusionEngine(
         params.sequential == null &&
             ImageExecutionPlanner.recipeFor(params).supportsSequential &&
             lastPhase == DiffusionPhases.LOADING
+
+    override fun generateStream(params: ImageGenerationRequest): Flow<GenerationStreamEvent> =
+        callbackFlow {
+            val job =
+                edgeScope.coroutineScope.launch {
+                    try {
+                        val bitmap = generateBitmapInternal(params) { s, t ->
+                            trySend(
+                                GenerationStreamEvent.Progress(ProgressEvent.Step("Sampling", s, t))
+                            )
+                        }
+                        trySend(GenerationStreamEvent.Completed(listOf(bitmap)))
+                        close()
+                    } catch (t: Throwable) {
+                        close(t)
+                    }
+                }
+            awaitClose {
+                job.cancel()
+                cancelGeneration()
+            }
+        }
 
     override fun generateVideo(params: VideoGenerationRequest): Flow<GenerationStreamEvent> =
         callbackFlow {
@@ -233,6 +261,7 @@ internal class IsolatedDiffusionEngine(
         params: ImageGenerationRequest,
         forceCpu: Boolean,
         phaseTracker: ImageRequestPhaseTracker? = null,
+        onStep: ((Int, Int) -> Unit)? = null,
     ): IpcImageResult {
         val deferred = CompletableDeferred<IpcImageResult>()
         return runRequest(deferred, forceCpu) { connection, watchdog ->
@@ -241,6 +270,9 @@ internal class IsolatedDiffusionEngine(
                     override fun onPhase(update: PhaseUpdate) {
                         phaseTracker?.lastPhase = update.phase
                         dispatchPhase(watchdog, update)
+                        if (update.phase == DiffusionPhases.STEP) {
+                            onStep?.invoke(update.step, update.totalSteps)
+                        }
                     }
 
                     override fun onCompleted(result: IpcImageResult) {

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
@@ -122,12 +122,12 @@ internal class IsolatedDiffusionEngine(
             ImageExecutionPlanner.recipeFor(params).supportsSequential &&
             lastPhase == DiffusionPhases.LOADING
 
-    override suspend fun upscale(request: UpscaleRequest): Bitmap =
+    override suspend fun upscale(request: UpscaleRequest, onProgress: ((current: Int, total: Int) -> Unit)?): Bitmap =
         generationMutex.withLock {
             val phaseTracker = ImageRequestPhaseTracker()
             val result =
                 runWithRecovery(ComputeSubsystem.IMAGE) { forceCpu ->
-                    issueUpscaleRequest(request, forceCpu, phaseTracker)
+                    issueUpscaleRequest(request, forceCpu, phaseTracker, onProgress)
                 }
             lastMetrics = result.metrics?.let(IpcCodecs::fromIpc)
             PixelCodec.decodeBitmap(result.frame)
@@ -303,6 +303,7 @@ internal class IsolatedDiffusionEngine(
         request: UpscaleRequest,
         forceCpu: Boolean,
         phaseTracker: ImageRequestPhaseTracker? = null,
+        onProgress: ((current: Int, total: Int) -> Unit)? = null,
     ): IpcImageResult {
         val deferred = CompletableDeferred<IpcImageResult>()
         val finalRequest = if (forceCpu) request.copy(useVulkan = false) else request
@@ -314,6 +315,9 @@ internal class IsolatedDiffusionEngine(
                         override fun onPhase(update: PhaseUpdate) {
                             phaseTracker?.lastPhase = update.phase
                             dispatchPhase(watchdog, update)
+                            if (update.phase == DiffusionPhases.STEP) {
+                                onProgress?.invoke(update.step, update.totalSteps)
+                            }
                         }
 
                         override fun onCompleted(result: IpcImageResult) {

--- a/llmedge/src/test/cpp/CMakeLists.txt
+++ b/llmedge/src/test/cpp/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(sd_jni_under_test STATIC
     ../../main/cpp/sdcpp_jni.cpp
     ../../main/cpp/sdcpp_jni_load.cpp
     ../../main/cpp/sdcpp_jni_video.cpp
+    ../../main/cpp/sdcpp_jni_upscale.cpp
     ../../main/cpp/jni_thread_cache.cpp
     sd_test_stubs.cpp
 )

--- a/llmedge/src/test/cpp/sd_test_stubs.cpp
+++ b/llmedge/src/test/cpp/sd_test_stubs.cpp
@@ -158,6 +158,11 @@ void free_upscaler_ctx(upscaler_ctx_t*) {}
 int get_upscale_factor(upscaler_ctx_t*) { return 4; }
 bool upscale(upscaler_ctx_t* upscaler_ctx, sd_image_t input, uint32_t upscale_factor, sd_image_t** images_out, int* num_images_out) {
     (void)upscaler_ctx; (void)upscale_factor;
+    if (g_progress_cb) {
+        for (int i = 1; i <= 4; ++i) {
+            g_progress_cb(i, 4, 0.5f, g_progress_user_data);
+        }
+    }
     if (!images_out || !num_images_out) return false;
     sd_image_t* out = (sd_image_t*)calloc(1, sizeof(sd_image_t));
     if (!out) return false;

--- a/llmedge/src/test/cpp/sd_test_stubs.cpp
+++ b/llmedge/src/test/cpp/sd_test_stubs.cpp
@@ -111,12 +111,16 @@ static void fill_image(sd_image_t& image, int width, int height, int channel, ui
     }
 }
 
-sd_image_t* generate_image(sd_ctx_t*, const sd_img_gen_params_t* params) {
+bool generate_image(sd_ctx_t*, const sd_img_gen_params_t* params,
+                    sd_image_t** images_out, int* num_images_out) {
+    if (!images_out || !num_images_out) return false;
     auto* images = static_cast<sd_image_t*>(std::malloc(sizeof(sd_image_t)));
     fill_image(images[0], params->width > 0 ? params->width : 256,
                params->height > 0 ? params->height : 256,
                3, 42);
-    return images;
+    *images_out = images;
+    *num_images_out = 1;
+    return true;
 }
 
 bool generate_video(sd_ctx_t*, const sd_vid_gen_params_t* params,
@@ -146,10 +150,38 @@ bool generate_video(sd_ctx_t*, const sd_vid_gen_params_t* params,
 
 void free_sd_audio(sd_audio_t*) {}
 
-upscaler_ctx_t* new_upscaler_ctx(const char*, bool, bool, int, int, const char*, const char*) { return nullptr; }
+upscaler_ctx_t* new_upscaler_ctx(const char* esrgan_path, bool direct, int n_threads, int tile_size, const char* backend, const char* params_backend) {
+    (void)esrgan_path; (void)direct; (void)n_threads; (void)tile_size; (void)backend; (void)params_backend;
+    return reinterpret_cast<upscaler_ctx_t*>(1);
+}
 void free_upscaler_ctx(upscaler_ctx_t*) {}
-sd_image_t upscale(upscaler_ctx_t*, sd_image_t input_image, uint32_t) { return input_image; }
-int get_upscale_factor(upscaler_ctx_t*) { return 1; }
+int get_upscale_factor(upscaler_ctx_t*) { return 4; }
+bool upscale(upscaler_ctx_t* upscaler_ctx, sd_image_t input, uint32_t upscale_factor, sd_image_t** images_out, int* num_images_out) {
+    (void)upscaler_ctx; (void)upscale_factor;
+    if (!images_out || !num_images_out) return false;
+    sd_image_t* out = (sd_image_t*)calloc(1, sizeof(sd_image_t));
+    if (!out) return false;
+    out->width = input.width * 4;
+    out->height = input.height * 4;
+    out->channel = 3;
+    out->data = (uint8_t*)calloc(out->width * out->height * out->channel, sizeof(uint8_t));
+    if (!out->data) {
+        free(out);
+        return false;
+    }
+    *images_out = out;
+    *num_images_out = 1;
+    return true;
+}
+void free_sd_images(sd_image_t* result_images, int num_images) {
+    if (!result_images) return;
+    for (int i = 0; i < num_images; ++i) {
+        if (result_images[i].data) {
+            free(result_images[i].data);
+        }
+    }
+    free(result_images);
+}
 
 bool convert(const char*, const char*, const char*, enum sd_type_t, const char*, bool) { return true; }
 
@@ -157,6 +189,7 @@ bool preprocess_canny(sd_image_t, float, float, float, float, bool) { return tru
 
 }  // extern "C"
 
+ModelLoader::ModelLoader() = default;
 bool ModelLoader::init_from_file(const std::string&, const std::string&) { return true; }
 int64_t ModelLoader::get_params_mem_size(ggml_backend_t, ggml_type) { return 1024 * 1024; }
 std::map<ggml_type, uint32_t> ModelLoader::get_wtype_stat() { return {}; }
@@ -250,7 +283,12 @@ sd_image_t* sd_generate_image_with_precomputed_condition(sd_ctx_t* sd_ctx,
                                                          const sd_condition_raw_t* uncond) {
     (void)cond;
     (void)uncond;
-    return generate_image(sd_ctx, sd_img_gen_params);
+    sd_image_t* images = nullptr;
+    int num_images = 0;
+    if (!generate_image(sd_ctx, sd_img_gen_params, &images, &num_images)) {
+        return nullptr;
+    }
+    return images;
 }
 
 }  // extern "C"

--- a/llmedge/src/test/java/io/aatricks/llmedge/MockStableDiffusionBridge.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/MockStableDiffusionBridge.kt
@@ -131,6 +131,34 @@ open class MockStableDiffusionBridge : StableDiffusion.NativeBridge {
         return IntArray(outW * outH) { 0xFF000000.toInt() }
     }
 
+    override fun upscale(
+        esrganPath: String,
+        nThreads: Int,
+        tileSize: Int,
+        backend: String,
+        pixels: IntArray,
+        width: Int,
+        height: Int,
+        factor: Int,
+        outDims: IntArray,
+        progress: VideoProgressCallback?,
+    ): IntArray? {
+        for (i in 1..4) {
+            progress?.onProgress(i, 4, 0, 0, 0.5f)
+        }
+        return upscale(
+            esrganPath = esrganPath,
+            nThreads = nThreads,
+            tileSize = tileSize,
+            backend = backend,
+            pixels = pixels,
+            width = width,
+            height = height,
+            factor = factor,
+            outDims = outDims
+        )
+    }
+
     override fun txt2vid(
         handle: Long,
         prompt: String,

--- a/llmedge/src/test/java/io/aatricks/llmedge/MockStableDiffusionBridge.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/MockStableDiffusionBridge.kt
@@ -60,6 +60,7 @@ open class MockStableDiffusionBridge : StableDiffusion.NativeBridge {
     val txt2VidCalls = mutableListOf<Txt2VidCall>()
     val setProgressCallbackCalls = mutableListOf<Pair<Long, VideoProgressCallback?>>()
     val cancelGenerationCalls = mutableListOf<Long>()
+    val upscaleCalls = mutableListOf<UpscaleCall>()
 
     // State for progress simulation
     private val activeProgressCallback = AtomicReference<VideoProgressCallback?>()
@@ -87,6 +88,48 @@ open class MockStableDiffusionBridge : StableDiffusion.NativeBridge {
         val easyCacheStartPercent: Float,
         val easyCacheEndPercent: Float
     )
+
+    data class UpscaleCall(
+        val esrganPath: String,
+        val nThreads: Int,
+        val tileSize: Int,
+        val backend: String,
+        val width: Int,
+        val height: Int,
+        val factor: Int
+    )
+
+    override fun upscale(
+        esrganPath: String,
+        nThreads: Int,
+        tileSize: Int,
+        backend: String,
+        pixels: IntArray,
+        width: Int,
+        height: Int,
+        factor: Int,
+        outDims: IntArray,
+    ): IntArray? {
+        upscaleCalls.add(
+            UpscaleCall(
+                esrganPath = esrganPath,
+                nThreads = nThreads,
+                tileSize = tileSize,
+                backend = backend,
+                width = width,
+                height = height,
+                factor = factor
+            )
+        )
+        val factorUsed = if (factor == 0) 4 else factor
+        val outW = width * factorUsed
+        val outH = height * factorUsed
+        if (outDims.size >= 2) {
+            outDims[0] = outW
+            outDims[1] = outH
+        }
+        return IntArray(outW * outH) { 0xFF000000.toInt() }
+    }
 
     override fun txt2vid(
         handle: Long,
@@ -174,6 +217,7 @@ open class MockStableDiffusionBridge : StableDiffusion.NativeBridge {
         txt2VidCalls.clear()
         setProgressCallbackCalls.clear()
         cancelGenerationCalls.clear()
+        upscaleCalls.clear()
 
         activeProgressCallback.set(null)
         isCancelled.set(false)

--- a/llmedge/src/test/java/io/aatricks/llmedge/MockStableDiffusionBridge.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/MockStableDiffusionBridge.kt
@@ -28,7 +28,26 @@ open class MockStableDiffusionBridge : StableDiffusion.NativeBridge {
         easyCacheReuseThreshold: Float,
         easyCacheStartPercent: Float,
         easyCacheEndPercent: Float,
-    ): ByteArray? = null
+    ): ByteArray? {
+        if (isCancelled.get()) {
+            isCancelled.set(false)
+            return null
+        }
+        val callback = activeProgressCallback.get()
+        if (callback != null && steps > 0) {
+            for (step in 1..steps) {
+                if (progressCallbackDelayMs > 0) {
+                    Thread.sleep(progressCallbackDelayMs)
+                }
+                if (isCancelled.get()) {
+                    isCancelled.set(false)
+                    return null
+                }
+                callback.onProgress(step, steps, 0, 1, 1.0f)
+            }
+        }
+        return ByteArray(width * height * 3) { 0 }
+    }
 
     // Configuration options
     var shouldFailTxt2Vid = false

--- a/llmedge/src/test/java/io/aatricks/llmedge/StableDiffusionUpscaleTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/StableDiffusionUpscaleTest.kt
@@ -1,0 +1,69 @@
+package io.aatricks.llmedge
+
+import android.graphics.Bitmap
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import io.aatricks.llmedge.image.diffusion.StableDiffusion
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class StableDiffusionUpscaleTest {
+    private val mockBridge = MockStableDiffusionBridge()
+
+    @Before
+    fun setUp() {
+        System.setProperty("llmedge.disableNativeLoad", "true")
+        StableDiffusion.enableNativeBridgeForTests()
+        StableDiffusion.overrideNativeBridgeForTests { mockBridge }
+    }
+
+    @After
+    fun tearDown() {
+        mockBridge.reset()
+        StableDiffusion.resetNativeBridgeForTests()
+        System.clearProperty("llmedge.disableNativeLoad")
+    }
+
+    @Test
+    fun `upscaleImage calls bridge upscale and returns correct Bitmap`() = runTest {
+        val inputWidth = 64
+        val inputHeight = 64
+        val inputBitmap = Bitmap.createBitmap(inputWidth, inputHeight, Bitmap.Config.ARGB_8888)
+
+        val factor = 4
+        val modelPath = "/path/to/esrgan.bin"
+        val nThreads = 4
+        val tileSize = 128
+        val backend = "cpu"
+
+        val resultBitmap = StableDiffusion.upscaleImage(
+            modelPath = modelPath,
+            input = inputBitmap,
+            factor = factor,
+            nThreads = nThreads,
+            tileSize = tileSize,
+            backend = backend
+        )
+
+        assertNotNull(resultBitmap)
+        assertEquals(inputWidth * factor, resultBitmap.width)
+        assertEquals(inputHeight * factor, resultBitmap.height)
+
+        assertEquals(1, mockBridge.upscaleCalls.size)
+        val call = mockBridge.upscaleCalls[0]
+        assertEquals(modelPath, call.esrganPath)
+        assertEquals(nThreads, call.nThreads)
+        assertEquals(tileSize, call.tileSize)
+        assertEquals(backend, call.backend)
+        assertEquals(inputWidth, call.width)
+        assertEquals(inputHeight, call.height)
+        assertEquals(factor, call.factor)
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -3023,4 +3023,77 @@ class ImageClientTest {
             modelFile.delete()
         }
     }
+
+    @Test
+    fun `in-process upscale returns 4x dims and mock records backend cpu`() = runTest {
+        val realScope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Default)
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val modelFile = java.io.File.createTempFile("upscale-model", ".bin", context.filesDir).apply { writeBytes(byteArrayOf(0x01)) }
+
+        val bridge = io.aatricks.llmedge.MockStableDiffusionBridge()
+        StableDiffusion.overrideNativeBridgeForTests { bridge }
+
+        val edgeScope = LLMEdgeScope(realScope, 1)
+        val client = ImageClient.forTesting(
+            context = context,
+            scope = edgeScope,
+            config = LLMEdgeConfig(
+                image = ImageRuntimeConfig(workerMode = io.aatricks.llmedge.DiffusionWorkerMode.IN_PROCESS)
+            ),
+            resolver = DefaultModelRepository(),
+        )
+
+        try {
+            val inputBitmap = Bitmap.createBitmap(64, 64, Bitmap.Config.ARGB_8888)
+            val request = UpscaleRequest(
+                input = inputBitmap,
+                model = ModelSpec.localFile(modelFile),
+                useVulkan = false
+            )
+            val result = client.upscale(request)
+            assertEquals(256, result.width)
+            assertEquals(256, result.height)
+            assertEquals(1, bridge.upscaleCalls.size)
+            assertEquals("cpu", bridge.upscaleCalls[0].backend)
+            assertEquals(modelFile.absolutePath, bridge.upscaleCalls[0].esrganPath)
+        } finally {
+            client.close()
+            edgeScope.close()
+            realScope.cancel()
+            StableDiffusion.resetNativeBridgeForTests()
+            modelFile.delete()
+        }
+    }
+
+    @Test
+    fun `upscale with input larger than 1024 throws IllegalArgumentException`() = runTest {
+        val realScope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Default)
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val edgeScope = LLMEdgeScope(realScope, 1)
+        val client = ImageClient.forTesting(
+            context = context,
+            scope = edgeScope,
+            config = LLMEdgeConfig(),
+            resolver = DefaultModelRepository(),
+        )
+
+        try {
+            val inputBitmap = Bitmap.createBitmap(1025, 1025, Bitmap.Config.ARGB_8888)
+            val request = UpscaleRequest(
+                input = inputBitmap,
+                model = ModelSpec.localFile(java.io.File("dummy.bin")),
+            )
+            var threw = false
+            try {
+                client.upscale(request)
+            } catch (e: IllegalArgumentException) {
+                threw = true
+            }
+            assertTrue(threw)
+        } finally {
+            client.close()
+            edgeScope.close()
+            realScope.cancel()
+        }
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -36,6 +36,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import java.lang.Thread.sleep
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertFalse
@@ -2870,6 +2871,156 @@ class ImageClientTest {
             assertEquals(true, observedComponentPaths?.chromaT5ConditionerOnly)
         } finally {
             loaded.close()
+        }
+    }
+
+    @Test
+    fun `generateStream emits progress and completed`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val baseDir = context.filesDir
+        val modelFile = java.io.File.createTempFile("stream-model", ".gguf", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+
+        val bridge = io.aatricks.llmedge.MockStableDiffusionBridge().apply {
+            progressCallbackDelayMs = 0L
+        }
+        StableDiffusion.overrideNativeBridgeForTests { bridge }
+
+        coEvery {
+            StableDiffusion.loadWithRuntimeBackend(
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+            )
+        } coAnswers {
+            val constructor = StableDiffusion::class.java.getDeclaredConstructor(Long::class.javaPrimitiveType)
+            constructor.isAccessible = true
+            constructor.newInstance(1L)
+        }
+
+        val edgeScope = LLMEdgeScope(this, 1)
+        val client =
+            ImageClient.forTesting(
+                context = context,
+                scope = edgeScope,
+                config = LLMEdgeConfig(),
+                resolver = DefaultModelRepository(),
+            )
+
+        try {
+            val events = mutableListOf<GenerationStreamEvent>()
+            client.generateStream(
+                ImageGenerationRequest(
+                    prompt = "test stream",
+                    width = 128,
+                    height = 128,
+                    steps = 5,
+                    model = ModelSpec.localFile(modelFile),
+                )
+            ).collect {
+                events.add(it)
+            }
+
+            assertTrue(events.isNotEmpty())
+            val progresses = events.filterIsInstance<GenerationStreamEvent.Progress>()
+            val completedList = events.filterIsInstance<GenerationStreamEvent.Completed>()
+
+            assertEquals(1, completedList.size)
+            assertEquals(1, completedList[0].frames.size)
+            val bitmap = completedList[0].frames[0]
+            assertEquals(128, bitmap.width)
+            assertEquals(128, bitmap.height)
+
+            assertTrue(progresses.isNotEmpty())
+            var lastStep = 0
+            for (p in progresses) {
+                assertEquals("Sampling", p.update.message)
+                assertTrue(p.update.current > lastStep)
+                assertEquals(5, p.update.total)
+                lastStep = p.update.current
+            }
+        } finally {
+            client.close()
+            edgeScope.close()
+            StableDiffusion.resetNativeBridgeForTests()
+            modelFile.delete()
+        }
+    }
+
+    @Test
+    // Deliberately runBlocking + a real dispatcher, NOT runTest: the abandoned generation
+    // coroutine still holds the model mutex when close() runs, and closeOnce's runBlocking
+    // deadlocks the single-threaded virtual scheduler waiting for it.
+    fun `cancelling generateStream collection triggers cancelGeneration`() = kotlinx.coroutines.runBlocking {
+        val realScope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Default)
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val baseDir = context.filesDir
+        val modelFile = java.io.File.createTempFile("cancel-model", ".gguf", baseDir).apply { writeBytes(byteArrayOf(0x01)) }
+
+        val bridge = io.aatricks.llmedge.MockStableDiffusionBridge().apply {
+            progressCallbackDelayMs = 100L
+        }
+        StableDiffusion.overrideNativeBridgeForTests { bridge }
+
+        coEvery {
+            StableDiffusion.loadWithRuntimeBackend(
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+            )
+        } coAnswers {
+            val constructor = StableDiffusion::class.java.getDeclaredConstructor(Long::class.javaPrimitiveType)
+            constructor.isAccessible = true
+            constructor.newInstance(1L)
+        }
+
+        val edgeScope = LLMEdgeScope(realScope, 1)
+        val client =
+            ImageClient.forTesting(
+                context = context,
+                scope = edgeScope,
+                config = LLMEdgeConfig(),
+                resolver = DefaultModelRepository(),
+            )
+
+        try {
+            val flow = client.generateStream(
+                ImageGenerationRequest(
+                    prompt = "test stream",
+                    width = 128,
+                    height = 128,
+                    steps = 5,
+                    model = ModelSpec.localFile(modelFile),
+                )
+            )
+
+            kotlinx.coroutines.withTimeoutOrNull(5000) {
+                try {
+                    flow.collect { event ->
+                        if (event is GenerationStreamEvent.Progress) {
+                            throw kotlinx.coroutines.CancellationException("Simulated cancel")
+                        }
+                    }
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    if (e.message != "Simulated cancel") throw e
+                }
+            }
+
+            // awaitClose runs on the producer's thread; give it a moment to invoke cancelGeneration.
+            val deadline = System.currentTimeMillis() + 5000
+            while (bridge.cancelGenerationCalls.isEmpty() && System.currentTimeMillis() < deadline) {
+                kotlinx.coroutines.delay(20)
+            }
+            assertTrue(bridge.cancelGenerationCalls.isNotEmpty())
+        } finally {
+            client.close()
+            edgeScope.close()
+            realScope.cancel()
+            StableDiffusion.resetNativeBridgeForTests()
+            modelFile.delete()
         }
     }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -3050,12 +3050,16 @@ class ImageClientTest {
                 model = ModelSpec.localFile(modelFile),
                 useVulkan = false
             )
-            val result = client.upscale(request)
+            val progressList = mutableListOf<Pair<Int, Int>>()
+            val result = client.upscale(request) { current, total ->
+                progressList.add(current to total)
+            }
             assertEquals(256, result.width)
             assertEquals(256, result.height)
             assertEquals(1, bridge.upscaleCalls.size)
             assertEquals("cpu", bridge.upscaleCalls[0].backend)
             assertEquals(modelFile.absolutePath, bridge.upscaleCalls[0].esrganPath)
+            assertEquals(listOf(1 to 4, 2 to 4, 3 to 4, 4 to 4), progressList)
         } finally {
             client.close()
             edgeScope.close()

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IpcMarshallingTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IpcMarshallingTest.kt
@@ -3,6 +3,7 @@ package io.aatricks.llmedge.image.ipc
 import android.os.Parcel
 import android.os.Parcelable
 import io.aatricks.llmedge.image.ImageGenerationRequest
+import io.aatricks.llmedge.image.UpscaleRequest
 import io.aatricks.llmedge.image.diffusion.EasyCacheParams
 import io.aatricks.llmedge.image.diffusion.GenerationMetrics
 import io.aatricks.llmedge.image.diffusion.ImageRequestMetrics
@@ -196,5 +197,28 @@ class IpcMarshallingTest {
             )
         val decoded = IpcCodecs.fromIpc(parcelRoundTrip(IpcCodecs.toIpc(request)))
         assertEquals(request, decoded)
+    }
+
+    @Test
+    fun `upscale request survives codec and parcel round trip`() {
+        val bitmap = android.graphics.Bitmap.createBitmap(16, 16, android.graphics.Bitmap.Config.ARGB_8888)
+        val request = UpscaleRequest(
+            input = bitmap,
+            model = ModelSpec.LocalFile(File("/esrgan.bin")),
+            factor = 4,
+            useVulkan = true
+        )
+        val ipcRequest = IpcCodecs.toIpc(request)
+        val roundTripped = parcelRoundTrip(ipcRequest)
+        val decoded = IpcCodecs.fromIpc(roundTripped)
+
+        assertEquals(request.factor, decoded.factor)
+        assertEquals(request.useVulkan, decoded.useVulkan)
+        assertEquals(request.model, decoded.model)
+        assertEquals(request.input.width, decoded.input.width)
+        assertEquals(request.input.height, decoded.input.height)
+
+        ipcRequest.input.memory.close()
+        roundTripped.input.memory.close()
     }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngineTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngineTest.kt
@@ -17,6 +17,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -347,5 +348,182 @@ class IsolatedDiffusionEngineTest {
         assertTrue(error is WorkerKilledByMemoryException)
         assertEquals(1, requestSlots.size)
         assertEquals(false, requestSlots.single().sequential)
+    }
+
+    @Test
+    fun `generateStream emits Progress on STEP and Completed on onCompleted`() = runTest {
+        val params = ImageGenerationRequest(prompt = "hello")
+
+        val callbackSlots = mutableListOf<IDiffusionResultCallback>()
+        every {
+            worker.generateImage(any(), any())
+        } answers {
+            callbackSlots.add(secondArg<IDiffusionResultCallback>())
+        }
+
+        val shm = SharedMemory.create("test", 12)
+        val mockFrame = IpcFrameBuffer(shm, 1, 1, 1)
+        val mockResult = IpcImageResult(mockFrame, null)
+        val mockBitmap = mockk<android.graphics.Bitmap>(relaxed = true)
+        every { PixelCodec.decodeBitmap(any()) } returns mockBitmap
+
+        val events = mutableListOf<io.aatricks.llmedge.image.GenerationStreamEvent>()
+        // The shared `engine` uses a detached TestScope whose scheduler never advances
+        // under this runTest; generateStream launches its producer there and would hang.
+        // Bind a local engine to this test's scope instead.
+        val streamScope = LLMEdgeScope(this, 1)
+        val streamEngine = IsolatedDiffusionEngine(
+            context = context,
+            edgeScope = streamScope,
+            config = LLMEdgeConfig(),
+            connectionManager = connectionManager,
+        )
+        val job = launch {
+            streamEngine.generateStream(params).collect {
+                events.add(it)
+            }
+        }
+
+        while (callbackSlots.isEmpty()) {
+            kotlinx.coroutines.yield()
+        }
+        val callback = callbackSlots.first()
+
+        callback.onPhase(
+            PhaseUpdate(
+                phase = DiffusionPhases.STEP,
+                backend = null,
+                step = 5,
+                totalSteps = 20,
+                uptimeMillis = 100L
+            )
+        )
+        callback.onCompleted(mockResult)
+        job.join()
+        streamScope.close()
+
+        assertEquals(2, events.size)
+        val progress = events[0] as io.aatricks.llmedge.image.GenerationStreamEvent.Progress
+        assertEquals("Sampling", progress.update.message)
+        assertEquals(5, progress.update.current)
+        assertEquals(20, progress.update.total)
+
+        val completed = events[1] as io.aatricks.llmedge.image.GenerationStreamEvent.Completed
+        assertEquals(1, completed.frames.size)
+        assertEquals(mockBitmap, completed.frames[0])
+    }
+
+    @Test
+    fun `generateStream emits no Progress for non-STEP phase updates`() = runTest {
+        val params = ImageGenerationRequest(prompt = "hello")
+
+        val callbackSlots = mutableListOf<IDiffusionResultCallback>()
+        every {
+            worker.generateImage(any(), any())
+        } answers {
+            callbackSlots.add(secondArg<IDiffusionResultCallback>())
+        }
+
+        val shm = SharedMemory.create("test", 12)
+        val mockFrame = IpcFrameBuffer(shm, 1, 1, 1)
+        val mockResult = IpcImageResult(mockFrame, null)
+        val mockBitmap = mockk<android.graphics.Bitmap>(relaxed = true)
+        every { PixelCodec.decodeBitmap(any()) } returns mockBitmap
+
+        val events = mutableListOf<io.aatricks.llmedge.image.GenerationStreamEvent>()
+        // The shared `engine` uses a detached TestScope whose scheduler never advances
+        // under this runTest; generateStream launches its producer there and would hang.
+        // Bind a local engine to this test's scope instead.
+        val streamScope = LLMEdgeScope(this, 1)
+        val streamEngine = IsolatedDiffusionEngine(
+            context = context,
+            edgeScope = streamScope,
+            config = LLMEdgeConfig(),
+            connectionManager = connectionManager,
+        )
+        val job = launch {
+            streamEngine.generateStream(params).collect {
+                events.add(it)
+            }
+        }
+
+        while (callbackSlots.isEmpty()) {
+            kotlinx.coroutines.yield()
+        }
+        val callback = callbackSlots.first()
+
+        callback.onPhase(
+            PhaseUpdate(
+                phase = DiffusionPhases.LOADING,
+                backend = "CPU",
+                step = 0,
+                totalSteps = 0,
+                uptimeMillis = 100L
+            )
+        )
+        callback.onCompleted(mockResult)
+        job.join()
+        streamScope.close()
+
+        assertEquals(1, events.size)
+        assertTrue(events[0] is io.aatricks.llmedge.image.GenerationStreamEvent.Completed)
+    }
+
+    @Test
+    fun `generateStream drives watchdog with step updates`() = runTest {
+        io.mockk.mockkConstructor(GenerationWatchdog::class)
+        every { anyConstructed<GenerationWatchdog>().onStep(any(), any()) } returns Unit
+        every { anyConstructed<GenerationWatchdog>().onPhase(any(), any()) } returns Unit
+
+        val params = ImageGenerationRequest(prompt = "hello")
+
+        val callbackSlots = mutableListOf<IDiffusionResultCallback>()
+        every {
+            worker.generateImage(any(), any())
+        } answers {
+            callbackSlots.add(secondArg<IDiffusionResultCallback>())
+        }
+
+        val shm = SharedMemory.create("test", 12)
+        val mockFrame = IpcFrameBuffer(shm, 1, 1, 1)
+        val mockResult = IpcImageResult(mockFrame, null)
+        val mockBitmap = mockk<android.graphics.Bitmap>(relaxed = true)
+        every { PixelCodec.decodeBitmap(any()) } returns mockBitmap
+
+        // The shared `engine` uses a detached TestScope whose scheduler never advances
+        // under this runTest; generateStream launches its producer there and would hang.
+        // Bind a local engine to this test's scope instead.
+        val streamScope = LLMEdgeScope(this, 1)
+        val streamEngine = IsolatedDiffusionEngine(
+            context = context,
+            edgeScope = streamScope,
+            config = LLMEdgeConfig(),
+            connectionManager = connectionManager,
+        )
+        val job = launch {
+            streamEngine.generateStream(params).collect {}
+        }
+
+        while (callbackSlots.isEmpty()) {
+            kotlinx.coroutines.yield()
+        }
+        val callback = callbackSlots.first()
+
+        callback.onPhase(
+            PhaseUpdate(
+                phase = DiffusionPhases.STEP,
+                backend = null,
+                step = 7,
+                totalSteps = 15,
+                uptimeMillis = 100L
+            )
+        )
+        callback.onCompleted(mockResult)
+        job.join()
+        streamScope.close()
+
+        io.mockk.verify {
+            anyConstructed<GenerationWatchdog>().onStep(7, 15)
+        }
     }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngineTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngineTest.kt
@@ -549,6 +549,16 @@ class IsolatedDiffusionEngineTest {
             val callback = secondArg<IDiffusionResultCallback>()
             callbackSlots.add(callback)
 
+            callback.onPhase(
+                PhaseUpdate(
+                    phase = DiffusionPhases.STEP,
+                    backend = null,
+                    step = 2,
+                    totalSteps = 4,
+                    uptimeMillis = 0L,
+                )
+            )
+
             val shm = SharedMemory.create("test", 12)
             val mockFrame = IpcFrameBuffer(shm, 1, 1, 1)
             val mockResult = IpcImageResult(mockFrame, null)
@@ -558,10 +568,14 @@ class IsolatedDiffusionEngineTest {
         val mockBitmap = mockk<android.graphics.Bitmap>(relaxed = true)
         every { PixelCodec.decodeBitmap(any()) } returns mockBitmap
 
-        val result = engine.upscale(request)
+        val progressList = mutableListOf<Pair<Int, Int>>()
+        val result = engine.upscale(request) { current, total ->
+            progressList.add(current to total)
+        }
         assertEquals(mockBitmap, result)
         assertEquals(1, requestSlots.size)
         assertTrue(requestSlots[0].useVulkan)
+        assertEquals(listOf(2 to 4), progressList)
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngineTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngineTest.kt
@@ -8,6 +8,7 @@ import io.aatricks.llmedge.LLMEdgeConfig
 import io.aatricks.llmedge.core.LLMEdgeScope
 import io.aatricks.llmedge.core.WorkerKilledByMemoryException
 import io.aatricks.llmedge.image.ImageGenerationRequest
+import io.aatricks.llmedge.image.UpscaleRequest
 import io.aatricks.llmedge.model.ModelSpec
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -22,6 +23,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -525,5 +527,118 @@ class IsolatedDiffusionEngineTest {
         io.mockk.verify {
             anyConstructed<GenerationWatchdog>().onStep(7, 15)
         }
+    }
+
+    @Test
+    fun `upscale completes successfully`() = runTest {
+        val model = ModelSpec.LocalFile(File("esrgan.bin"))
+        // Real bitmap: mocking the final Bitmap class trips Robolectric's shadow retransformation.
+        val inputBitmap = android.graphics.Bitmap.createBitmap(64, 64, android.graphics.Bitmap.Config.ARGB_8888)
+        val request = UpscaleRequest(input = inputBitmap, model = model, useVulkan = true)
+        every { PixelCodec.encodeBitmap(any(), any()) } answers {
+            IpcFrameBuffer(SharedMemory.create("upscale-input", 12), 1, 1, 1)
+        }
+
+        val requestSlots = mutableListOf<IpcUpscaleRequest>()
+        val callbackSlots = mutableListOf<IDiffusionResultCallback>()
+
+        every {
+            worker.upscaleImage(any(), any())
+        } answers {
+            requestSlots.add(firstArg<IpcUpscaleRequest>())
+            val callback = secondArg<IDiffusionResultCallback>()
+            callbackSlots.add(callback)
+
+            val shm = SharedMemory.create("test", 12)
+            val mockFrame = IpcFrameBuffer(shm, 1, 1, 1)
+            val mockResult = IpcImageResult(mockFrame, null)
+            callback.onCompleted(mockResult)
+        }
+
+        val mockBitmap = mockk<android.graphics.Bitmap>(relaxed = true)
+        every { PixelCodec.decodeBitmap(any()) } returns mockBitmap
+
+        val result = engine.upscale(request)
+        assertEquals(mockBitmap, result)
+        assertEquals(1, requestSlots.size)
+        assertTrue(requestSlots[0].useVulkan)
+    }
+
+    @Test
+    fun `upscale failure maps to InferenceFailedException`() = runTest {
+        val model = ModelSpec.LocalFile(File("esrgan.bin"))
+        // Real bitmap: mocking the final Bitmap class trips Robolectric's shadow retransformation.
+        val inputBitmap = android.graphics.Bitmap.createBitmap(64, 64, android.graphics.Bitmap.Config.ARGB_8888)
+        val request = UpscaleRequest(input = inputBitmap, model = model, useVulkan = true)
+        every { PixelCodec.encodeBitmap(any(), any()) } answers {
+            IpcFrameBuffer(SharedMemory.create("upscale-input", 12), 1, 1, 1)
+        }
+
+        every {
+            worker.upscaleImage(any(), any())
+        } answers {
+            val callback = secondArg<IDiffusionResultCallback>()
+            callback.onFailed(
+                IpcFailure(
+                    code = IpcFailure.CODE_GENERIC,
+                    exceptionClass = "java.lang.RuntimeException",
+                    message = "Simulated upscale failure",
+                    backend = "CPU"
+                )
+            )
+        }
+
+        var threw = false
+        try {
+            engine.upscale(request)
+        } catch (e: io.aatricks.llmedge.core.InferenceFailedException) {
+            threw = true
+            assertTrue(e.message?.contains("Simulated upscale failure") == true)
+        }
+        assertTrue(threw)
+    }
+
+    @Test
+    fun `upscale retry occurs when worker dies`() = runTest {
+        val model = ModelSpec.LocalFile(File("esrgan.bin"))
+        // Real bitmap: mocking the final Bitmap class trips Robolectric's shadow retransformation.
+        val inputBitmap = android.graphics.Bitmap.createBitmap(64, 64, android.graphics.Bitmap.Config.ARGB_8888)
+        val request = UpscaleRequest(input = inputBitmap, model = model, useVulkan = true)
+        every { PixelCodec.encodeBitmap(any(), any()) } answers {
+            IpcFrameBuffer(SharedMemory.create("upscale-input", 12), 1, 1, 1)
+        }
+
+        // Mock WorkerFailureClassifier to return WorkerCrashedException (implicating Vulkan)
+        every {
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+        } returns io.aatricks.llmedge.core.WorkerCrashedException(
+            backend = "VULKAN",
+            exitReason = 5,
+            crashSummary = "phase=GENERATING; SIGSEGV | /vendor/lib64/hw/mt6855/vulkan.mtk.so | base.apk!libsdcpp.so",
+        )
+
+        val requestSlots = mutableListOf<IpcUpscaleRequest>()
+        every {
+            worker.upscaleImage(any(), any())
+        } answers {
+            val callback = secondArg<IDiffusionResultCallback>()
+            requestSlots.add(firstArg())
+            if (requestSlots.size == 1) {
+                // Simulate worker death
+                connection.onDeath?.invoke()
+            } else {
+                val shm = SharedMemory.create("test", 12)
+                callback.onCompleted(IpcImageResult(IpcFrameBuffer(shm, 1, 1, 1), null))
+            }
+        }
+
+        val mockBitmap = mockk<android.graphics.Bitmap>(relaxed = true)
+        every { PixelCodec.decodeBitmap(any()) } returns mockBitmap
+
+        val result = engine.upscale(request)
+        assertEquals(mockBitmap, result)
+        assertEquals(2, requestSlots.size)
+        assertTrue(requestSlots[0].useVulkan)
+        assertFalse(requestSlots[1].useVulkan)
     }
 }


### PR DESCRIPTION
Adds three related capabilities to the image pipeline:

- ImageClient.generateStream: per-step progress for image generation as a Flow, mirroring generateVideo. In-process mode threads a callback through ImageGenerationExecutor; isolated mode forwards the worker's existing STEP PhaseUpdates. No AIDL changes for this part.
- ImageClient.upscale(UpscaleRequest): ESRGAN upscaling via a one-shot nativeUpscale JNI call (context created and freed per call). Runs through both engines; the isolated path reuses runRequest, so watchdog, crash attribution, and CPU retry apply. New IpcUpscaleRequest parcelable and an upscaleImage method appended to IDiffusionWorker. Input capped at 1024x1024, CPU by default. Remacri (LyliaEngine/4x_foolhardy_Remacri, safetensors) is the tested reference model; its old-architecture tensor names go through the existing ESRGAN name conversion.
- Per-tile upscale progress: the tiling loop already feeds sd.cpp's global progress callback, so nativeUpscale optionally installs one for the duration of the call and tile counts surface through the same STEP route as sampling steps.

Also bumps stable-diffusion.cpp to the fork master (bbcef27). The previously recorded gitlink d78db8d no longer existed on the remote, which broke fresh submodule checkouts; the host-test stubs were re-synced to the current header (generate_image out-params, ModelLoader ctor, upscaler signatures). README and docs/usage.md document generateStream and upscale.

Verified: 452 SDK unit tests, host cpp build plus video_jni_tests, and on a Galaxy S22: step ETA within estimate during a 20-step generation, Remacri download plus 128 to 512 upscale in 80s in the isolated worker, 512 to 2048 upscale without OOM or worker death.