### PR TITLE
Handle diffusion GGUF metadata before generic parsing

### DIFF
--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
@@ -111,7 +111,7 @@ internal object ImageRuntimeRequestPlanner {
                 vaeDecodeOnly = true,
                 sequentialLoad = true,
                 preferPerformanceMode = config.image.preferPerformanceMode,
-                loraModelDir = null,
+                loraModelDir = params.loraModelDir,
                 loraApplyMode = params.loraApplyMode,
             )
         val conditioningSpec: DiffusionRuntimeSpec

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionMetadataSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionMetadataSupport.kt
@@ -46,7 +46,31 @@ internal object StableDiffusionMetadataSupport {
 
         val filename = explicitFilename ?: resolvedModelPath.substringAfterLast('/')
         val lowerName = filename.lowercase(Locale.US)
-        val ggufMetadata = GgufModelMetadataSupport.inspect(resolvedModelPath)
+        val architectureHint =
+            listOfNotNull(explicitFilename, modelId, resolvedModelPath)
+                .joinToString(" ")
+                .lowercase(Locale.US)
+        val knownDiffusionArchitecture =
+            when {
+                architectureHint.contains("wan") -> "wan"
+                architectureHint.contains("hunyuan") -> "hunyuan_video"
+                architectureHint.contains("sd3") -> "sd3"
+                architectureHint.contains("flux") -> "flux"
+                architectureHint.contains("chroma") -> "chroma"
+                architectureHint.contains("minit2i") -> "minit2i"
+                architectureHint.contains("stable-diffusion") -> "stable-diffusion"
+                architectureHint.contains("sdxl") -> "sdxl"
+                architectureHint.contains("sd15") -> "sd15"
+                architectureHint.contains("qwen-image") -> "qwen-image"
+                architectureHint.contains("z-image") -> "z-image"
+                else -> null
+            }
+        val ggufMetadata =
+            if (knownDiffusionArchitecture == null) {
+                GgufModelMetadataSupport.inspect(resolvedModelPath)
+            } else {
+                null
+            }
         val tags = mutableSetOf<String>()
 
         AndroidLogAdapter.d(
@@ -58,8 +82,7 @@ internal object StableDiffusionMetadataSupport {
             when {
                 !ggufMetadata?.architecture.isNullOrBlank() -> ggufMetadata?.architecture
                 !modelId.isNullOrBlank() -> modelId
-                lowerName.contains("hunyuan") -> "hunyuan_video"
-                lowerName.contains("wan") -> "wan"
+                knownDiffusionArchitecture != null -> knownDiffusionArchitecture
                 else -> null
             }
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/rag/EmbeddingProvider.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/rag/EmbeddingProvider.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import com.ml.shubham0204.sentence_embeddings.SentenceEmbedding
 import java.io.File
+import java.io.InputStream
+import java.net.URI
 import java.security.MessageDigest
 import kotlinx.coroutines.runBlocking
 
@@ -33,7 +35,82 @@ data class EmbeddingConfig(
     val outputTensorName: String = "sentence_embedding",
     val useFP16: Boolean = false,
     val useXNNPack: Boolean = true,
-)
+) {
+    companion object {
+        @JvmStatic
+        @JvmOverloads
+        fun fromFiles(
+            modelFile: File,
+            tokenizerFile: File,
+            useTokenTypeIds: Boolean = false,
+            outputTensorName: String = "sentence_embedding",
+            useFP16: Boolean = false,
+            useXNNPack: Boolean = true,
+        ): EmbeddingConfig =
+            EmbeddingConfig(
+                modelAssetPath = modelFile.toURI().toASCIIString(),
+                tokenizerAssetPath = tokenizerFile.toURI().toASCIIString(),
+                useTokenTypeIds = useTokenTypeIds,
+                outputTensorName = outputTensorName,
+                useFP16 = useFP16,
+                useXNNPack = useXNNPack,
+            )
+    }
+}
+
+internal sealed interface EmbeddingFileSource {
+    fun materialize(
+        cachedFile: File,
+        assetOpener: (String) -> InputStream,
+    ): File
+
+    data class Asset(private val path: String) : EmbeddingFileSource {
+        override fun materialize(
+            cachedFile: File,
+            assetOpener: (String) -> InputStream,
+        ): File {
+            if (cachedFile.isFile) return cachedFile
+            cachedFile.parentFile?.mkdirs()
+            val tmpFile = File(cachedFile.parent, "${cachedFile.name}.${System.nanoTime()}.tmp")
+            try {
+                assetOpener(path).use { input ->
+                    tmpFile.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+                if (!tmpFile.renameTo(cachedFile)) {
+                    tmpFile.copyTo(cachedFile, overwrite = true)
+                    tmpFile.delete()
+                }
+                return cachedFile
+            } catch (t: Throwable) {
+                tmpFile.delete()
+                throw t
+            }
+        }
+    }
+
+    data class LocalFile(private val file: File) : EmbeddingFileSource {
+        override fun materialize(
+            cachedFile: File,
+            assetOpener: (String) -> InputStream,
+        ): File {
+            require(file.isFile && file.canRead()) {
+                "Embedding file is not readable: ${file.absolutePath}"
+            }
+            return file
+        }
+    }
+
+    companion object {
+        fun parse(path: String): EmbeddingFileSource =
+            if (path.startsWith("file:", ignoreCase = true)) {
+                LocalFile(File(URI(path)))
+            } else {
+                Asset(path)
+            }
+    }
+}
 
 class EmbeddingProvider(private val context: Context, private var config: EmbeddingConfig = EmbeddingConfig()) {
     private val se = SentenceEmbedding()
@@ -59,35 +136,21 @@ class EmbeddingProvider(private val context: Context, private var config: Embedd
         return "${hash}_$basename"
     }
 
-    private suspend fun copyAssetToFiles(assetPath: String, outFile: File) = withContext(Dispatchers.IO) {
-        if (outFile.exists()) return@withContext
-        outFile.parentFile?.mkdirs()
-        val tmpFile = File(outFile.parent, "${outFile.name}.${System.nanoTime()}.tmp")
-        try {
-            context.assets.open(assetPath).use { input ->
-                tmpFile.outputStream().use { output ->
-                    input.copyTo(output)
-                }
-            }
-            if (!tmpFile.renameTo(outFile)) {
-                tmpFile.copyTo(outFile, overwrite = true)
-                tmpFile.delete()
-            }
-        } catch (e: Throwable) {
-            tmpFile.delete()
-            throw e
-        }
-    }
-
     suspend fun init() = sessionMutex.withLock {
         check(!closed) { "EmbeddingProvider is closed" }
         withContext(Dispatchers.IO) {
             if (initialized) return@withContext
             val modelsDir = File(context.filesDir, "embedding_models")
-            val modelFile = File(modelsDir, getUniqueFileName(config.modelAssetPath))
-            val tokenizerFile = File(modelsDir, getUniqueFileName(config.tokenizerAssetPath))
-            copyAssetToFiles(config.modelAssetPath, modelFile)
-            copyAssetToFiles(config.tokenizerAssetPath, tokenizerFile)
+            val modelFile =
+                EmbeddingFileSource.parse(config.modelAssetPath).materialize(
+                    File(modelsDir, getUniqueFileName(config.modelAssetPath)),
+                    context.assets::open,
+                )
+            val tokenizerFile =
+                EmbeddingFileSource.parse(config.tokenizerAssetPath).materialize(
+                    File(modelsDir, getUniqueFileName(config.tokenizerAssetPath)),
+                    context.assets::open,
+                )
 
             val tokenizerBytes = tokenizerFile.readBytes()
             modelFilePath = modelFile.absolutePath

--- a/llmedge/src/test/java/io/aatricks/llmedge/MetadataInferenceTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/MetadataInferenceTest.kt
@@ -1,6 +1,7 @@
 package io.aatricks.llmedge
 
 import io.aatricks.llmedge.image.diffusion.StableDiffusionLoadSupport
+import io.aatricks.llmedge.runtime.GGUFReader
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -11,6 +12,72 @@ import java.io.File
 import io.aatricks.llmedge.image.diffusion.VideoModelMetadata
 
 class MetadataInferenceTest {
+
+    @Test
+    fun `known wan gguf uses request hints without opening the generic gguf reader`() = runTest {
+        val modelFile = File.createTempFile("wan2.1-t2v-1.3b-", ".gguf")
+        modelFile.writeBytes(byteArrayOf('G'.code.toByte(), 'G'.code.toByte(), 'U'.code.toByte(), 'F'.code.toByte()))
+        GGUFReader.overrideNativeBridgeForTests {
+            object : GGUFReader.NativeBridge {
+                override fun getGGUFContextNativeHandle(modelPath: String): Long = 1L
+                override fun getContextSize(nativeHandle: Long): Long = -1L
+                override fun getChatTemplate(nativeHandle: Long): String = ""
+                override fun getArchitecture(nativeHandle: Long): String = "unexpected-native-architecture"
+                override fun getParameterCount(nativeHandle: Long): String = "999B"
+                override fun getModelName(nativeHandle: Long): String = "unexpected-native-model"
+                override fun releaseGGUFContext(nativeHandle: Long) = Unit
+            }
+        }
+
+        try {
+            val metadata =
+                StableDiffusionLoadSupport.inferVideoModelMetadata(
+                    resolvedModelPath = modelFile.absolutePath,
+                    modelId = "samuelchristlie/Wan2.1-T2V-1.3B-GGUF",
+                    explicitFilename = "Wan2.1-T2V-1.3B-Q3_K_S.gguf",
+                )
+
+            assertEquals("samuelchristlie/Wan2.1-T2V-1.3B-GGUF", metadata.architecture)
+            assertEquals("t2v", metadata.modelType)
+            assertEquals("1.3B", metadata.parameterCount)
+        } finally {
+            GGUFReader.resetNativeBridgeForTests()
+            modelFile.delete()
+        }
+    }
+
+    @Test
+    fun `known image diffusion gguf uses filename hints without opening the generic gguf reader`() = runTest {
+        val modelFile = File.createTempFile("sd3-finetune-", ".gguf")
+        modelFile.writeBytes(byteArrayOf('G'.code.toByte(), 'G'.code.toByte(), 'U'.code.toByte(), 'F'.code.toByte()))
+        GGUFReader.overrideNativeBridgeForTests {
+            object : GGUFReader.NativeBridge {
+                override fun getGGUFContextNativeHandle(modelPath: String): Long = 1L
+                override fun getContextSize(nativeHandle: Long): Long = -1L
+                override fun getChatTemplate(nativeHandle: Long): String = ""
+                override fun getArchitecture(nativeHandle: Long): String = "unexpected-native-architecture"
+                override fun getParameterCount(nativeHandle: Long): String = "999B"
+                override fun getModelName(nativeHandle: Long): String = "unexpected-native-model"
+                override fun releaseGGUFContext(nativeHandle: Long) = Unit
+            }
+        }
+
+        try {
+            val metadata =
+                StableDiffusionLoadSupport.inferVideoModelMetadata(
+                    resolvedModelPath = modelFile.absolutePath,
+                    modelId = null,
+                    explicitFilename = "sd3-finetune.gguf",
+                )
+
+            assertEquals("sd3", metadata.architecture)
+            assertNull(metadata.modelType)
+            assertNull(metadata.parameterCount)
+        } finally {
+            GGUFReader.resetNativeBridgeForTests()
+            modelFile.delete()
+        }
+    }
 
     @Test
     fun `inferVideoModelMetadata detects wan architecture from filename`() = runTest {

--- a/llmedge/src/test/java/io/aatricks/llmedge/Sd3MediumLinuxE2ETest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/Sd3MediumLinuxE2ETest.kt
@@ -3,6 +3,7 @@ package io.aatricks.llmedge
 import android.content.Context
 import android.graphics.Bitmap
 import io.aatricks.llmedge.image.diffusion.GenerateParams
+import io.aatricks.llmedge.image.diffusion.LoraApplyMode
 import io.aatricks.llmedge.image.diffusion.StableDiffusion
 import io.aatricks.llmedge.image.diffusion.StableDiffusionComponentPaths
 import java.io.File
@@ -24,6 +25,7 @@ import org.robolectric.annotation.Config
  *   LLMEDGE_TEST_SD3_CLIP_L_PATH
  *   LLMEDGE_TEST_SD3_CLIP_G_PATH
  *   LLMEDGE_TEST_SD3_VAE_PATH
+ *   LLMEDGE_TEST_SD3_LORA_PATH (optional)
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -38,6 +40,7 @@ class Sd3MediumLinuxE2ETest {
         val clipLPath = env("LLMEDGE_TEST_SD3_CLIP_L_PATH")
         val clipGPath = env("LLMEDGE_TEST_SD3_CLIP_G_PATH")
         val vaePath = env("LLMEDGE_TEST_SD3_VAE_PATH")
+        val loraPath = env("LLMEDGE_TEST_SD3_LORA_PATH")
 
         Assume.assumeTrue("Diffusion model path not set", !diffusionPath.isNullOrBlank())
         Assume.assumeTrue("CLIP_L path not set", !clipLPath.isNullOrBlank())
@@ -51,10 +54,19 @@ class Sd3MediumLinuxE2ETest {
 
         val width = 256
         val height = 256
-        val steps = 28
-        val cfg = 4.5f
+        val loraFile = loraPath?.let(::File)
+        if (loraFile != null) {
+            Assume.assumeTrue("LoRA file not found", loraFile.isFile)
+        }
+        val steps = if (loraFile != null) 4 else 28
+        val cfg = if (loraFile != null) 3.0f else 4.5f
         val seed = 42L
-        val prompt = "a red fox in snow, detailed, 8k"
+        val prompt =
+            if (loraFile != null) {
+                "a red fox in snow, detailed, 8k <lora:${loraFile.nameWithoutExtension}:0.125>"
+            } else {
+                "a red fox in snow, detailed, 8k"
+            }
 
         val context = org.robolectric.RuntimeEnvironment.getApplication() as Context
         val sd =
@@ -68,6 +80,8 @@ class Sd3MediumLinuxE2ETest {
                 keepVaeOnCpu = true,
                 flashAttn = true,
                 sequentialLoad = false,
+                loraModelDir = loraFile?.parentFile?.absolutePath,
+                loraApplyMode = LoraApplyMode.AUTO,
                 componentPaths = StableDiffusionComponentPaths(
                     clipLPath = clipLPath,
                     clipGPath = clipGPath,
@@ -103,7 +117,8 @@ class Sd3MediumLinuxE2ETest {
 
         val outputDir = File("build/outputs/images")
         outputDir.mkdirs()
-        val outputFile = File(outputDir, "sd3_medium_e2e_${width}x${height}_s${steps}_seed${seed}.png")
+        val outputPrefix = if (loraFile != null) "hyper_sd3" else "sd3_medium"
+        val outputFile = File(outputDir, "${outputPrefix}_e2e_${width}x${height}_s${steps}_seed${seed}.png")
         FileOutputStream(outputFile).use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
 
         println("[Sd3MediumLinuxE2ETest] uniqueColors=$uniqueColors output=${outputFile.absolutePath}")

--- a/llmedge/src/test/java/io/aatricks/llmedge/VideoGenerationSequentialE2ETest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/VideoGenerationSequentialE2ETest.kt
@@ -368,7 +368,7 @@ class VideoGenerationSequentialE2ETest {
         val diffusionModel =
                 StableDiffusion.load(
                         context = context,
-                        modelPath = paths.modelPath,
+                        diffusionModelPath = paths.modelPath,
                         vaePath = paths.vaePath,
                         t5xxlPath = null, // No T5 - we already precomputed conditions
                         nThreads = Runtime.getRuntime().availableProcessors().coerceAtMost(8),

--- a/llmedge/src/test/java/io/aatricks/llmedge/VideoGenerationSequentialE2ETest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/VideoGenerationSequentialE2ETest.kt
@@ -483,6 +483,26 @@ class VideoGenerationSequentialE2ETest {
             )
         }
 
+        (System.getenv("LLMEDGE_TEST_OUTPUT_DIR") ?: System.getProperty("LLMEDGE_TEST_OUTPUT_DIR"))
+                ?.takeIf(String::isNotBlank)
+                ?.let(::File)
+                ?.also(File::mkdirs)
+                ?.let { outputDir ->
+                    bitmaps.forEachIndexed { index, bitmap ->
+                        File(outputDir, "frame_%02d.png".format(index)).outputStream().use { output ->
+                            bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+                        }
+                    }
+                    File(outputDir, "wan-sequential.gif").outputStream().use { output ->
+                        io.aatricks.llmedge.vision.ImageUtils.createAnimatedGif(
+                                frames = bitmaps,
+                                delayMs = 125,
+                                output = output,
+                                loop = 0,
+                        )
+                    }
+                }
+
         println("[SequentialE2E] ✓ All validations passed!")
     }
 

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
@@ -154,6 +154,33 @@ class ImageRuntimeRequestPlannerTest {
     }
 
     @Test
+    fun `sequential image plan retains LoRA prompt resolution through every runtime`() {
+        val params =
+            ImageGenerationRequest(
+                prompt = "x <lora:hyper:0.125>",
+                model = ModelSpec.LocalFile(File("dit.safetensors")),
+                vae = ModelSpec.LocalFile(File("vae.safetensors")),
+                t5xxl = ModelSpec.LocalFile(File("t5xxl.safetensors")),
+                clipL = ModelSpec.LocalFile(File("clip_l.safetensors")),
+                clipG = ModelSpec.LocalFile(File("clip_g.safetensors")),
+                loraModelDir = "/models/lora",
+                loraApplyMode = io.aatricks.llmedge.image.diffusion.LoraApplyMode.IMMEDIATELY,
+                splitDiffusionModel = true,
+                sequential = true,
+            )
+
+        val plan = ImageRuntimeRequestPlanner.imageSequentialPlan(params, LLMEdgeConfig())
+
+        org.junit.Assert.assertEquals("/models/lora", plan.conditioningRequest.options.loraModelDir)
+        org.junit.Assert.assertEquals("/models/lora", plan.conditioningRequest2?.options?.loraModelDir)
+        org.junit.Assert.assertEquals("/models/lora", plan.diffusionRequest.options.loraModelDir)
+        org.junit.Assert.assertEquals(
+            io.aatricks.llmedge.image.diffusion.LoraApplyMode.IMMEDIATELY,
+            plan.diffusionRequest.options.loraApplyMode,
+        )
+    }
+
+    @Test
     fun `masked T5 sequential planner isolates the text encoder before the diffusion model`() {
         val ditModel = ModelSpec.LocalFile(File("minit2i.safetensors"))
         val textEncoder = ModelSpec.LocalFile(File("flan-t5-large.safetensors"))

--- a/llmedge/src/test/java/io/aatricks/llmedge/rag/RAGTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/rag/RAGTest.kt
@@ -1,9 +1,11 @@
 package io.aatricks.llmedge.rag
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import java.io.File
+import kotlinx.coroutines.test.runTest
 
 class RAGTest {
 
@@ -74,6 +76,23 @@ class RAGTest {
         assertEquals("text_embeddings", config.outputTensorName)
         assertEquals(false, config.useFP16)
         assertEquals(false, config.useXNNPack)
+    }
+
+    @Test
+    fun `local embedding files are used without copying packaged assets`() = runTest {
+        val directory = createTempDir(prefix = "embedding-files-")
+        val modelFile = File(directory, "model.onnx").apply { writeText("model") }
+        val tokenizerFile = File(directory, "tokenizer.json").apply { writeText("{}") }
+        val copiedModel = File(directory, "copied-model.onnx")
+        val config = EmbeddingConfig.fromFiles(modelFile, tokenizerFile)
+
+        val resolvedModel =
+            EmbeddingFileSource.parse(config.modelAssetPath).materialize(copiedModel) {
+                error("AssetManager must not be used for local embedding files")
+            }
+
+        assertEquals(modelFile.canonicalFile, resolvedModel.canonicalFile)
+        assertFalse(copiedModel.exists())
     }
 
     @Test


### PR DESCRIPTION
## Changes

- identify diffusion GGUF files before the generic GGUF metadata reader runs
- keep filename-based metadata inference for Wan and SD3 imports
- pass the sequential video model through `diffusionModelPath`
- retain LoRA prompt resolution and application across sequential image phases
- support downloaded local files for embedding models and tokenizers
- add native image and video E2E output coverage
- update the examples submodule revision

## Tests

- `:llmedge:testDebugUnitTest`
- `:llmedge:externalNativeBuildDebug`
- local Kotlin, JNI, and C++ sequential Wan generation at 256x256, 5 frames
- local JNI/C++ Hyper-SD3 four-step generation with all 682 LoRA tensors
- Hyper-SD3 four-step sequential generation on Galaxy S22
- imported Wan GGUF native load on Galaxy S22
- MiniLM first-use download and ONNX embedding on Galaxy S22