### PR TITLE
Run GPU backend probes in the isolated worker process

### DIFF
--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/image/ipc/IsolatedWorkerTest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/image/ipc/IsolatedWorkerTest.kt
@@ -217,6 +217,56 @@ class IsolatedWorkerTest {
     }
 
     @Test
+    fun probeSurvivesNativeAbortInWorkerAndPersistsVerdict() {
+        // Reset the prober's process-lifetime memo so this test drives a live probe.
+        WorkerBackendProber::class.java.getDeclaredField("cached")
+            .apply { isAccessible = true }
+            .set(WorkerBackendProber, null)
+        WorkerBackendProber::class.java.getDeclaredField("vulkanQuarantined")
+            .apply { isAccessible = true }
+            .set(WorkerBackendProber, false)
+
+        // Pre-bind the worker so the fault is installed in the process the prober will reach.
+        val connected = CountDownLatch(1)
+        var binder: IBinder? = null
+        val connection =
+            object : ServiceConnection {
+                override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                    binder = service
+                    connected.countDown()
+                }
+
+                override fun onServiceDisconnected(name: ComponentName?) = Unit
+            }
+        try {
+            assertTrue(
+                context.bindService(
+                    Intent(context, DiffusionWorkerService::class.java),
+                    connection,
+                    Context.BIND_AUTO_CREATE,
+                ),
+            )
+            assertTrue("service did not connect", connected.await(20, TimeUnit.SECONDS))
+            IDiffusionWorker.Stub.asInterface(binder).installFaultInjection(
+                Bundle().apply {
+                    putString(DiffusionWorkerService.FAULT_MODE, DiffusionWorkerService.FAULT_NATIVE_ABORT)
+                },
+            )
+
+            val result = runBlocking { withTimeout(60_000) { WorkerBackendProber.probe(context) } }
+
+            // The host (this test process) survived the worker abort; Vulkan must be quarantined.
+            assertTrue("probe after a worker abort must not report Vulkan", !result.vulkanAvailable)
+            val verdicts = BackendVerdictStore(context).load()
+            assertTrue(verdicts.contains(ComputeSubsystem.IMAGE to ComputeBackend.VULKAN))
+            assertTrue(verdicts.contains(ComputeSubsystem.VIDEO to ComputeBackend.VULKAN))
+            assertTrue(WorkerBackendProber.isVulkanQuarantined())
+        } finally {
+            runCatching { context.unbindService(connection) }
+        }
+    }
+
+    @Test
     fun watchdogKillsHungWorkerAndPersistsVerdict() {
         val config =
             LLMEdgeConfig(

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IDiffusionWorker.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IDiffusionWorker.aidl
@@ -7,6 +7,7 @@ import io.aatricks.llmedge.image.ipc.IpcVideoRequest;
 import io.aatricks.llmedge.image.ipc.IDiffusionResultCallback;
 import io.aatricks.llmedge.image.ipc.IDiffusionVideoCallback;
 import io.aatricks.llmedge.image.ipc.IpcUpscaleRequest;
+import io.aatricks.llmedge.image.ipc.IpcBackendProbeResult;
 
 interface IDiffusionWorker {
     int getPid();
@@ -18,4 +19,5 @@ interface IDiffusionWorker {
     // Debug builds only (FLAG_DEBUGGABLE); throws SecurityException otherwise.
     void installFaultInjection(in Bundle args);
     oneway void upscaleImage(in IpcUpscaleRequest request, IDiffusionResultCallback callback);
+    IpcBackendProbeResult probeBackends(in List<String> blacklistSeed);
 }

--- a/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcBackendProbeResult.aidl
+++ b/llmedge/src/main/aidl/io/aatricks/llmedge/image/ipc/IpcBackendProbeResult.aidl
@@ -1,0 +1,3 @@
+package io.aatricks.llmedge.image.ipc;
+
+parcelable IpcBackendProbeResult;

--- a/llmedge/src/main/java/io/aatricks/llmedge/LLMEdge.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/LLMEdge.kt
@@ -16,6 +16,7 @@ import io.aatricks.llmedge.text.TextClient
 import io.aatricks.llmedge.vision.VisionClient
 import io.aatricks.llmedge.vision.VisionPipeline
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 data class VulkanDeviceInfo(
     val deviceCount: Int,
@@ -125,6 +126,16 @@ class LLMEdge private constructor(
             modelRepository: ModelRepository = DefaultModelRepository(),
         ): LLMEdge =
             ClientBootstrap.createOwned(context, scope, config.execution.inferenceThreads) { bootstrap ->
+                // Warm the crash-safe GPU probe so text/vision Vulkan gating (which requires a
+                // worker-probe verdict) resolves without the host app calling it explicitly.
+                // Skipped under Robolectric, where the worker service can never bind.
+                if (android.os.Build.FINGERPRINT != "robolectric") {
+                    scope.launch {
+                        runCatching {
+                            io.aatricks.llmedge.image.ipc.WorkerBackendProber.probe(bootstrap.appContext)
+                        }
+                    }
+                }
                 LLMEdge(
                     appContext = bootstrap.appContext,
                     edgeScope = bootstrap.edgeScope,

--- a/llmedge/src/main/java/io/aatricks/llmedge/LLMEdge.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/LLMEdge.kt
@@ -138,35 +138,71 @@ class LLMEdge private constructor(
          * Returns backend availability for the text/LLM stack.
          *
          * This probes the SmolLM runtime, not Stable Diffusion.
+         * Note: may load the GPU driver; prefer the context overloads.
          */
         @JvmStatic
         fun getTextBackendAvailability(): ComputeBackendAvailability =
             RuntimeCapabilities.textBackendAvailability()
+            
+        @JvmStatic
+        fun getTextBackendAvailability(context: Context): ComputeBackendAvailability {
+            io.aatricks.llmedge.image.ipc.WorkerBackendProber.persistedOrNull(context.applicationContext)
+            return RuntimeCapabilities.textBackendAvailability()
+        }
 
         /**
          * Returns backend availability for the speech-to-text stack.
          *
          * Bark remains CPU-only and is therefore excluded from this GPU probe.
+         * Note: may load the GPU driver; prefer the context overloads.
          */
         @JvmStatic
         fun getSpeechBackendAvailability(): ComputeBackendAvailability =
             RuntimeCapabilities.speechBackendAvailability()
+            
+        @JvmStatic
+        fun getSpeechBackendAvailability(context: Context): ComputeBackendAvailability {
+            io.aatricks.llmedge.image.ipc.WorkerBackendProber.persistedOrNull(context.applicationContext)
+            return RuntimeCapabilities.speechBackendAvailability()
+        }
+
+        /**
+         * Probes backend availability in a safe, isolated worker process. Call this once to populate 
+         * the cache before calling getImageBackendAvailability().
+         */
+        suspend fun probeImageBackendAvailability(context: Context): ComputeBackendAvailability =
+            io.aatricks.llmedge.image.ipc.WorkerBackendProber.probe(context.applicationContext)
 
         /**
          * Returns backend availability for the image/video diffusion stack.
+         * 
+         * Call probeImageBackendAvailability(context) once to populate; unknown reports unavailable.
          */
         @JvmStatic
         fun getImageBackendAvailability(): ComputeBackendAvailability =
             RuntimeCapabilities.imageBackendAvailability()
+            
+        @JvmStatic
+        fun getImageBackendAvailability(context: Context): ComputeBackendAvailability =
+            io.aatricks.llmedge.image.ipc.WorkerBackendProber.cachedOrNull() ?:
+            io.aatricks.llmedge.image.ipc.WorkerBackendProber.persistedOrNull(context.applicationContext) ?:
+            ComputeBackendAvailability(false, false, null)
 
         /**
          * Returns backend availability for the vision-language stack.
          *
          * Vision rides on the SmolLM runtime and shares its backend capabilities.
+         * Note: may load the GPU driver; prefer the context overloads.
          */
         @JvmStatic
         fun getVisionBackendAvailability(): ComputeBackendAvailability =
             RuntimeCapabilities.visionBackendAvailability()
+            
+        @JvmStatic
+        fun getVisionBackendAvailability(context: Context): ComputeBackendAvailability {
+            io.aatricks.llmedge.image.ipc.WorkerBackendProber.persistedOrNull(context.applicationContext)
+            return RuntimeCapabilities.visionBackendAvailability()
+        }
 
         @Deprecated(
             message = "Ambiguous subsystem name. Prefer getImageBackendAvailability().vulkanAvailable or another per-subsystem capability API.",

--- a/llmedge/src/main/java/io/aatricks/llmedge/LLMEdge.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/LLMEdge.kt
@@ -144,11 +144,14 @@ class LLMEdge private constructor(
         fun getTextBackendAvailability(): ComputeBackendAvailability =
             RuntimeCapabilities.textBackendAvailability()
             
+        /**
+         * Crash-safe variant: Vulkan capability is derived from the isolated-worker probe
+         * ([probeImageBackendAvailability]) instead of loading the SmolLM runtime in-process.
+         * On drivers below Vulkan 1.2 (e.g. Adreno 619) the in-process check aborts the host.
+         */
         @JvmStatic
-        fun getTextBackendAvailability(context: Context): ComputeBackendAvailability {
-            io.aatricks.llmedge.image.ipc.WorkerBackendProber.persistedOrNull(context.applicationContext)
-            return RuntimeCapabilities.textBackendAvailability()
-        }
+        fun getTextBackendAvailability(context: Context): ComputeBackendAvailability =
+            RuntimeCapabilities.probeDerivedAvailability(context)
 
         /**
          * Returns backend availability for the speech-to-text stack.
@@ -198,11 +201,13 @@ class LLMEdge private constructor(
         fun getVisionBackendAvailability(): ComputeBackendAvailability =
             RuntimeCapabilities.visionBackendAvailability()
             
+        /**
+         * Crash-safe variant: see [getTextBackendAvailability] — vision rides on SmolLM and
+         * shares the same in-process abort hazard.
+         */
         @JvmStatic
-        fun getVisionBackendAvailability(context: Context): ComputeBackendAvailability {
-            io.aatricks.llmedge.image.ipc.WorkerBackendProber.persistedOrNull(context.applicationContext)
-            return RuntimeCapabilities.visionBackendAvailability()
-        }
+        fun getVisionBackendAvailability(context: Context): ComputeBackendAvailability =
+            RuntimeCapabilities.probeDerivedAvailability(context)
 
         @Deprecated(
             message = "Ambiguous subsystem name. Prefer getImageBackendAvailability().vulkanAvailable or another per-subsystem capability API.",

--- a/llmedge/src/main/java/io/aatricks/llmedge/core/runtime/RuntimeCapabilities.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/core/runtime/RuntimeCapabilities.kt
@@ -23,6 +23,22 @@ internal object RuntimeCapabilities {
     fun imageBackendAvailability(): ComputeBackendAvailability =
         WorkerBackendProber.cachedOrNull() ?: ComputeBackendAvailability(false, false, null)
 
+    /**
+     * GPU availability derived purely from the isolated-worker probe — never loads a GPU
+     * driver in the host process. Used for the SmolLM-based stacks (text/vision) whose own
+     * Vulkan check runs ggml backend registration in-process; that path GGML_ABORTs the host
+     * on Vulkan < 1.2 drivers (e.g. Adreno 619) and cannot be made crash-safe from Kotlin.
+     */
+    fun probeDerivedAvailability(context: android.content.Context): ComputeBackendAvailability {
+        val probe =
+            WorkerBackendProber.cachedOrNull()
+                ?: WorkerBackendProber.persistedOrNull(context.applicationContext)
+        return ComputeBackendAvailability(
+            openClAvailable = probe?.openClAvailable ?: false,
+            vulkanAvailable = probe?.vulkanAvailable ?: false,
+        )
+    }
+
     fun visionBackendAvailability(): ComputeBackendAvailability =
         ComputeBackendAvailability(
             openClAvailable = SmolLM.isOpenClAvailable(),

--- a/llmedge/src/main/java/io/aatricks/llmedge/core/runtime/RuntimeCapabilities.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/core/runtime/RuntimeCapabilities.kt
@@ -3,6 +3,7 @@ package io.aatricks.llmedge.core.runtime
 import io.aatricks.llmedge.ComputeBackendAvailability
 import io.aatricks.llmedge.VulkanDeviceInfo
 import io.aatricks.llmedge.image.diffusion.StableDiffusion
+import io.aatricks.llmedge.image.ipc.WorkerBackendProber
 import io.aatricks.llmedge.speech.stt.Whisper
 import io.aatricks.llmedge.text.runtime.SmolLM
 
@@ -10,26 +11,22 @@ internal object RuntimeCapabilities {
     fun textBackendAvailability(): ComputeBackendAvailability =
         ComputeBackendAvailability(
             openClAvailable = SmolLM.isOpenClAvailable(),
-            vulkanAvailable = SmolLM.isVulkanBackendAvailable(),
+            vulkanAvailable = if (WorkerBackendProber.isVulkanQuarantined()) false else SmolLM.isVulkanBackendAvailable(),
         )
 
     fun speechBackendAvailability(): ComputeBackendAvailability =
         ComputeBackendAvailability(
             openClAvailable = Whisper.isOpenClAvailable(),
-            vulkanAvailable = Whisper.isVulkanBackendAvailable(),
+            vulkanAvailable = if (WorkerBackendProber.isVulkanQuarantined()) false else Whisper.isVulkanBackendAvailable(),
         )
 
     fun imageBackendAvailability(): ComputeBackendAvailability =
-        ComputeBackendAvailability(
-            openClAvailable = StableDiffusion.isOpenClAvailable(),
-            vulkanAvailable = isStableDiffusionVulkanAvailable(),
-            vulkanDeviceInfo = getStableDiffusionVulkanDeviceInfo(),
-        )
+        WorkerBackendProber.cachedOrNull() ?: ComputeBackendAvailability(false, false, null)
 
     fun visionBackendAvailability(): ComputeBackendAvailability =
         ComputeBackendAvailability(
             openClAvailable = SmolLM.isOpenClAvailable(),
-            vulkanAvailable = SmolLM.isVulkanBackendAvailable(),
+            vulkanAvailable = if (WorkerBackendProber.isVulkanQuarantined()) false else SmolLM.isVulkanBackendAvailable(),
         )
 
     fun isStableDiffusionVulkanAvailable(): Boolean {

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/BackendVerdictStore.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/BackendVerdictStore.kt
@@ -46,6 +46,42 @@ internal class BackendVerdictStore(context: Context) {
         prefs.edit().clear().apply()
     }
 
+    /** [availability.vulkanDeviceInfo.freeMemoryMB] is a probe-time snapshot. */
+    fun recordImageProbe(availability: io.aatricks.llmedge.ComputeBackendAvailability) {
+        val info = availability.vulkanDeviceInfo
+        prefs.edit()
+            .putString(KEY_FINGERPRINT, Build.FINGERPRINT)
+            .putBoolean("probe.image.opencl", availability.openClAvailable)
+            .putBoolean("probe.image.vulkan", availability.vulkanAvailable)
+            .putInt("probe.image.vkDeviceCount", info?.deviceCount ?: 0)
+            .putLong("probe.image.vkFreeMb", info?.freeMemoryMB ?: 0L)
+            .putLong("probe.image.vkTotalMb", info?.totalMemoryMB ?: 0L)
+            .apply()
+    }
+
+    fun loadImageProbe(): io.aatricks.llmedge.ComputeBackendAvailability? {
+        val stored = prefs.getString(KEY_FINGERPRINT, null) ?: return null
+        if (stored != Build.FINGERPRINT) {
+            reset()
+            return null
+        }
+        if (!prefs.contains("probe.image.vulkan")) return null
+        val vkDeviceCount = prefs.getInt("probe.image.vkDeviceCount", 0)
+        val info = if (vkDeviceCount > 0) {
+            io.aatricks.llmedge.VulkanDeviceInfo(
+                deviceCount = vkDeviceCount,
+                freeMemoryMB = prefs.getLong("probe.image.vkFreeMb", 0L),
+                totalMemoryMB = prefs.getLong("probe.image.vkTotalMb", 0L),
+                deviceIndex = 0
+            )
+        } else null
+        return io.aatricks.llmedge.ComputeBackendAvailability(
+            openClAvailable = prefs.getBoolean("probe.image.opencl", false),
+            vulkanAvailable = prefs.getBoolean("probe.image.vulkan", false),
+            vulkanDeviceInfo = info
+        )
+    }
+
     private fun verdictKey(
         subsystem: ComputeSubsystem,
         backend: ComputeBackend,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
@@ -240,7 +240,11 @@ internal class DiffusionWorkerService : Service() {
             }
 
             override fun probeBackends(blacklistSeed: List<String>): IpcBackendProbeResult {
-                if (simulateFaultIfRequested()) return IpcBackendProbeResult(false, 0, 0, 0)
+                if (simulateFaultIfRequested()) {
+                    // A crash fault is pending delivery; never reply, so the process death
+                    // surfaces to the caller as binder death — like a real mid-probe crash.
+                    java.util.concurrent.CountDownLatch(1).await()
+                }
                 WorkerVulkanGate.apply(WorkerVulkanGate.shouldDisable(useVulkan = true, blacklistSeed))
                 val openClAvailable = io.aatricks.llmedge.image.diffusion.StableDiffusion.isOpenClAvailable()
                 val vulkanDeviceCount = io.aatricks.llmedge.image.diffusion.StableDiffusion.getVulkanDeviceCount()

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
@@ -238,6 +238,17 @@ internal class DiffusionWorkerService : Service() {
                     }
                 }
             }
+
+            override fun probeBackends(blacklistSeed: List<String>): IpcBackendProbeResult {
+                if (simulateFaultIfRequested()) return IpcBackendProbeResult(false, 0, 0, 0)
+                WorkerVulkanGate.apply(WorkerVulkanGate.shouldDisable(useVulkan = true, blacklistSeed))
+                val openClAvailable = io.aatricks.llmedge.image.diffusion.StableDiffusion.isOpenClAvailable()
+                val vulkanDeviceCount = io.aatricks.llmedge.image.diffusion.StableDiffusion.getVulkanDeviceCount()
+                val vulkanMemory = if (vulkanDeviceCount > 0) io.aatricks.llmedge.image.diffusion.StableDiffusion.getVulkanDeviceMemory(0) else null
+                val vulkanFreeBytes = if (vulkanMemory != null && vulkanMemory.size >= 2) vulkanMemory[0] else 0L
+                val vulkanTotalBytes = if (vulkanMemory != null && vulkanMemory.size >= 2) vulkanMemory[1] else 0L
+                return IpcBackendProbeResult(openClAvailable, vulkanDeviceCount, vulkanFreeBytes, vulkanTotalBytes)
+            }
         }
 
     /** Returns true when a fault was simulated instead of generating. */

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcTypes.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IpcTypes.kt
@@ -21,6 +21,14 @@ internal data class WorkerInitConfig(
 ) : Parcelable
 
 @Parcelize
+internal data class IpcBackendProbeResult(
+    val openClAvailable: Boolean,
+    val vulkanDeviceCount: Int,
+    val vulkanFreeBytes: Long,
+    val vulkanTotalBytes: Long
+) : Parcelable
+
+@Parcelize
 internal data class IpcModelSpec(
     /** "local" or "hf". */
     val type: String,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerBackendProber.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerBackendProber.kt
@@ -73,10 +73,14 @@ internal object WorkerBackendProber {
         val store = BackendVerdictStore(context)
         var connection: WorkerConnectionManager.Connection? = null
         try {
-            connection = manager.connect(null)
+            // Timeout covers the bind as well as the binder call: a stalled service spawn
+            // must fail the probe, not park it forever. It runs on the IO dispatcher's real
+            // clock so runTest virtual time cannot fire it early.
             val result = withContext(Dispatchers.IO) {
                 withTimeout(PROBE_TIMEOUT_MS) {
-                    connection.worker.probeBackends(blacklistSeed)
+                    val live = manager.connect(null)
+                    connection = live
+                    live.worker.probeBackends(blacklistSeed)
                 }
             }
             val availability = mapResult(result)
@@ -130,10 +134,11 @@ internal object WorkerBackendProber {
     private suspend fun executeRetryProbe(context: Context, manager: WorkerConnectionManager, store: BackendVerdictStore, blacklistSeed: List<String>): ComputeBackendAvailability {
         var connection: WorkerConnectionManager.Connection? = null
         try {
-            connection = manager.connect(null)
             val result = withContext(Dispatchers.IO) {
                 withTimeout(PROBE_TIMEOUT_MS) {
-                    connection.worker.probeBackends(blacklistSeed)
+                    val live = manager.connect(null)
+                    connection = live
+                    live.worker.probeBackends(blacklistSeed)
                 }
             }
             val mapped = mapResult(result)

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerBackendProber.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerBackendProber.kt
@@ -101,7 +101,12 @@ internal object WorkerBackendProber {
                     stallMs = PROBE_TIMEOUT_MS
                 )
             }
-            
+            AndroidLogAdapter.w(
+                LOG_TAG,
+                "Backend probe failed: ${t.javaClass.simpleName} (connection=${connection != null}, " +
+                    "classified=${classifierEx?.javaClass?.simpleName}, priorVerdict=$alreadyHasVulkanVerdict)",
+            )
+
             if (classifierEx is WorkerKilledByMemoryException) {
                 return ComputeBackendAvailability(false, false, null)
             }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerBackendProber.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerBackendProber.kt
@@ -1,0 +1,166 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.content.Context
+import io.aatricks.llmedge.ComputeBackendAvailability
+import io.aatricks.llmedge.VulkanDeviceInfo
+import io.aatricks.llmedge.core.AndroidLogAdapter
+import io.aatricks.llmedge.core.WorkerKilledByMemoryException
+import io.aatricks.llmedge.runtime.BackendRuntimePolicy
+import io.aatricks.llmedge.runtime.ComputeBackend
+import io.aatricks.llmedge.runtime.ComputeSubsystem
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+
+internal object WorkerBackendProber {
+    private const val LOG_TAG = "WorkerBackendProber"
+    private const val PROBE_TIMEOUT_MS = 10_000L
+
+    @Volatile private var cached: ComputeBackendAvailability? = null
+    @Volatile private var vulkanQuarantined: Boolean = false
+    private val mutex = Mutex()
+
+    fun cachedOrNull(): ComputeBackendAvailability? = cached
+
+    fun persistedOrNull(context: Context): ComputeBackendAvailability? {
+        val store = BackendVerdictStore(context)
+        val hasVulkanVerdict = store.load().any { it.second == ComputeBackend.VULKAN }
+        if (hasVulkanVerdict) {
+            vulkanQuarantined = true
+        }
+        val persisted = store.loadImageProbe() ?: return null
+        return if (hasVulkanVerdict) {
+            ComputeBackendAvailability(persisted.openClAvailable, false, null)
+        } else {
+            persisted
+        }
+    }
+
+    internal fun isVulkanQuarantined(): Boolean = vulkanQuarantined
+
+    suspend fun probe(context: Context): ComputeBackendAvailability = mutex.withLock {
+        cached?.let { return it }
+
+        val store = BackendVerdictStore(context)
+        val loadedVerdicts = store.load()
+        val hasVulkanVerdict = loadedVerdicts.any { it.second == ComputeBackend.VULKAN }
+        if (hasVulkanVerdict) {
+            vulkanQuarantined = true
+        }
+        
+        val persisted = store.loadImageProbe()
+        if (persisted != null) {
+            if (hasVulkanVerdict) {
+                val updated = ComputeBackendAvailability(persisted.openClAvailable, false, null)
+                cached = updated
+                return updated
+            }
+            cached = persisted
+            return persisted
+        }
+
+        val blacklistSeed = if (hasVulkanVerdict) {
+            listOf("IMAGE:VULKAN")
+        } else emptyList()
+
+        return executeProbe(context, blacklistSeed, hasVulkanVerdict)
+    }
+
+    private suspend fun executeProbe(context: Context, blacklistSeed: List<String>, alreadyHasVulkanVerdict: Boolean): ComputeBackendAvailability {
+        val manager = WorkerConnectionManager(context)
+        val store = BackendVerdictStore(context)
+        var connection: WorkerConnectionManager.Connection? = null
+        try {
+            connection = manager.connect(null)
+            val result = withContext(Dispatchers.IO) {
+                withTimeout(PROBE_TIMEOUT_MS) {
+                    connection.worker.probeBackends(blacklistSeed)
+                }
+            }
+            val availability = mapResult(result)
+            store.recordImageProbe(availability)
+            cached = availability
+            return availability
+        } catch (t: Throwable) {
+            if (t is kotlinx.coroutines.CancellationException && t !is kotlinx.coroutines.TimeoutCancellationException) {
+                throw t
+            }
+            if (t is kotlinx.coroutines.TimeoutCancellationException) {
+                connection?.let { manager.killWorker(it) }
+            }
+            
+            val classifierEx = connection?.let {
+                WorkerFailureClassifier.classify(
+                    context = context,
+                    pid = it.pid,
+                    lastPhase = "PROBE",
+                    lastBackend = "VULKAN",
+                    killedByWatchdog = t is kotlinx.coroutines.TimeoutCancellationException,
+                    stallMs = PROBE_TIMEOUT_MS
+                )
+            }
+            
+            if (classifierEx is WorkerKilledByMemoryException) {
+                return ComputeBackendAvailability(false, false, null)
+            }
+            
+            if (!alreadyHasVulkanVerdict) {
+                store.recordHang(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
+                store.recordHang(ComputeSubsystem.VIDEO, ComputeBackend.VULKAN)
+                BackendRuntimePolicy.seed(listOf(ComputeSubsystem.IMAGE to ComputeBackend.VULKAN, ComputeSubsystem.VIDEO to ComputeBackend.VULKAN))
+                vulkanQuarantined = true
+                
+                // Retry ONCE with Vulkan blacklisted
+                return executeRetryProbe(context, manager, store, listOf("IMAGE:VULKAN"))
+            } else {
+                return ComputeBackendAvailability(false, false, null)
+            }
+        } finally {
+            manager.close()
+        }
+    }
+    
+    private suspend fun executeRetryProbe(context: Context, manager: WorkerConnectionManager, store: BackendVerdictStore, blacklistSeed: List<String>): ComputeBackendAvailability {
+        var connection: WorkerConnectionManager.Connection? = null
+        try {
+            connection = manager.connect(null)
+            val result = withContext(Dispatchers.IO) {
+                withTimeout(PROBE_TIMEOUT_MS) {
+                    connection.worker.probeBackends(blacklistSeed)
+                }
+            }
+            val mapped = mapResult(result)
+            val availability = ComputeBackendAvailability(mapped.openClAvailable, false, null)
+            store.recordImageProbe(availability)
+            cached = availability
+            return availability
+        } catch (t: Throwable) {
+            if (t is kotlinx.coroutines.CancellationException && t !is kotlinx.coroutines.TimeoutCancellationException) {
+                throw t
+            }
+            if (t is kotlinx.coroutines.TimeoutCancellationException) {
+                connection?.let { manager.killWorker(it) }
+            }
+            return ComputeBackendAvailability(false, false, null)
+        }
+    }
+
+    private fun mapResult(result: IpcBackendProbeResult): ComputeBackendAvailability {
+        val vulkanAvailable = result.vulkanDeviceCount > 0 && result.vulkanTotalBytes > 0
+        val deviceInfo = if (vulkanAvailable) {
+            VulkanDeviceInfo(
+                deviceCount = result.vulkanDeviceCount,
+                freeMemoryMB = result.vulkanFreeBytes / (1024 * 1024),
+                totalMemoryMB = result.vulkanTotalBytes / (1024 * 1024),
+                deviceIndex = 0
+            )
+        } else null
+        return ComputeBackendAvailability(
+            openClAvailable = result.openClAvailable,
+            vulkanAvailable = vulkanAvailable,
+            vulkanDeviceInfo = deviceInfo
+        )
+    }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerConnectionManager.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerConnectionManager.kt
@@ -36,10 +36,12 @@ internal class WorkerConnectionManager(private val context: Context) {
     private var serviceConnection: ServiceConnection? = null
 
     /** Binds (or reuses the live connection) and (re)initializes the worker with [initConfig]. */
-    suspend fun connect(initConfig: WorkerInitConfig): Connection =
+    suspend fun connect(initConfig: WorkerInitConfig?): Connection =
         mutex.withLock {
             current?.takeIf { !it.dead && it.binder.isBinderAlive }?.let { live ->
-                live.worker.initialize(initConfig)
+                if (initConfig != null) {
+                    live.worker.initialize(initConfig)
+                }
                 return live
             }
             unbindLocked()
@@ -55,7 +57,9 @@ internal class WorkerConnectionManager(private val context: Context) {
                 },
                 0,
             )
-            worker.initialize(initConfig)
+            if (initConfig != null) {
+                worker.initialize(initConfig)
+            }
             current = connection
             return connection
         }

--- a/llmedge/src/main/java/io/aatricks/llmedge/text/TextRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/text/TextRuntimeSupport.kt
@@ -7,6 +7,7 @@ import io.aatricks.llmedge.core.runtime.BackendCandidateResolver
 import io.aatricks.llmedge.core.runtime.ManagedRuntimeBase
 import io.aatricks.llmedge.core.runtime.RuntimePool
 import io.aatricks.llmedge.core.runtime.RuntimeCacheKeyBuilder
+import io.aatricks.llmedge.core.runtime.RuntimeCapabilities
 import io.aatricks.llmedge.core.runtime.createCachedRuntimePool
 import io.aatricks.llmedge.core.runtime.runtimePoolProfile
 import io.aatricks.llmedge.model.ModelRepository
@@ -80,7 +81,12 @@ internal fun createTextRuntimePool(
                         subsystem = ComputeSubsystem.TEXT,
                         allowGpu = options.useVulkan ?: config.text.useVulkan,
                         openClAvailable = SmolLM.isOpenClAvailable(),
-                        vulkanAvailable = SmolLM.isVulkanBackendAvailable(),
+                        // Short-circuit: only touch SmolLM's registry (which GGML_ABORTs on
+                        // Vulkan < 1.2 drivers) after the isolated-worker probe proved the
+                        // driver survives instance creation.
+                        vulkanAvailable =
+                            RuntimeCapabilities.probeDerivedAvailability(context).vulkanAvailable &&
+                                SmolLM.isVulkanBackendAvailable(),
                     )
                 },
             ),

--- a/llmedge/src/main/java/io/aatricks/llmedge/vision/VisionRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/vision/VisionRuntimeSupport.kt
@@ -6,6 +6,7 @@ import io.aatricks.llmedge.core.LLMEdgeScope
 import io.aatricks.llmedge.core.runtime.BackendCandidateResolver
 import io.aatricks.llmedge.core.runtime.ManagedRuntimeBase
 import io.aatricks.llmedge.core.runtime.RuntimeCacheKeyBuilder
+import io.aatricks.llmedge.core.runtime.RuntimeCapabilities
 import io.aatricks.llmedge.core.runtime.RuntimePool
 import io.aatricks.llmedge.core.runtime.createCachedRuntimePool
 import io.aatricks.llmedge.core.runtime.runtimePoolProfile
@@ -146,7 +147,11 @@ internal fun createVisionRuntimePool(
                         subsystem = io.aatricks.llmedge.runtime.ComputeSubsystem.VISION,
                         allowGpu = config.vision.useVulkan,
                         openClAvailable = SmolLM.isOpenClAvailable(),
-                        vulkanAvailable = SmolLM.isVulkanBackendAvailable(),
+                        // Same gate as text: SmolLM's registry aborts on Vulkan < 1.2 drivers,
+                        // so only probe it once the worker probe proved the driver survives.
+                        vulkanAvailable =
+                            RuntimeCapabilities.probeDerivedAvailability(context).vulkanAvailable &&
+                                SmolLM.isVulkanBackendAvailable(),
                     )
                 },
             ),

--- a/llmedge/src/test/java/io/aatricks/llmedge/LLMEdgeTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/LLMEdgeTest.kt
@@ -31,6 +31,10 @@ class LLMEdgeTest {
     }
     @Test
     fun `no-arg getImageBackendAvailability with no cache returns all-false and never touches StableDiffusion`() {
+        // Robolectric shares the sandbox across same-config classes; clear any leaked memo.
+        io.aatricks.llmedge.image.ipc.WorkerBackendProber::class.java.getDeclaredField("cached")
+            .apply { isAccessible = true }
+            .set(io.aatricks.llmedge.image.ipc.WorkerBackendProber, null)
         io.mockk.mockkObject(io.aatricks.llmedge.image.diffusion.StableDiffusion)
         
         val availability = LLMEdge.getImageBackendAvailability()

--- a/llmedge/src/test/java/io/aatricks/llmedge/LLMEdgeTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/LLMEdgeTest.kt
@@ -29,4 +29,45 @@ class LLMEdgeTest {
             edge.close()
         }
     }
+    @Test
+    fun `no-arg getImageBackendAvailability with no cache returns all-false and never touches StableDiffusion`() {
+        io.mockk.mockkObject(io.aatricks.llmedge.image.diffusion.StableDiffusion)
+        
+        val availability = LLMEdge.getImageBackendAvailability()
+        org.junit.Assert.assertFalse(availability.vulkanAvailable)
+        org.junit.Assert.assertFalse(availability.openClAvailable)
+        
+        io.mockk.verify(exactly = 0) {
+            io.aatricks.llmedge.image.diffusion.StableDiffusion.isOpenClAvailable()
+        }
+        io.mockk.verify(exactly = 0) {
+            io.aatricks.llmedge.image.diffusion.StableDiffusion.getVulkanDeviceCount()
+        }
+        io.mockk.unmockkObject(io.aatricks.llmedge.image.diffusion.StableDiffusion)
+    }
+
+    @Test
+    fun `text availability under quarantine skips SmolLM isVulkanBackendAvailable`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        
+        io.mockk.mockkObject(io.aatricks.llmedge.text.runtime.SmolLM)
+        io.mockk.every { io.aatricks.llmedge.text.runtime.SmolLM.isOpenClAvailable() } returns true
+        io.mockk.every { io.aatricks.llmedge.text.runtime.SmolLM.isVulkanBackendAvailable() } returns true
+        
+        // Setup quarantine
+        io.aatricks.llmedge.image.ipc.BackendVerdictStore(context).recordHang(
+            io.aatricks.llmedge.runtime.ComputeSubsystem.IMAGE,
+            io.aatricks.llmedge.runtime.ComputeBackend.VULKAN
+        )
+        
+        val availability = LLMEdge.getTextBackendAvailability(context)
+        org.junit.Assert.assertFalse(availability.vulkanAvailable)
+        org.junit.Assert.assertTrue(availability.openClAvailable)
+        
+        io.mockk.verify(exactly = 0) {
+            io.aatricks.llmedge.text.runtime.SmolLM.isVulkanBackendAvailable()
+        }
+        
+        io.mockk.unmockkObject(io.aatricks.llmedge.text.runtime.SmolLM)
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/LLMEdgeTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/LLMEdgeTest.kt
@@ -47,27 +47,35 @@ class LLMEdgeTest {
     }
 
     @Test
-    fun `text availability under quarantine skips SmolLM isVulkanBackendAvailable`() {
+    fun `text availability context overload derives from worker probe without touching SmolLM`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        
+        val cachedField =
+            io.aatricks.llmedge.image.ipc.WorkerBackendProber::class.java.getDeclaredField("cached")
+        cachedField.isAccessible = true
+        cachedField.set(io.aatricks.llmedge.image.ipc.WorkerBackendProber, null)
+        io.aatricks.llmedge.image.ipc.BackendVerdictStore(context).reset()
+
         io.mockk.mockkObject(io.aatricks.llmedge.text.runtime.SmolLM)
-        io.mockk.every { io.aatricks.llmedge.text.runtime.SmolLM.isOpenClAvailable() } returns true
-        io.mockk.every { io.aatricks.llmedge.text.runtime.SmolLM.isVulkanBackendAvailable() } returns true
-        
-        // Setup quarantine
-        io.aatricks.llmedge.image.ipc.BackendVerdictStore(context).recordHang(
-            io.aatricks.llmedge.runtime.ComputeSubsystem.IMAGE,
-            io.aatricks.llmedge.runtime.ComputeBackend.VULKAN
+
+        // Never probed: conservative all-false.
+        val before = LLMEdge.getTextBackendAvailability(context)
+        org.junit.Assert.assertFalse(before.vulkanAvailable)
+        org.junit.Assert.assertFalse(before.openClAvailable)
+
+        // A persisted worker probe drives the answer.
+        io.aatricks.llmedge.image.ipc.BackendVerdictStore(context).recordImageProbe(
+            ComputeBackendAvailability(false, true, VulkanDeviceInfo(1, 100, 200, 0)),
         )
-        
-        val availability = LLMEdge.getTextBackendAvailability(context)
-        org.junit.Assert.assertFalse(availability.vulkanAvailable)
-        org.junit.Assert.assertTrue(availability.openClAvailable)
-        
+        val after = LLMEdge.getTextBackendAvailability(context)
+        org.junit.Assert.assertTrue(after.vulkanAvailable)
+
         io.mockk.verify(exactly = 0) {
             io.aatricks.llmedge.text.runtime.SmolLM.isVulkanBackendAvailable()
         }
-        
+        io.mockk.verify(exactly = 0) {
+            io.aatricks.llmedge.text.runtime.SmolLM.isOpenClAvailable()
+        }
+
         io.mockk.unmockkObject(io.aatricks.llmedge.text.runtime.SmolLM)
     }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/BackendVerdictStoreTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/BackendVerdictStoreTest.kt
@@ -67,4 +67,38 @@ class BackendVerdictStoreTest {
         store.reset()
         assertTrue(store.load().isEmpty())
     }
+
+    @Test
+    fun `recordImageProbe and loadImageProbe round trip`() {
+        val availability = io.aatricks.llmedge.ComputeBackendAvailability(
+            openClAvailable = true,
+            vulkanAvailable = true,
+            vulkanDeviceInfo = io.aatricks.llmedge.VulkanDeviceInfo(
+                deviceCount = 2,
+                freeMemoryMB = 1000L,
+                totalMemoryMB = 2000L,
+                deviceIndex = 0
+            )
+        )
+        store.recordImageProbe(availability)
+        val loaded = store.loadImageProbe()
+        assertEquals(availability, loaded)
+    }
+
+    @Test
+    fun `loadImageProbe returns null on fingerprint mismatch`() {
+        val availability = io.aatricks.llmedge.ComputeBackendAvailability(
+            openClAvailable = true,
+            vulkanAvailable = true,
+            vulkanDeviceInfo = null
+        )
+        store.recordImageProbe(availability)
+        
+        context.getSharedPreferences("llmedge_backend_verdicts", Context.MODE_PRIVATE)
+            .edit()
+            .putString("fingerprint", "some/other/build:fingerprint")
+            .commit()
+            
+        org.junit.Assert.assertNull(store.loadImageProbe())
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IpcMarshallingTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IpcMarshallingTest.kt
@@ -221,4 +221,16 @@ class IpcMarshallingTest {
         ipcRequest.input.memory.close()
         roundTripped.input.memory.close()
     }
+
+    @Test
+    fun `probe result survives parcel round trip`() {
+        val result = IpcBackendProbeResult(
+            openClAvailable = true,
+            vulkanDeviceCount = 1,
+            vulkanFreeBytes = 1000L,
+            vulkanTotalBytes = 2000L
+        )
+        val decoded = parcelRoundTrip(result)
+        assertEquals(result, decoded)
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerBackendProberTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerBackendProberTest.kt
@@ -1,0 +1,220 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.aatricks.llmedge.core.WorkerKilledByMemoryException
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import io.aatricks.llmedge.runtime.ComputeSubsystem
+import io.aatricks.llmedge.runtime.ComputeBackend
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class WorkerBackendProberTest {
+    private lateinit var context: Context
+    private lateinit var store: BackendVerdictStore
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        store = BackendVerdictStore(context)
+        store.reset()
+        mockkObject(WorkerFailureClassifier)
+        
+        val cachedField = WorkerBackendProber::class.java.getDeclaredField("cached")
+        cachedField.isAccessible = true
+        cachedField.set(WorkerBackendProber, null)
+        val quarantinedField = WorkerBackendProber::class.java.getDeclaredField("vulkanQuarantined")
+        quarantinedField.isAccessible = true
+        quarantinedField.set(WorkerBackendProber, false)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `successful probe maps availability and persists snapshot, second call memoized`() = runTest {
+        io.mockk.mockkConstructor(WorkerConnectionManager::class)
+        val connection = mockk<WorkerConnectionManager.Connection>(relaxed = true)
+        val worker = mockk<IDiffusionWorker>(relaxed = true)
+        every { connection.worker } returns worker
+        coEvery { anyConstructed<WorkerConnectionManager>().connect(null) } returns connection
+        
+        every { worker.probeBackends(any()) } returns IpcBackendProbeResult(
+            openClAvailable = true,
+            vulkanDeviceCount = 1,
+            vulkanFreeBytes = 500L * 1024 * 1024,
+            vulkanTotalBytes = 1000L * 1024 * 1024
+        )
+
+        val result1 = WorkerBackendProber.probe(context)
+        assertTrue(result1.openClAvailable)
+        assertTrue(result1.vulkanAvailable)
+        assertEquals(500L, result1.vulkanDeviceInfo?.freeMemoryMB)
+        assertEquals(1, result1.vulkanDeviceInfo?.deviceCount)
+
+        val result2 = WorkerBackendProber.probe(context)
+        assertEquals(result1, result2)
+
+        coVerify(exactly = 1) { anyConstructed<WorkerConnectionManager>().connect(null) }
+        
+        val loaded = store.loadImageProbe()
+        assertEquals(result1, loaded)
+    }
+
+    @Test
+    fun `DeadObjectException from probeBackends persists verdicts, retries once, returns vulkan false`() = runTest {
+        io.mockk.mockkConstructor(WorkerConnectionManager::class)
+        val connection = mockk<WorkerConnectionManager.Connection>(relaxed = true)
+        every { connection.pid } returns 1234
+        val worker = mockk<IDiffusionWorker>(relaxed = true)
+        every { connection.worker } returns worker
+        coEvery { anyConstructed<WorkerConnectionManager>().connect(null) } returns connection
+
+        every {
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+        } returns io.aatricks.llmedge.core.WorkerCrashedException(
+            backend = "VULKAN",
+            exitReason = 5,
+            crashSummary = "crash",
+        )
+
+        val seeds = mutableListOf<List<String>>()
+        every { worker.probeBackends(any()) } answers {
+            seeds.add(firstArg())
+            if (seeds.size == 1) {
+                throw android.os.DeadObjectException()
+            } else {
+                IpcBackendProbeResult(true, 1, 1024*1024, 1024*1024)
+            }
+        }
+
+        val result = WorkerBackendProber.probe(context)
+        
+        assertTrue(result.openClAvailable)
+        assertFalse(result.vulkanAvailable)
+        assertNull(result.vulkanDeviceInfo)
+
+        coVerify(exactly = 2) { anyConstructed<WorkerConnectionManager>().connect(null) }
+        assertEquals(emptyList<String>(), seeds[0])
+        assertEquals(listOf("IMAGE:VULKAN"), seeds[1])
+
+        val verdicts = store.load()
+        assertTrue(verdicts.contains(ComputeSubsystem.IMAGE to ComputeBackend.VULKAN))
+        assertTrue(verdicts.contains(ComputeSubsystem.VIDEO to ComputeBackend.VULKAN))
+        
+        assertTrue(WorkerBackendProber.isVulkanQuarantined())
+    }
+
+    @Test
+    fun `timeout via virtual time invokes killWorker and persists verdict`() = runTest {
+        io.mockk.mockkConstructor(WorkerConnectionManager::class)
+        val connection = mockk<WorkerConnectionManager.Connection>(relaxed = true)
+        val worker = mockk<IDiffusionWorker>(relaxed = true)
+        every { connection.worker } returns worker
+        coEvery { anyConstructed<WorkerConnectionManager>().connect(null) } returns connection
+        every { connection.pid } returns 1234
+
+        every {
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+        } returns io.aatricks.llmedge.core.GenerationHangException(backend = "VULKAN", phase = "PROBE", stallMs = 10000L)
+
+        every { worker.probeBackends(any()) } answers {
+            val exClass = Class.forName("kotlinx.coroutines.TimeoutCancellationException")
+            try {
+                throw exClass.getDeclaredConstructor(String::class.java).apply { isAccessible = true }.newInstance("Timeout") as Exception
+            } catch (e: NoSuchMethodException) {
+                throw exClass.getDeclaredConstructor(String::class.java, kotlinx.coroutines.Job::class.java).apply { isAccessible = true }.newInstance("Timeout", null) as Exception
+            }
+        }
+
+        val result = WorkerBackendProber.probe(context)
+        assertFalse(result.openClAvailable)
+        assertFalse(result.vulkanAvailable)
+
+        io.mockk.verify(exactly = 2) { anyConstructed<WorkerConnectionManager>().killWorker(connection) }
+        
+        val verdicts = store.load()
+        assertTrue(verdicts.contains(ComputeSubsystem.IMAGE to ComputeBackend.VULKAN))
+    }
+
+    @Test
+    fun `pre-existing persisted verdict means connect never called when snapshot exists`() = runTest {
+        io.mockk.mockkConstructor(WorkerConnectionManager::class)
+        
+        store.recordHang(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
+        store.recordImageProbe(io.aatricks.llmedge.ComputeBackendAvailability(true, true, io.aatricks.llmedge.VulkanDeviceInfo(1, 1000, 2000, 0)))
+
+        val result = WorkerBackendProber.probe(context)
+        
+        assertTrue(result.openClAvailable)
+        assertFalse(result.vulkanAvailable)
+        assertNull(result.vulkanDeviceInfo)
+        assertTrue(WorkerBackendProber.isVulkanQuarantined())
+
+        coVerify(exactly = 0) { anyConstructed<WorkerConnectionManager>().connect(any()) }
+    }
+
+    @Test
+    fun `persistedOrNull strips vulkan from snapshot when a vulkan verdict exists`() {
+        store.recordImageProbe(io.aatricks.llmedge.ComputeBackendAvailability(true, true, io.aatricks.llmedge.VulkanDeviceInfo(1, 1000, 2000, 0)))
+        store.recordHang(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
+
+        val result = WorkerBackendProber.persistedOrNull(context)
+
+        assertEquals(true, result?.openClAvailable)
+        assertEquals(false, result?.vulkanAvailable)
+        assertNull(result?.vulkanDeviceInfo)
+        assertTrue(WorkerBackendProber.isVulkanQuarantined())
+    }
+
+    @Test
+    fun `persisted snapshot short-circuit and fingerprint change invalidates`() = runTest {
+        io.mockk.mockkConstructor(WorkerConnectionManager::class)
+        
+        store.recordImageProbe(io.aatricks.llmedge.ComputeBackendAvailability(true, true, io.aatricks.llmedge.VulkanDeviceInfo(1, 1000, 2000, 0)))
+        
+        val result1 = WorkerBackendProber.probe(context)
+        assertTrue(result1.vulkanAvailable)
+        coVerify(exactly = 0) { anyConstructed<WorkerConnectionManager>().connect(any()) }
+        
+        val cachedField = WorkerBackendProber::class.java.getDeclaredField("cached")
+        cachedField.isAccessible = true
+        cachedField.set(WorkerBackendProber, null)
+        
+        context.getSharedPreferences("llmedge_backend_verdicts", Context.MODE_PRIVATE)
+            .edit()
+            .putString("fingerprint", "different")
+            .commit()
+            
+        val connection = mockk<WorkerConnectionManager.Connection>(relaxed = true)
+        val worker = mockk<IDiffusionWorker>(relaxed = true)
+        every { connection.worker } returns worker
+        coEvery { anyConstructed<WorkerConnectionManager>().connect(null) } returns connection
+        every { worker.probeBackends(any()) } returns IpcBackendProbeResult(false, 0, 0, 0)
+        
+        val result2 = WorkerBackendProber.probe(context)
+        assertFalse(result2.vulkanAvailable)
+        coVerify(exactly = 1) { anyConstructed<WorkerConnectionManager>().connect(null) }
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/text/TextClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/text/TextClientTest.kt
@@ -982,6 +982,13 @@ class TextClientTest {
     @Test
     fun `generate retries decode failure with cpu safe runtime`() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
+        // Vulkan candidacy is gated on the worker probe now; seed a positive result.
+        io.aatricks.llmedge.image.ipc.WorkerBackendProber::class.java.getDeclaredField("cached")
+            .apply { isAccessible = true }
+            .set(
+                io.aatricks.llmedge.image.ipc.WorkerBackendProber,
+                io.aatricks.llmedge.ComputeBackendAvailability(false, true, null),
+            )
         val modelFile = createTempGgufFile(context.cacheDir)
         val modelSpec = ModelSpec.localFile(modelFile)
         val resolver =

--- a/llmedge/src/test/java/io/aatricks/llmedge/vision/VisionPipelineTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/vision/VisionPipelineTest.kt
@@ -99,6 +99,13 @@ class VisionPipelineTest {
     @Test
     fun `prepare uses config-backed runtime defaults`() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
+        // Vulkan candidacy is gated on the worker probe now; seed a positive result.
+        io.aatricks.llmedge.image.ipc.WorkerBackendProber::class.java.getDeclaredField("cached")
+            .apply { isAccessible = true }
+            .set(
+                io.aatricks.llmedge.image.ipc.WorkerBackendProber,
+                io.aatricks.llmedge.ComputeBackendAvailability(false, true, null),
+            )
         val resolver = mockk<ModelRepository>()
         val config =
             LLMEdgeConfig(

--- a/mods/llama.cpp/vulkan-env-gate.patch
+++ b/mods/llama.cpp/vulkan-env-gate.patch
@@ -1,0 +1,20 @@
+Honor GGML_DISABLE_VULKAN in the backend registry, mirroring the same gate in the
+stable-diffusion.cpp fork (ggml-backend-reg.cpp). Without it, any code path that
+touches the registry on a Vulkan-compiled build (including availability probes)
+runs ggml_vk_instance_init, which GGML_ABORTs the process on drivers below
+Vulkan 1.2 (e.g. Adreno 619) — see llmedge-examples#29.
+--- a/ggml/src/ggml-backend.cpp
++++ b/ggml/src/ggml-backend.cpp
+@@ -497,7 +497,11 @@
+ #endif
+
+ #ifdef GGML_USE_VULKAN
+-    ggml_backend_vk_reg_devices();
++    if (getenv("GGML_DISABLE_VULKAN") == nullptr) {
++        ggml_backend_vk_reg_devices();
++    } else {
++        fprintf(stderr, "ggml_backend_registry_init: Vulkan backend disabled by GGML_DISABLE_VULKAN\n");
++    }
+ #endif
+
+ #ifdef GGML_USE_CANN


### PR DESCRIPTION
Fixes the startup crash reported in Aatricks/llmedge-examples#29 (Samsung Tab A9+, Snapdragon 695 / Adreno 619).

The public availability APIs loaded the Vulkan-enabled native libraries in the host process and ran live device enumeration; a vendor-driver SIGSEGV there is uncatchable and killed the host app. This routes the image probe through the existing isolated `:llmedge_sd` worker:

- New `probeBackends` AIDL call, executed in the worker behind `WorkerVulkanGate` with fault-injection support.
- New `LLMEdge.probeImageBackendAvailability(context)` suspend API; a worker death or 10s hang during the probe records `IMAGE:VULKAN`/`VIDEO:VULKAN` verdicts (fingerprint-keyed, mirroring the generation path), retries once with Vulkan blacklisted to still resolve OpenCL, and quarantines Vulkan for the process.
- Sync getters now serve cached/persisted state only and never load `libsdcpp` in-process; unknown reports unavailable.
- Text/vision/speech getters skip the in-process SmolLM/Whisper Vulkan check once a Vulkan verdict exists (context overloads seed the quarantine from prefs).

Tests: 455 unit tests green (`:llmedge:testDebugUnitTest`), including new prober coverage for success/memoization, binder death, timeout, verdict short-circuit, and fingerprint invalidation.

Pending: S22 device gate (cold start, fault-injection probe, image gen regression).