### PR TITLE
Harden runtime cancellation and backend probing

### DIFF
--- a/llmedge/src/main/java/io/aatricks/llmedge/core/runtime/RuntimeExecution.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/core/runtime/RuntimeExecution.kt
@@ -37,6 +37,9 @@ internal suspend fun <TSpec, TOptions, TRuntime : ManagedRuntime, TResult> Runti
         try {
             return execute(RuntimeExecutionContext(runtime = acquire.runtime, acquire = acquire))
         } catch (error: Throwable) {
+            if (error is kotlinx.coroutines.CancellationException) {
+                throw error
+            }
             val blacklisted = recordBackendFailureIfNeeded(spec, options, acquire.runtime, error)
             if (!blacklisted) {
                 throw error

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageClient.kt
@@ -140,6 +140,7 @@ class ImageClient internal constructor(
         fun resetBackendVerdicts(context: Context) {
             io.aatricks.llmedge.image.ipc.BackendVerdictStore(context).reset()
             BackendRuntimePolicy.resetForTests()
+            io.aatricks.llmedge.image.ipc.WorkerBackendProber.reset()
         }
     }
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeSupport.kt
@@ -205,6 +205,9 @@ internal class DiffusionRuntimeLoader(
                 chromaT5ConditionerOnly = chromaT5ConditionerOnly,
             )
         } catch (error: Throwable) {
+            if (error is kotlinx.coroutines.CancellationException) {
+                throw error
+            }
             if (!shouldRetryWithoutFlash(spec, options)) {
                 throw error
             }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerBackendProber.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerBackendProber.kt
@@ -40,6 +40,11 @@ internal object WorkerBackendProber {
 
     internal fun isVulkanQuarantined(): Boolean = vulkanQuarantined
 
+    internal fun reset() {
+        cached = null
+        vulkanQuarantined = false
+    }
+
     suspend fun probe(context: Context): ComputeBackendAvailability = mutex.withLock {
         cached?.let { return it }
 
@@ -110,6 +115,10 @@ internal object WorkerBackendProber {
                 "Backend probe failed: ${t.javaClass.simpleName} (connection=${connection != null}, " +
                     "classified=${classifierEx?.javaClass?.simpleName}, priorVerdict=$alreadyHasVulkanVerdict)",
             )
+
+            if (connection == null) {
+                return ComputeBackendAvailability(false, false, null)
+            }
 
             if (classifierEx is WorkerKilledByMemoryException) {
                 return ComputeBackendAvailability(false, false, null)

--- a/llmedge/src/main/java/io/aatricks/llmedge/tools/ToolAgent.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/tools/ToolAgent.kt
@@ -8,6 +8,7 @@ import io.aatricks.llmedge.text.ConversationWindow
 import io.aatricks.llmedge.text.ConversationSessionSupport
 import io.aatricks.llmedge.text.TextClient
 import io.aatricks.llmedge.text.TextModelOptions
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
@@ -87,6 +88,8 @@ class ToolAgent internal constructor(
                         )
                     emit(ToolAgentEvent.Completed(result))
                 }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
             } catch (t: Throwable) {
                 emit(ToolAgentEvent.Failed(t.message ?: "Tool agent failed.", t))
             }

--- a/llmedge/src/test/java/io/aatricks/llmedge/core/runtime/RuntimePoolTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/core/runtime/RuntimePoolTest.kt
@@ -5,6 +5,7 @@ import io.aatricks.llmedge.runtime.ComputeBackend
 import io.aatricks.llmedge.runtime.ComputeSubsystem
 import io.aatricks.llmedge.runtime.ModelCache
 import java.lang.Thread.sleep
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -113,6 +114,32 @@ class RuntimePoolTest {
         assertEquals(ComputeBackend.CPU, second.backend)
         assertEquals(2, loadCalls)
         assertEquals(1, closeCalls)
+    }
+
+    @Test
+    fun `execution cancellation is not treated as a backend failure`() = runTest {
+        var attempts = 0
+        val pool = createPool { _, _, backend ->
+            FakeRuntime(backend)
+        }
+        val options = FakeOptions(allowGpu = true, openClAvailable = true)
+
+        val failure =
+            runCatching {
+                pool.executeWithRetry("model", options) {
+                    attempts++
+                    throw CancellationException("backend cancelled")
+                }
+            }.exceptionOrNull()
+
+        assertTrue(failure is CancellationException)
+        assertEquals(1, attempts)
+        assertFalse(
+            BackendRuntimePolicy.isBlacklisted(
+                ComputeSubsystem.TEXT,
+                ComputeBackend.OPENCL,
+            ),
+        )
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -35,6 +35,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import java.lang.Thread.sleep
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
@@ -1417,6 +1418,51 @@ class ImageClientTest {
             edgeScope.close()
             StableDiffusion.resetNativeBridgeForTests()
         }
+    }
+
+    @Test
+    fun `diffusion load cancellation does not retry without flash attention`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val modelFile =
+            java.io.File.createTempFile("cancelled-image-load", ".safetensors", context.filesDir).apply {
+                writeBytes(byteArrayOf(0x01))
+            }
+        var loadCalls = 0
+        coEvery {
+            StableDiffusion.loadWithRuntimeBackend(
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
+                any(),
+                any(),
+                any(),
+            )
+        } coAnswers {
+            loadCalls++
+            throw CancellationException("cancelled during load")
+        }
+
+        val failure =
+            runCatching {
+                DiffusionRuntimeLoader(context, DefaultModelRepository()).load(
+                    spec = DiffusionRuntimeSpec(DiffusionRuntimeRole.IMAGE, ModelSpec.localFile(modelFile)),
+                    options =
+                        DiffusionLoadOptions(
+                            subsystem = ComputeSubsystem.IMAGE,
+                            allowGpu = false,
+                            nThreads = 1,
+                            offloadToCpu = true,
+                            keepClipOnCpu = true,
+                            keepVaeOnCpu = true,
+                            flashAttn = true,
+                            preferPerformanceMode = false,
+                        ),
+                    backend = ComputeBackend.CPU,
+                )
+            }.exceptionOrNull()
+
+        assertTrue(failure is CancellationException)
+        assertEquals(1, loadCalls)
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerBackendProberTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerBackendProberTest.kt
@@ -3,6 +3,7 @@ package io.aatricks.llmedge.image.ipc
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import io.aatricks.llmedge.core.WorkerKilledByMemoryException
+import io.aatricks.llmedge.image.ImageClient
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.every
@@ -215,6 +216,46 @@ class WorkerBackendProberTest {
         
         val result2 = WorkerBackendProber.probe(context)
         assertFalse(result2.vulkanAvailable)
+        coVerify(exactly = 1) { anyConstructed<WorkerConnectionManager>().connect(null) }
+    }
+
+    @Test
+    fun `public verdict reset clears cached probe and quarantine state`() {
+        val cachedField = WorkerBackendProber::class.java.getDeclaredField("cached").apply { isAccessible = true }
+        val quarantinedField =
+            WorkerBackendProber::class.java.getDeclaredField("vulkanQuarantined").apply {
+                isAccessible = true
+            }
+        cachedField.set(
+            WorkerBackendProber,
+            io.aatricks.llmedge.ComputeBackendAvailability(
+                openClAvailable = false,
+                vulkanAvailable = false,
+                vulkanDeviceInfo = null,
+            ),
+        )
+        quarantinedField.set(WorkerBackendProber, true)
+        store.recordHang(ComputeSubsystem.IMAGE, ComputeBackend.VULKAN)
+
+        ImageClient.resetBackendVerdicts(context)
+
+        assertNull(WorkerBackendProber.cachedOrNull())
+        assertFalse(WorkerBackendProber.isVulkanQuarantined())
+        assertTrue(store.load().isEmpty())
+    }
+
+    @Test
+    fun `worker bind failure does not create a permanent vulkan verdict`() = runTest {
+        io.mockk.mockkConstructor(WorkerConnectionManager::class)
+        coEvery {
+            anyConstructed<WorkerConnectionManager>().connect(null)
+        } throws SecurityException("worker service unavailable")
+
+        val result = WorkerBackendProber.probe(context)
+
+        assertFalse(result.vulkanAvailable)
+        assertTrue(store.load().isEmpty())
+        assertFalse(WorkerBackendProber.isVulkanQuarantined())
         coVerify(exactly = 1) { anyConstructed<WorkerConnectionManager>().connect(null) }
     }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/tools/ToolAgentTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/tools/ToolAgentTest.kt
@@ -9,6 +9,7 @@ import io.aatricks.llmedge.text.TextModelOptions
 import io.aatricks.llmedge.text.runtime.SmolLM
 import java.io.File
 import java.nio.file.Files
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
@@ -536,6 +537,38 @@ class ToolAgentTest {
                 events.filterIsInstance<ToolAgentEvent.TextChunk>().joinToString("") { it.value },
             )
             assertTrue(events.last() is ToolAgentEvent.Completed)
+        } finally {
+            edge.close()
+        }
+    }
+
+    @Test
+    fun `stream rethrows tool cancellation instead of emitting failure`() = runTest {
+        installBridge(listOf("""{"tool":"stop","arguments":{}}"""))
+        val edge = createEdge(this)
+        val agent =
+            edge.text.toolAgent(
+                model = localModel(edge),
+                options = TextModelOptions(temperature = 0.0f, useVulkan = false),
+                tools =
+                    listOf(
+                        Tool(
+                            name = "stop",
+                            description = "Stops the operation.",
+                            handler = { throw CancellationException("cancelled by tool") },
+                        ),
+                    ),
+            )
+
+        try {
+            var cancellation: CancellationException? = null
+            try {
+                agent.stream("Stop now.", maxSteps = 1).toList()
+            } catch (caught: CancellationException) {
+                cancellation = caught
+            }
+
+            assertEquals("cancelled by tool", cancellation?.message)
         } finally {
             edge.close()
         }

--- a/mods/llama.cpp/metal-dflash-include.patch
+++ b/mods/llama.cpp/metal-dflash-include.patch
@@ -1,0 +1,15 @@
+diff --git a/src/llama-dflash.cpp b/src/llama-dflash.cpp
+index e5f228f..cd9adcf 100644
+--- a/src/llama-dflash.cpp
++++ b/src/llama-dflash.cpp
+@@ -10,6 +10,10 @@
+ #include "ggml.h"
+ #include "ggml-backend.h"
+ 
++#ifdef GGML_USE_METAL
++#include "ggml-metal.h"
++#endif
++
+ #include <algorithm>
+ #include <cmath>
+ #include <cstring>


### PR DESCRIPTION
## Summary
- preserve cancellation across tool, runtime retry, and diffusion load paths
- fully clear cached worker probe state and avoid GPU quarantine on bind failures
- restore the macOS SmolLM host build with the Metal backend declaration

## Verification
- `:llmedge:testDebugUnitTest --rerun-tasks`
- `:llmedge:lintDebug`
- `scripts/build_native_linux.sh smollm`
- `scripts/build_native_linux.sh whisper`