### PR TITLE
Persist worker diagnostics so a field crash is diagnosable without adb

### DIFF
--- a/llmedge/src/main/cpp/GGUFReader.cpp
+++ b/llmedge/src/main/cpp/GGUFReader.cpp
@@ -89,6 +89,13 @@ Java_io_aatricks_llmedge_runtime_GGUFReader_00024DefaultNativeBridge_getModelNam
     return to_utf8_bytes(env, modelName);
 }
 
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_io_aatricks_llmedge_runtime_GGUFReader_00024DefaultNativeBridge_getTensorNamePrefixesBytes(JNIEnv* env, jobject thiz, jlong nativeHandle) {
+    gguf_context* ggufContext = reinterpret_cast<gguf_context*>(nativeHandle);
+    const std::string prefixes = llmedge_gguf_get_tensor_name_prefixes(ggufContext);
+    return to_utf8_bytes(env, prefixes);
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_io_aatricks_llmedge_runtime_GGUFReader_00024DefaultNativeBridge_releaseGGUFContext(JNIEnv* env, jobject thiz, jlong nativeHandle) {
     auto* ggufContext = reinterpret_cast<gguf_context*>(nativeHandle);

--- a/llmedge/src/main/cpp/gguf_reader_internal.cpp
+++ b/llmedge/src/main/cpp/gguf_reader_internal.cpp
@@ -1,5 +1,6 @@
 #include "gguf_reader_internal.h"
 
+#include <set>
 #include <string>
 #include <unordered_map>
 
@@ -53,6 +54,39 @@ int64_t llmedge_gguf_get_file_type(const struct gguf_context * gguf_context) {
         return -1;
     }
     return static_cast<int64_t>(gguf_get_val_u32(gguf_context, file_type_key_id));
+}
+
+std::string llmedge_gguf_get_tensor_name_prefixes(const struct gguf_context * gguf_context) {
+    const int64_t tensor_count = gguf_get_n_tensors(gguf_context);
+    if (tensor_count <= 0) {
+        return std::string();
+    }
+
+    // DEPTH CONTRACT: exactly one segment — the tensor name up to its first '.', or the whole
+    // name when it has none. Callers classify against depth-1 keys ("text_encoders",
+    // "first_stage_model", "joint_blocks"); returning deeper prefixes would silently break them.
+    std::set<std::string> prefixes;
+    for (int64_t tensor_id = 0; tensor_id < tensor_count; ++tensor_id) {
+        const char * name = gguf_get_tensor_name(gguf_context, tensor_id);
+        if (name == nullptr) {
+            continue;
+        }
+        std::string tensor_name(name);
+        const size_t separator = tensor_name.find('.');
+        prefixes.insert(separator == std::string::npos ? tensor_name : tensor_name.substr(0, separator));
+        if (prefixes.size() >= LLMEDGE_GGUF_MAX_TENSOR_PREFIXES) {
+            break;
+        }
+    }
+
+    std::string joined;
+    for (const std::string & prefix : prefixes) {
+        if (!joined.empty()) {
+            joined.push_back('\n');
+        }
+        joined.append(prefix);
+    }
+    return joined;
 }
 
 int32_t llmedge_gguf_get_dominant_tensor_type(const struct gguf_context * gguf_context) {

--- a/llmedge/src/main/cpp/gguf_reader_internal.h
+++ b/llmedge/src/main/cpp/gguf_reader_internal.h
@@ -13,3 +13,11 @@ std::string llmedge_gguf_get_parameter_count(const struct gguf_context * gguf_co
 std::string llmedge_gguf_get_model_name(const struct gguf_context * gguf_context);
 int64_t llmedge_gguf_get_file_type(const struct gguf_context * gguf_context);
 int32_t llmedge_gguf_get_dominant_tensor_type(const struct gguf_context * gguf_context);
+
+// Caps the prefix set for a checkpoint with an unexpected naming scheme; real checkpoints yield
+// a handful of distinct first segments.
+#define LLMEDGE_GGUF_MAX_TENSOR_PREFIXES 64
+
+// Deduplicated, newline-joined first segments of every tensor name (see the DEPTH CONTRACT note
+// in the implementation). Lets a caller tell a bare denoiser from an all-in-one bundle.
+std::string llmedge_gguf_get_tensor_name_prefixes(const struct gguf_context * gguf_context);

--- a/llmedge/src/main/java/io/aatricks/llmedge/core/AndroidLogAdapter.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/core/AndroidLogAdapter.kt
@@ -6,6 +6,26 @@ internal object AndroidLogAdapter {
     private const val WARN_LEVEL = "W"
     private const val ERROR_LEVEL = "E"
 
+    /** Receives every line alongside logcat, so diagnostics can outlive the process. */
+    internal fun interface Sink {
+        fun onLog(level: String, tag: String, message: String, throwable: Throwable?)
+    }
+
+    @Volatile private var sink: Sink? = null
+
+    internal fun setSink(sink: Sink?) {
+        this.sink = sink
+    }
+
+    private fun mirror(level: String, tag: String, message: String, throwable: Throwable? = null) {
+        val target = sink ?: return
+        try {
+            target.onLog(level, tag, message, throwable)
+        } catch (_: Throwable) {
+            // A failing diagnostic sink must never break the call it is observing.
+        }
+    }
+
     private val logClass: Class<*>? by lazy {
         try {
             Class.forName("android.util.Log")
@@ -33,6 +53,7 @@ internal object AndroidLogAdapter {
     fun w(tag: String, message: String) = log(warnMethod, WARN_LEVEL, tag, message)
 
     fun e(tag: String, message: String, throwable: Throwable? = null) {
+        mirror(ERROR_LEVEL, tag, message, throwable)
         val method = errorMethod
         if (method != null) {
             try {
@@ -48,6 +69,7 @@ internal object AndroidLogAdapter {
     }
 
     private fun log(method: java.lang.reflect.Method?, level: String, tag: String, message: String) {
+        mirror(level, tag, message)
         if (method != null) {
             try {
                 method.invoke(null, tag, message)

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/Sd3Medium.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/Sd3Medium.kt
@@ -8,15 +8,16 @@ import io.aatricks.llmedge.model.ModelSpec
 /**
  * Stable Diffusion 3 Medium presets for on-device generation through stable-diffusion.cpp.
  *
- * This preset now includes the optional T5XXL FP8 text encoder for full text conditioning,
- * yielding high quality generation at the expense of downloading a ~4.89 GB encoder.
- * Sequential low-RAM mode is supported for SD3 split conditioning by loading CLIP-L, CLIP-G,
- * and T5XXL sequentially before loading the DiT + VAE.
+ * This preset includes the T5XXL text encoder for full text conditioning, as a Q3_K_S GGUF of
+ * the T5 v1.1 XXL encoder (~2.1 GB) rather than the fp8 safetensors ComfyUI ships. Same
+ * architecture and weights, lower precision: it trades some prompt fidelity for a download that
+ * fits on a phone. Sequential low-RAM mode is supported for SD3 split conditioning by loading
+ * CLIP-L + CLIP-G, then T5XXL, before loading the DiT + VAE.
  *
  * Mobile default resolution is 512x512, though the model's native resolution is 1024x1024.
  * Callers with sufficient RAM headroom may pass 1024x1024.
  *
- * The total split download size is approximately 8.0 GB.
+ * The total split download size is approximately 5.2 GB.
  */
 object Sd3Medium {
     /** The SD3 Medium DiT model (Q4_0, ~1.28 GB). */

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/DiffusionWorkerService.kt
@@ -308,6 +308,10 @@ internal class DiffusionWorkerService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        // Mirror this process's diagnostics to disk before anything else can log. The breadcrumb
+        // below only fires for an uncaught throwable that reaches the handler; when it does not
+        // (observed in the field), this trail is all the host has to localise the failure.
+        WorkerDiagnosticsLog.install(this, Process.myPid())
         // A generation exception is caught and reported over binder; an *uncaught* one kills this
         // process (exitReason REASON_CRASH) with the stack lost to logcat. Persist it so the host
         // can surface it in WorkerCrashedException — the only way to see it without adb.

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerDiagnosticsLog.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerDiagnosticsLog.kt
@@ -1,0 +1,86 @@
+package io.aatricks.llmedge.image.ipc
+
+import android.content.Context
+import android.os.SystemClock
+import io.aatricks.llmedge.core.AndroidLogAdapter
+import java.io.File
+
+/**
+ * Mirrors the worker process's own [AndroidLogAdapter] output to a file in the shared data
+ * directory, so the trail leading up to a crash survives the process.
+ *
+ * The worker's diagnostics — which pass acquired which backend, which runtime was invalidated
+ * before which phase — otherwise exist only in logcat, which a field reporter without a PC cannot
+ * read. The host reads the tail of this file after `binderDied` and folds it into
+ * [io.aatricks.llmedge.core.WorkerCrashedException], which is what a shared app log ends up
+ * containing.
+ *
+ * Lines are flushed per write: a buffered line is a line lost to the crash it was meant to
+ * explain.
+ */
+internal object WorkerDiagnosticsLog {
+    private const val MAX_BYTES = 256 * 1024
+    private const val MAX_LINES = 400
+    private const val STALE_FILE_AGE_MS = 10 * 60 * 1000L
+
+    private val recent = ArrayDeque<String>()
+    private var file: File? = null
+
+    fun logFile(context: Context, pid: Int): File =
+        File(context.filesDir, "diffusion-worker-log-$pid.txt")
+
+    /** Installs the sink for this process. Call once, before any generation work. */
+    @Synchronized
+    fun install(context: Context, pid: Int) {
+        val target = logFile(context, pid)
+        runCatching { target.delete() }
+        file = target
+        recent.clear()
+        sweepStaleFiles(context, pid)
+        AndroidLogAdapter.setSink { level, tag, message, throwable ->
+            append("$level/$tag: $message" + (throwable?.let { "\n${it.stackTraceToString()}" } ?: ""))
+        }
+    }
+
+    @Synchronized
+    private fun append(line: String) {
+        val target = file ?: return
+        val stamped = "[${SystemClock.uptimeMillis()}] $line"
+        recent.addLast(stamped)
+        while (recent.size > MAX_LINES) {
+            recent.removeFirst()
+        }
+        runCatching {
+            if (target.length() > MAX_BYTES) {
+                target.writeText(recent.joinToString("\n", postfix = "\n"))
+            } else {
+                target.appendText("$stamped\n")
+            }
+        }
+    }
+
+    /** Reads and removes the tail left behind by a dead worker. */
+    fun consumeTail(context: Context, pid: Int, maxChars: Int): String? =
+        runCatching {
+            val target = logFile(context, pid)
+            if (!target.isFile) return null
+            val text = target.readText().trim()
+            target.delete()
+            text.takeLast(maxChars).ifBlank { null }
+        }.getOrNull()
+
+    /** Drops logs left by workers that died without the host ever reading them. */
+    private fun sweepStaleFiles(context: Context, currentPid: Int) {
+        runCatching {
+            val cutoff = System.currentTimeMillis() - STALE_FILE_AGE_MS
+            context.filesDir
+                .listFiles { candidate ->
+                    candidate.name.startsWith("diffusion-worker-log-") &&
+                        candidate.name != "diffusion-worker-log-$currentPid.txt" &&
+                        candidate.lastModified() < cutoff
+                }
+                .orEmpty()
+                .forEach(File::delete)
+        }
+    }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerFailureClassifier.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerFailureClassifier.kt
@@ -13,6 +13,9 @@ import java.io.File
 
 /** Maps a dead worker (binderDied) to a typed failure using ApplicationExitInfo (API 30+). */
 internal object WorkerFailureClassifier {
+    /** Kept generous: this is the whole post-mortem when no tombstone or breadcrumb exists. */
+    private const val WORKER_LOG_TAIL_CHARS = 4000
+
     /** Breadcrumb the worker writes on an uncaught JVM exception (see [DiffusionWorkerService]). */
     internal fun crashBreadcrumbFile(context: Context, pid: Int): File =
         File(context.filesDir, "diffusion-worker-crash-$pid.txt")
@@ -82,6 +85,12 @@ internal object WorkerFailureClassifier {
         if (parts.size == 1) {
             exitInfo?.description?.takeIf { it.isNotBlank() }?.let { parts.add(it) }
         }
+
+        // Always last, and always present: when none of the above resolved a cause, the worker's
+        // own log trail is what tells us which pass it died in.
+        WorkerDiagnosticsLog.consumeTail(context, pid, WORKER_LOG_TAIL_CHARS)
+            ?.let { parts.add("worker-log:\n$it") }
+
         return parts.joinToString("; ")
     }
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/GgufFileSummary.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/GgufFileSummary.kt
@@ -1,9 +1,8 @@
 package io.aatricks.llmedge.model
 
-import java.io.BufferedInputStream
+import io.aatricks.llmedge.runtime.GGUFReader
 import java.io.File
-import java.io.FileInputStream
-import java.io.InputStream
+import kotlinx.coroutines.runBlocking
 
 /**
  * A component family a GGUF checkpoint carries, derived from its tensor names.
@@ -22,18 +21,12 @@ enum class GgufComponent {
 /**
  * What [GgufFileSummary.read] could recover from a GGUF file's header.
  *
- * Only the metadata and tensor-info sections are read, so the cost is independent of the weight
- * payload. Every failure degrades to `null` rather than throwing: this exists to produce a better
- * error message, and must never be the reason a valid model is rejected.
- *
- * Deliberately not built on [io.aatricks.llmedge.runtime.GGUFReader], which overlaps only on
- * `general.architecture`: that reader enumerates no tensors, so it cannot tell a bare denoiser
- * from a bundle, and it needs its native library — which would put a `.so` dependency on the
- * import path and take this classification out of reach of JVM unit tests.
+ * Reads metadata and tensor names only, so the cost is independent of the weight payload. Every
+ * failure degrades to `null` rather than throwing: this exists to produce a better error message,
+ * and must never be the reason a valid model is rejected.
  */
 data class GgufFileSummary(
-    val version: Int,
-    val tensorCount: Long,
+    val tensorPrefixes: Set<String>,
     /** The `general.architecture` metadata value, when present. */
     val architecture: String?,
     val components: Set<GgufComponent>,
@@ -43,135 +36,34 @@ data class GgufFileSummary(
         get() = GgufComponent.TEXT_ENCODER in components || GgufComponent.VAE in components
 
     companion object {
-        private const val MAGIC = 0x46554747L // "GGUF" read little-endian.
-        private const val MIN_VERSION = 2
-
-        /** Guards against a corrupt count turning into an unbounded read. */
-        private const val MAX_TENSORS = 1_000_000L
-        private const val MAX_KV_PAIRS = 100_000L
-        private const val MAX_ARRAY_LENGTH = 50_000_000L
-        private const val MAX_STRING_BYTES = 1L shl 20
-
-        private val vaePrefixes = listOf("first_stage_model.", "vae.")
+        // Matched against GGUFReader.getTensorNamePrefixes(), which is exactly one segment deep —
+        // so every key here must be a whole first segment, never a dotted path.
+        private val vaePrefixes = setOf("first_stage_model", "vae")
         private val textEncoderPrefixes =
-            listOf("text_encoders.", "cond_stage_model.", "conditioner.", "clip_l.", "clip_g.", "t5xxl.")
-        private val diffusionPrefixes = listOf("model.diffusion_model.", "diffusion_model.")
+            setOf("text_encoders", "cond_stage_model", "conditioner", "clip_l", "clip_g", "t5xxl")
+        private val diffusionPrefixes =
+            setOf("model", "diffusion_model", "joint_blocks", "double_blocks", "single_blocks")
 
         @JvmStatic
         fun read(file: File): GgufFileSummary? =
             runCatching {
-                BufferedInputStream(FileInputStream(file), 1 shl 16).use(::parse)
+                GGUFReader().use { reader ->
+                    runBlocking { reader.load(file.absolutePath) }
+                    val prefixes = reader.getTensorNamePrefixes()
+                    if (prefixes.isEmpty()) return null
+                    GgufFileSummary(
+                        tensorPrefixes = prefixes,
+                        architecture = reader.getArchitecture(),
+                        components = classify(prefixes),
+                    )
+                }
             }.getOrNull()
 
-        private fun parse(input: InputStream): GgufFileSummary? {
-            if (input.readUInt32() != MAGIC) return null
-            val version = input.readUInt32().toInt()
-            if (version < MIN_VERSION) return null
-
-            val tensorCount = input.readUInt64()
-            val kvCount = input.readUInt64()
-            if (tensorCount !in 0..MAX_TENSORS || kvCount !in 0..MAX_KV_PAIRS) return null
-
-            var architecture: String? = null
-            repeat(kvCount.toInt()) {
-                val key = input.readGgufString() ?: return null
-                val value = input.readKvValue() ?: return null
-                if (key == "general.architecture" && value is String) {
-                    architecture = value
-                }
+        internal fun classify(prefixes: Set<String>): Set<GgufComponent> =
+            buildSet {
+                if (prefixes.any(vaePrefixes::contains)) add(GgufComponent.VAE)
+                if (prefixes.any(textEncoderPrefixes::contains)) add(GgufComponent.TEXT_ENCODER)
+                if (prefixes.any(diffusionPrefixes::contains)) add(GgufComponent.DIFFUSION)
             }
-
-            val components = mutableSetOf<GgufComponent>()
-            repeat(tensorCount.toInt()) {
-                val name = input.readGgufString() ?: return null
-                classify(name)?.let(components::add)
-                val dimensions = input.readUInt32().toInt()
-                if (dimensions !in 0..8) return null
-                repeat(dimensions) { input.readUInt64() }
-                input.readUInt32() // ggml type
-                input.readUInt64() // offset
-            }
-
-            return GgufFileSummary(
-                version = version,
-                tensorCount = tensorCount,
-                architecture = architecture,
-                components = components,
-            )
-        }
-
-        private fun classify(tensorName: String): GgufComponent? =
-            when {
-                vaePrefixes.any(tensorName::startsWith) -> GgufComponent.VAE
-                textEncoderPrefixes.any(tensorName::startsWith) -> GgufComponent.TEXT_ENCODER
-                diffusionPrefixes.any(tensorName::startsWith) -> GgufComponent.DIFFUSION
-                else -> null
-            }
-
-        /**
-         * Skips a metadata value, materialising it only for the scalar string case the caller
-         * reads. Arrays recurse one level, which is all GGUF allows.
-         */
-        private fun InputStream.readKvValue(): Any? =
-            when (readUInt32().toInt()) {
-                0, 1, 7 -> readExactly(1) // uint8 / int8 / bool
-                2, 3 -> readExactly(2) // uint16 / int16
-                4, 5, 6 -> readExactly(4) // uint32 / int32 / float32
-                8 -> readGgufString()
-                9 -> readArrayValue()
-                10, 11, 12 -> readExactly(8) // uint64 / int64 / float64
-                else -> null
-            }
-
-        private fun InputStream.readArrayValue(): Any? {
-            val elementType = readUInt32().toInt()
-            val length = readUInt64()
-            if (length !in 0..MAX_ARRAY_LENGTH) return null
-            repeat(length.toInt()) {
-                val element: Any? =
-                    when (elementType) {
-                        0, 1, 7 -> readExactly(1)
-                        2, 3 -> readExactly(2)
-                        4, 5, 6 -> readExactly(4)
-                        8 -> readGgufString()
-                        10, 11, 12 -> readExactly(8)
-                        else -> null
-                    }
-                element ?: return null
-            }
-            return Unit
-        }
-
-        private fun InputStream.readGgufString(): String? {
-            val length = readUInt64()
-            if (length !in 0..MAX_STRING_BYTES) return null
-            val bytes = readExactly(length.toInt()) ?: return null
-            return String(bytes, Charsets.UTF_8)
-        }
-
-        private fun InputStream.readUInt32(): Long = readLittleEndian(4)
-
-        private fun InputStream.readUInt64(): Long = readLittleEndian(8)
-
-        private fun InputStream.readLittleEndian(byteCount: Int): Long {
-            val bytes = readExactly(byteCount) ?: return -1L
-            var value = 0L
-            for (index in byteCount - 1 downTo 0) {
-                value = (value shl 8) or (bytes[index].toLong() and 0xFF)
-            }
-            return value
-        }
-
-        private fun InputStream.readExactly(count: Int): ByteArray? {
-            if (count < 0) return null
-            val buffer = ByteArray(count)
-            var read = 0
-            while (read < count) {
-                val n = read(buffer, read, count - read)
-                if (n < 0) return null
-                read += n
-            }
-            return buffer
-        }
     }
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/GgufFileSummary.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/GgufFileSummary.kt
@@ -1,0 +1,172 @@
+package io.aatricks.llmedge.model
+
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+
+/**
+ * A component family a GGUF checkpoint carries, derived from its tensor names.
+ *
+ * Diffusion checkpoints ship either as a bare denoiser ([DIFFUSION] alone) or as an all-in-one
+ * bundle that also bakes in the text encoders and the VAE. The two are not interchangeable: a
+ * bundle handed to a diffusion-model-only slot leaves the runtime loading a second, conflicting
+ * copy of the encoders alongside the ones baked into the file.
+ */
+enum class GgufComponent {
+    DIFFUSION,
+    TEXT_ENCODER,
+    VAE,
+}
+
+/**
+ * What [GgufFileSummary.read] could recover from a GGUF file's header.
+ *
+ * Only the metadata and tensor-info sections are read, so the cost is independent of the weight
+ * payload. Every failure degrades to `null` rather than throwing: this exists to produce a better
+ * error message, and must never be the reason a valid model is rejected.
+ */
+data class GgufFileSummary(
+    val version: Int,
+    val tensorCount: Long,
+    /** The `general.architecture` metadata value, when present. */
+    val architecture: String?,
+    val components: Set<GgufComponent>,
+) {
+    /** True when the file bundles text encoders or a VAE next to the denoiser. */
+    val isAllInOne: Boolean
+        get() = GgufComponent.TEXT_ENCODER in components || GgufComponent.VAE in components
+
+    companion object {
+        private const val MAGIC = 0x46554747L // "GGUF" read little-endian.
+        private const val MIN_VERSION = 2
+
+        /** Guards against a corrupt count turning into an unbounded read. */
+        private const val MAX_TENSORS = 1_000_000L
+        private const val MAX_KV_PAIRS = 100_000L
+        private const val MAX_ARRAY_LENGTH = 50_000_000L
+        private const val MAX_STRING_BYTES = 1L shl 20
+
+        private val vaePrefixes = listOf("first_stage_model.", "vae.")
+        private val textEncoderPrefixes =
+            listOf("text_encoders.", "cond_stage_model.", "conditioner.", "clip_l.", "clip_g.", "t5xxl.")
+        private val diffusionPrefixes = listOf("model.diffusion_model.", "diffusion_model.")
+
+        @JvmStatic
+        fun read(file: File): GgufFileSummary? =
+            runCatching {
+                BufferedInputStream(FileInputStream(file), 1 shl 16).use(::parse)
+            }.getOrNull()
+
+        private fun parse(input: InputStream): GgufFileSummary? {
+            if (input.readUInt32() != MAGIC) return null
+            val version = input.readUInt32().toInt()
+            if (version < MIN_VERSION) return null
+
+            val tensorCount = input.readUInt64()
+            val kvCount = input.readUInt64()
+            if (tensorCount !in 0..MAX_TENSORS || kvCount !in 0..MAX_KV_PAIRS) return null
+
+            var architecture: String? = null
+            repeat(kvCount.toInt()) {
+                val key = input.readGgufString() ?: return null
+                val value = input.readKvValue() ?: return null
+                if (key == "general.architecture" && value is String) {
+                    architecture = value
+                }
+            }
+
+            val components = mutableSetOf<GgufComponent>()
+            repeat(tensorCount.toInt()) {
+                val name = input.readGgufString() ?: return null
+                classify(name)?.let(components::add)
+                val dimensions = input.readUInt32().toInt()
+                if (dimensions !in 0..8) return null
+                repeat(dimensions) { input.readUInt64() }
+                input.readUInt32() // ggml type
+                input.readUInt64() // offset
+            }
+
+            return GgufFileSummary(
+                version = version,
+                tensorCount = tensorCount,
+                architecture = architecture,
+                components = components,
+            )
+        }
+
+        private fun classify(tensorName: String): GgufComponent? =
+            when {
+                vaePrefixes.any(tensorName::startsWith) -> GgufComponent.VAE
+                textEncoderPrefixes.any(tensorName::startsWith) -> GgufComponent.TEXT_ENCODER
+                diffusionPrefixes.any(tensorName::startsWith) -> GgufComponent.DIFFUSION
+                else -> null
+            }
+
+        /**
+         * Skips a metadata value, materialising it only for the scalar string case the caller
+         * reads. Arrays recurse one level, which is all GGUF allows.
+         */
+        private fun InputStream.readKvValue(): Any? =
+            when (readUInt32().toInt()) {
+                0, 1, 7 -> readExactly(1) // uint8 / int8 / bool
+                2, 3 -> readExactly(2) // uint16 / int16
+                4, 5, 6 -> readExactly(4) // uint32 / int32 / float32
+                8 -> readGgufString()
+                9 -> readArrayValue()
+                10, 11, 12 -> readExactly(8) // uint64 / int64 / float64
+                else -> null
+            }
+
+        private fun InputStream.readArrayValue(): Any? {
+            val elementType = readUInt32().toInt()
+            val length = readUInt64()
+            if (length !in 0..MAX_ARRAY_LENGTH) return null
+            repeat(length.toInt()) {
+                val element: Any? =
+                    when (elementType) {
+                        0, 1, 7 -> readExactly(1)
+                        2, 3 -> readExactly(2)
+                        4, 5, 6 -> readExactly(4)
+                        8 -> readGgufString()
+                        10, 11, 12 -> readExactly(8)
+                        else -> null
+                    }
+                element ?: return null
+            }
+            return Unit
+        }
+
+        private fun InputStream.readGgufString(): String? {
+            val length = readUInt64()
+            if (length !in 0..MAX_STRING_BYTES) return null
+            val bytes = readExactly(length.toInt()) ?: return null
+            return String(bytes, Charsets.UTF_8)
+        }
+
+        private fun InputStream.readUInt32(): Long = readLittleEndian(4)
+
+        private fun InputStream.readUInt64(): Long = readLittleEndian(8)
+
+        private fun InputStream.readLittleEndian(byteCount: Int): Long {
+            val bytes = readExactly(byteCount) ?: return -1L
+            var value = 0L
+            for (index in byteCount - 1 downTo 0) {
+                value = (value shl 8) or (bytes[index].toLong() and 0xFF)
+            }
+            return value
+        }
+
+        private fun InputStream.readExactly(count: Int): ByteArray? {
+            if (count < 0) return null
+            val buffer = ByteArray(count)
+            var read = 0
+            while (read < count) {
+                val n = read(buffer, read, count - read)
+                if (n < 0) return null
+                read += n
+            }
+            return buffer
+        }
+    }
+}

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/GgufFileSummary.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/GgufFileSummary.kt
@@ -25,6 +25,11 @@ enum class GgufComponent {
  * Only the metadata and tensor-info sections are read, so the cost is independent of the weight
  * payload. Every failure degrades to `null` rather than throwing: this exists to produce a better
  * error message, and must never be the reason a valid model is rejected.
+ *
+ * Deliberately not built on [io.aatricks.llmedge.runtime.GGUFReader], which overlaps only on
+ * `general.architecture`: that reader enumerates no tensors, so it cannot tell a bare denoiser
+ * from a bundle, and it needs its native library — which would put a `.so` dependency on the
+ * import path and take this classification out of reach of JVM unit tests.
  */
 data class GgufFileSummary(
     val version: Int,

--- a/llmedge/src/main/java/io/aatricks/llmedge/model/ModelFileValidator.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/model/ModelFileValidator.kt
@@ -67,6 +67,42 @@ object ModelFileValidator {
         return file
     }
 
+    /**
+     * Rejects an all-in-one checkpoint for a caller that loads the text encoders and VAE
+     * separately. Such a file lands in `diffusion_model_path`, so its baked-in encoders and the
+     * separately supplied ones are both loaded — a misconfiguration that surfaces later as a
+     * generation-time crash rather than a load error, which makes it near-impossible to diagnose
+     * from an app log alone.
+     *
+     * A file whose components cannot be determined passes: this exists to explain a known
+     * mistake, not to gate models.
+     */
+    @JvmStatic
+    fun requireDiffusionOnlyGguf(
+        file: File,
+        displayName: String = file.name,
+    ): File {
+        val summary = GgufFileSummary.read(file) ?: return file
+        if (!summary.isAllInOne) return file
+        val bundled =
+            summary.components
+                .filter { it != GgufComponent.DIFFUSION }
+                .sorted()
+                .joinToString(" and ") {
+                    when (it) {
+                        GgufComponent.TEXT_ENCODER -> "text encoders"
+                        GgufComponent.VAE -> "a VAE"
+                        GgufComponent.DIFFUSION -> "a denoiser"
+                    }
+                }
+        throw InvalidModelFileException(
+            file.absolutePath,
+            "$displayName is an all-in-one checkpoint (it bundles $bundled). This preset " +
+                "downloads those separately and needs a diffusion-model-only file. Pick a " +
+                "DiT-only GGUF, or switch to a preset that takes all-in-one checkpoints.",
+        )
+    }
+
     @JvmStatic
     fun resolveReadableFile(
         context: Context,

--- a/llmedge/src/main/java/io/aatricks/llmedge/runtime/GGUFReader.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/runtime/GGUFReader.kt
@@ -39,6 +39,7 @@ class GGUFReader : Closeable {
         fun getModelName(nativeHandle: Long): String
         fun getFileType(nativeHandle: Long): Int = -1
         fun getDominantTensorType(nativeHandle: Long): Int = -1
+        fun getTensorNamePrefixes(nativeHandle: Long): String = ""
         fun releaseGGUFContext(nativeHandle: Long)
     }
 
@@ -143,6 +144,21 @@ class GGUFReader : Closeable {
         return if (dominantTensorType < 0) null else dominantTensorType
     }
 
+    /**
+     * The distinct first segments of this file's tensor names — `text_encoders`, `joint_blocks`,
+     * `first_stage_model` and so on. Exactly one segment deep; see the DEPTH CONTRACT note in
+     * `gguf_reader_internal.cpp`, which callers' prefix keys must match.
+     *
+     * Enough to tell a bare denoiser from an all-in-one bundle without reading any weights.
+     */
+    internal fun getTensorNamePrefixes(): Set<String> {
+        verifyHandle()
+        return nativeBridge.getTensorNamePrefixes(nativeHandle)
+            .lineSequence()
+            .filter(String::isNotBlank)
+            .toSet()
+    }
+
     override fun close() {
         if (nativeHandle != 0L) {
             nativeBridge.releaseGGUFContext(nativeHandle)
@@ -175,6 +191,9 @@ class GGUFReader : Closeable {
         override fun getModelName(nativeHandle: Long): String =
             getModelNameBytes(nativeHandle)?.toString(Charsets.UTF_8).orEmpty()
 
+        override fun getTensorNamePrefixes(nativeHandle: Long): String =
+            getTensorNamePrefixesBytes(nativeHandle)?.toString(Charsets.UTF_8).orEmpty()
+
         private external fun getChatTemplateBytes(nativeHandle: Long): ByteArray?
 
         private external fun getArchitectureBytes(nativeHandle: Long): ByteArray?
@@ -182,6 +201,8 @@ class GGUFReader : Closeable {
         private external fun getParameterCountBytes(nativeHandle: Long): ByteArray?
 
         private external fun getModelNameBytes(nativeHandle: Long): ByteArray?
+
+        private external fun getTensorNamePrefixesBytes(nativeHandle: Long): ByteArray?
 
         override external fun getFileType(nativeHandle: Long): Int
         override external fun getDominantTensorType(nativeHandle: Long): Int

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerFailureClassifierTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerFailureClassifierTest.kt
@@ -45,4 +45,51 @@ class WorkerFailureClassifierTest {
         assertTrue(result is WorkerCrashedException)
         assertEquals("CPU", (result as WorkerCrashedException).backend)
     }
+
+    /**
+     * Reproduces llmedge-examples#37: a REASON_CRASH worker death that left no tombstone (not a
+     * native crash) and no breadcrumb (the uncaught handler never ran), which previously reduced
+     * the whole post-mortem to the word "crash".
+     */
+    @Test
+    fun `crash summary carries the worker log trail when no breadcrumb exists`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val pid = 4242
+        WorkerDiagnosticsLog.logFile(context, pid).writeText(
+            "[100] I/DiffusionWorker: Worker engine initialized\n" +
+                "[200] I/DiffusionRuntimeLoader: Creating managed CPU runtime for t5xxl sequential=true\n",
+        )
+
+        val result =
+            WorkerFailureClassifier.classify(
+                context = context,
+                pid = pid,
+                lastPhase = DiffusionPhases.GENERATING,
+                lastBackend = "CPU",
+                killedByWatchdog = false,
+                stallMs = 0L,
+            ) as WorkerCrashedException
+
+        val summary = requireNotNull(result.crashSummary)
+        assertTrue(summary, summary.contains("worker-log:"))
+        assertTrue(summary, summary.contains("Creating managed CPU runtime for t5xxl"))
+        assertTrue("trail should be consumed", !WorkerDiagnosticsLog.logFile(context, pid).exists())
+    }
+
+    @Test
+    fun `crash summary omits the trail section when the worker left no log`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val result =
+            WorkerFailureClassifier.classify(
+                context = context,
+                pid = 5150,
+                lastPhase = DiffusionPhases.GENERATING,
+                lastBackend = "CPU",
+                killedByWatchdog = false,
+                stallMs = 0L,
+            ) as WorkerCrashedException
+
+        assertTrue(requireNotNull(result.crashSummary).let { !it.contains("worker-log:") })
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/model/GgufFileSummaryTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/model/GgufFileSummaryTest.kt
@@ -1,0 +1,207 @@
+package io.aatricks.llmedge.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+class GgufFileSummaryTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private var fileCounter = 0
+
+    @Test
+    fun `reads architecture and classifies a diffusion-only checkpoint`() {
+        val file = writeGguf(
+            architecture = "sd3",
+            tensorNames = listOf("joint_blocks.0.x_block.attn.qkv.weight", "model.diffusion_model.pos_embed"),
+        )
+
+        val summary = GgufFileSummary.read(file)!!
+
+        assertEquals("sd3", summary.architecture)
+        assertEquals(2L, summary.tensorCount)
+        assertEquals(setOf(GgufComponent.DIFFUSION), summary.components)
+        assertFalse(summary.isAllInOne)
+    }
+
+    @Test
+    fun `flags a bundle carrying text encoders and a VAE`() {
+        val file = writeGguf(
+            architecture = "sd3",
+            tensorNames = listOf(
+                "model.diffusion_model.joint_blocks.0.weight",
+                "text_encoders.clip_l.transformer.weight",
+                "first_stage_model.decoder.conv_in.weight",
+            ),
+        )
+
+        val summary = GgufFileSummary.read(file)!!
+
+        assertEquals(
+            setOf(GgufComponent.DIFFUSION, GgufComponent.TEXT_ENCODER, GgufComponent.VAE),
+            summary.components,
+        )
+        assertTrue(summary.isAllInOne)
+    }
+
+    @Test
+    fun `skips metadata value types it does not read`() {
+        val file = writeGguf(
+            architecture = "flux",
+            tensorNames = listOf("model.diffusion_model.double_blocks.0.weight"),
+            extraMetadata = listOf(
+                "some.uint32" to KvValue.UInt32(7),
+                "some.float32" to KvValue.Float32(1.5f),
+                "some.bool" to KvValue.Bool(true),
+                "some.uint64" to KvValue.UInt64(1L shl 40),
+                "some.strings" to KvValue.StringArray(listOf("alpha", "beta")),
+                "some.ints" to KvValue.UInt32Array(listOf(1, 2, 3)),
+            ),
+        )
+
+        val summary = GgufFileSummary.read(file)!!
+
+        assertEquals("flux", summary.architecture)
+        assertEquals(setOf(GgufComponent.DIFFUSION), summary.components)
+    }
+
+    @Test
+    fun `returns null for a non-gguf file`() {
+        val file = temporaryFolder.newFile("not-a-model.gguf").apply { writeText("definitely not gguf") }
+
+        assertNull(GgufFileSummary.read(file))
+    }
+
+    @Test
+    fun `returns null for a truncated header rather than throwing`() {
+        val complete = writeGguf(architecture = "sd3", tensorNames = listOf("model.diffusion_model.a.weight"))
+        val truncated = temporaryFolder.newFile("truncated.gguf")
+        truncated.writeBytes(complete.readBytes().copyOf(20))
+
+        assertNull(GgufFileSummary.read(truncated))
+    }
+
+    @Test
+    fun `reports no components for an unrecognised tensor layout`() {
+        val file = writeGguf(architecture = "unknown", tensorNames = listOf("mystery.weight"))
+
+        val summary = GgufFileSummary.read(file)!!
+
+        assertTrue(summary.components.isEmpty())
+        assertFalse(summary.isAllInOne)
+    }
+
+    private sealed interface KvValue {
+        data class Str(val value: String) : KvValue
+
+        data class UInt32(val value: Int) : KvValue
+
+        data class Float32(val value: Float) : KvValue
+
+        data class Bool(val value: Boolean) : KvValue
+
+        data class UInt64(val value: Long) : KvValue
+
+        data class StringArray(val values: List<String>) : KvValue
+
+        data class UInt32Array(val values: List<Int>) : KvValue
+    }
+
+    /** Builds a minimal but spec-shaped GGUF v3 header; the weight payload is irrelevant here. */
+    private fun writeGguf(
+        architecture: String?,
+        tensorNames: List<String>,
+        extraMetadata: List<Pair<String, KvValue>> = emptyList(),
+    ): File {
+        val out = ByteArrayOutputStream()
+        out.write(byteArrayOf('G'.code.toByte(), 'G'.code.toByte(), 'U'.code.toByte(), 'F'.code.toByte()))
+        out.writeUInt32(3)
+        out.writeUInt64(tensorNames.size.toLong())
+
+        val metadata = buildList {
+            architecture?.let { add("general.architecture" to KvValue.Str(it)) }
+            addAll(extraMetadata)
+        }
+        out.writeUInt64(metadata.size.toLong())
+        metadata.forEach { (key, value) ->
+            out.writeGgufString(key)
+            out.writeKv(value)
+        }
+
+        tensorNames.forEach { name ->
+            out.writeGgufString(name)
+            out.writeUInt32(2) // dimension count
+            out.writeUInt64(16)
+            out.writeUInt64(16)
+            out.writeUInt32(0) // ggml type F32
+            out.writeUInt64(0) // offset
+        }
+        out.write(ByteArray(32)) // stand-in for the weight payload
+
+        return temporaryFolder.newFile("model-${fileCounter++}.gguf").apply {
+            writeBytes(out.toByteArray())
+        }
+    }
+
+    private fun ByteArrayOutputStream.writeKv(value: KvValue) {
+        when (value) {
+            is KvValue.Str -> {
+                writeUInt32(8)
+                writeGgufString(value.value)
+            }
+            is KvValue.UInt32 -> {
+                writeUInt32(4)
+                writeUInt32(value.value.toLong())
+            }
+            is KvValue.Float32 -> {
+                writeUInt32(6)
+                writeUInt32(java.lang.Float.floatToIntBits(value.value).toLong())
+            }
+            is KvValue.Bool -> {
+                writeUInt32(7)
+                write(if (value.value) 1 else 0)
+            }
+            is KvValue.UInt64 -> {
+                writeUInt32(10)
+                writeUInt64(value.value)
+            }
+            is KvValue.StringArray -> {
+                writeUInt32(9)
+                writeUInt32(8)
+                writeUInt64(value.values.size.toLong())
+                value.values.forEach { writeGgufString(it) }
+            }
+            is KvValue.UInt32Array -> {
+                writeUInt32(9)
+                writeUInt32(4)
+                writeUInt64(value.values.size.toLong())
+                value.values.forEach { writeUInt32(it.toLong()) }
+            }
+        }
+    }
+
+    private fun ByteArrayOutputStream.writeGgufString(value: String) {
+        val bytes = value.toByteArray(Charsets.UTF_8)
+        writeUInt64(bytes.size.toLong())
+        write(bytes)
+    }
+
+    private fun ByteArrayOutputStream.writeUInt32(value: Long) {
+        for (index in 0 until 4) {
+            write(((value shr (index * 8)) and 0xFF).toInt())
+        }
+    }
+
+    private fun ByteArrayOutputStream.writeUInt64(value: Long) {
+        for (index in 0 until 8) {
+            write(((value shr (index * 8)) and 0xFF).toInt())
+        }
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/model/GgufFileSummaryTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/model/GgufFileSummaryTest.kt
@@ -1,48 +1,51 @@
 package io.aatricks.llmedge.model
 
+import io.aatricks.llmedge.core.InvalidModelFileException
+import io.aatricks.llmedge.runtime.GGUFReader
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.io.ByteArrayOutputStream
 import java.io.File
 
+/**
+ * Classification is asserted against the tensor-name prefixes the native reader returns. The
+ * DEPTH CONTRACT those keys depend on — exactly one segment — lives in
+ * `gguf_reader_internal.cpp`; the fixtures below use real checkpoint layouts so a change on
+ * either side shows up here.
+ */
 class GgufFileSummaryTest {
     @get:Rule
     val temporaryFolder = TemporaryFolder()
 
-    private var fileCounter = 0
+    private var counter = 0
+
+    @After
+    fun tearDown() {
+        GGUFReader.resetNativeBridgeForTests()
+    }
 
     @Test
-    fun `reads architecture and classifies a diffusion-only checkpoint`() {
-        val file = writeGguf(
-            architecture = "sd3",
-            tensorNames = listOf("joint_blocks.0.x_block.attn.qkv.weight", "model.diffusion_model.pos_embed"),
-        )
+    fun `city96 style DiT-only checkpoint is not an all-in-one`() {
+        stubReader("sd3", setOf("joint_blocks", "pos_embed", "x_embedder", "final_layer"))
 
-        val summary = GgufFileSummary.read(file)!!
+        val summary = GgufFileSummary.read(ggufFile())!!
 
         assertEquals("sd3", summary.architecture)
-        assertEquals(2L, summary.tensorCount)
         assertEquals(setOf(GgufComponent.DIFFUSION), summary.components)
         assertFalse(summary.isAllInOne)
     }
 
     @Test
-    fun `flags a bundle carrying text encoders and a VAE`() {
-        val file = writeGguf(
-            architecture = "sd3",
-            tensorNames = listOf(
-                "model.diffusion_model.joint_blocks.0.weight",
-                "text_encoders.clip_l.transformer.weight",
-                "first_stage_model.decoder.conv_in.weight",
-            ),
-        )
+    fun `second-state style bundle is flagged as all-in-one`() {
+        stubReader("sd3", setOf("model", "text_encoders", "first_stage_model"))
 
-        val summary = GgufFileSummary.read(file)!!
+        val summary = GgufFileSummary.read(ggufFile())!!
 
         assertEquals(
             setOf(GgufComponent.DIFFUSION, GgufComponent.TEXT_ENCODER, GgufComponent.VAE),
@@ -52,156 +55,103 @@ class GgufFileSummaryTest {
     }
 
     @Test
-    fun `skips metadata value types it does not read`() {
-        val file = writeGguf(
-            architecture = "flux",
-            tensorNames = listOf("model.diffusion_model.double_blocks.0.weight"),
-            extraMetadata = listOf(
-                "some.uint32" to KvValue.UInt32(7),
-                "some.float32" to KvValue.Float32(1.5f),
-                "some.bool" to KvValue.Bool(true),
-                "some.uint64" to KvValue.UInt64(1L shl 40),
-                "some.strings" to KvValue.StringArray(listOf("alpha", "beta")),
-                "some.ints" to KvValue.UInt32Array(listOf(1, 2, 3)),
-            ),
-        )
+    fun `a text-encoder-only checkpoint claims no diffusion components`() {
+        stubReader("t5encoder", setOf("enc", "token_embd"))
 
-        val summary = GgufFileSummary.read(file)!!
-
-        assertEquals("flux", summary.architecture)
-        assertEquals(setOf(GgufComponent.DIFFUSION), summary.components)
-    }
-
-    @Test
-    fun `returns null for a non-gguf file`() {
-        val file = temporaryFolder.newFile("not-a-model.gguf").apply { writeText("definitely not gguf") }
-
-        assertNull(GgufFileSummary.read(file))
-    }
-
-    @Test
-    fun `returns null for a truncated header rather than throwing`() {
-        val complete = writeGguf(architecture = "sd3", tensorNames = listOf("model.diffusion_model.a.weight"))
-        val truncated = temporaryFolder.newFile("truncated.gguf")
-        truncated.writeBytes(complete.readBytes().copyOf(20))
-
-        assertNull(GgufFileSummary.read(truncated))
-    }
-
-    @Test
-    fun `reports no components for an unrecognised tensor layout`() {
-        val file = writeGguf(architecture = "unknown", tensorNames = listOf("mystery.weight"))
-
-        val summary = GgufFileSummary.read(file)!!
+        val summary = GgufFileSummary.read(ggufFile())!!
 
         assertTrue(summary.components.isEmpty())
         assertFalse(summary.isAllInOne)
     }
 
-    private sealed interface KvValue {
-        data class Str(val value: String) : KvValue
+    @Test
+    fun `a reader that yields no tensors summarises to null`() {
+        stubReader("sd3", emptySet())
 
-        data class UInt32(val value: Int) : KvValue
-
-        data class Float32(val value: Float) : KvValue
-
-        data class Bool(val value: Boolean) : KvValue
-
-        data class UInt64(val value: Long) : KvValue
-
-        data class StringArray(val values: List<String>) : KvValue
-
-        data class UInt32Array(val values: List<Int>) : KvValue
+        assertNull(GgufFileSummary.read(ggufFile()))
     }
 
-    /** Builds a minimal but spec-shaped GGUF v3 header; the weight payload is irrelevant here. */
-    private fun writeGguf(
-        architecture: String?,
-        tensorNames: List<String>,
-        extraMetadata: List<Pair<String, KvValue>> = emptyList(),
-    ): File {
-        val out = ByteArrayOutputStream()
-        out.write(byteArrayOf('G'.code.toByte(), 'G'.code.toByte(), 'U'.code.toByte(), 'F'.code.toByte()))
-        out.writeUInt32(3)
-        out.writeUInt64(tensorNames.size.toLong())
+    @Test
+    fun `a failing reader summarises to null rather than throwing`() {
+        GGUFReader.overrideNativeBridgeForTests {
+            object : GGUFReader.NativeBridge {
+                override fun getGGUFContextNativeHandle(modelPath: String): Long =
+                    throw UnsatisfiedLinkError("libggufreader.so unavailable")
 
-        val metadata = buildList {
-            architecture?.let { add("general.architecture" to KvValue.Str(it)) }
-            addAll(extraMetadata)
-        }
-        out.writeUInt64(metadata.size.toLong())
-        metadata.forEach { (key, value) ->
-            out.writeGgufString(key)
-            out.writeKv(value)
+                override fun getContextSize(nativeHandle: Long): Long = -1L
+
+                override fun getChatTemplate(nativeHandle: Long): String = ""
+
+                override fun getArchitecture(nativeHandle: Long): String = ""
+
+                override fun getParameterCount(nativeHandle: Long): String = ""
+
+                override fun getModelName(nativeHandle: Long): String = ""
+
+                override fun releaseGGUFContext(nativeHandle: Long) = Unit
+            }
         }
 
-        tensorNames.forEach { name ->
-            out.writeGgufString(name)
-            out.writeUInt32(2) // dimension count
-            out.writeUInt64(16)
-            out.writeUInt64(16)
-            out.writeUInt32(0) // ggml type F32
-            out.writeUInt64(0) // offset
-        }
-        out.write(ByteArray(32)) // stand-in for the weight payload
+        assertNull(GgufFileSummary.read(ggufFile()))
+    }
 
-        return temporaryFolder.newFile("model-${fileCounter++}.gguf").apply {
-            writeBytes(out.toByteArray())
+    @Test
+    fun `requireDiffusionOnlyGguf rejects a bundle and names what it carries`() {
+        stubReader("sd3", setOf("model", "text_encoders", "first_stage_model"))
+
+        try {
+            ModelFileValidator.requireDiffusionOnlyGguf(ggufFile(), "sd3-medium-Q4_0.gguf")
+            fail("Expected an all-in-one checkpoint to be rejected")
+        } catch (expected: InvalidModelFileException) {
+            val message = expected.message.orEmpty()
+            assertTrue(message, message.contains("all-in-one"))
+            assertTrue(message, message.contains("text encoders and a VAE"))
+            assertTrue(message, message.contains("sd3-medium-Q4_0.gguf"))
         }
     }
 
-    private fun ByteArrayOutputStream.writeKv(value: KvValue) {
-        when (value) {
-            is KvValue.Str -> {
-                writeUInt32(8)
-                writeGgufString(value.value)
-            }
-            is KvValue.UInt32 -> {
-                writeUInt32(4)
-                writeUInt32(value.value.toLong())
-            }
-            is KvValue.Float32 -> {
-                writeUInt32(6)
-                writeUInt32(java.lang.Float.floatToIntBits(value.value).toLong())
-            }
-            is KvValue.Bool -> {
-                writeUInt32(7)
-                write(if (value.value) 1 else 0)
-            }
-            is KvValue.UInt64 -> {
-                writeUInt32(10)
-                writeUInt64(value.value)
-            }
-            is KvValue.StringArray -> {
-                writeUInt32(9)
-                writeUInt32(8)
-                writeUInt64(value.values.size.toLong())
-                value.values.forEach { writeGgufString(it) }
-            }
-            is KvValue.UInt32Array -> {
-                writeUInt32(9)
-                writeUInt32(4)
-                writeUInt64(value.values.size.toLong())
-                value.values.forEach { writeUInt32(it.toLong()) }
+    @Test
+    fun `requireDiffusionOnlyGguf accepts a DiT-only checkpoint`() {
+        stubReader("sd3", setOf("joint_blocks", "pos_embed"))
+        val file = ggufFile()
+
+        assertEquals(file, ModelFileValidator.requireDiffusionOnlyGguf(file))
+    }
+
+    @Test
+    fun `requireDiffusionOnlyGguf accepts a file it cannot classify`() {
+        stubReader("unknown", emptySet())
+        val file = ggufFile()
+
+        assertEquals(file, ModelFileValidator.requireDiffusionOnlyGguf(file))
+    }
+
+    private fun stubReader(architecture: String, prefixes: Set<String>) {
+        GGUFReader.overrideNativeBridgeForTests {
+            object : GGUFReader.NativeBridge {
+                override fun getGGUFContextNativeHandle(modelPath: String): Long = 1L
+
+                override fun getContextSize(nativeHandle: Long): Long = -1L
+
+                override fun getChatTemplate(nativeHandle: Long): String = ""
+
+                override fun getArchitecture(nativeHandle: Long): String = architecture
+
+                override fun getParameterCount(nativeHandle: Long): String = ""
+
+                override fun getModelName(nativeHandle: Long): String = ""
+
+                override fun getTensorNamePrefixes(nativeHandle: Long): String =
+                    prefixes.joinToString("\n")
+
+                override fun releaseGGUFContext(nativeHandle: Long) = Unit
             }
         }
     }
 
-    private fun ByteArrayOutputStream.writeGgufString(value: String) {
-        val bytes = value.toByteArray(Charsets.UTF_8)
-        writeUInt64(bytes.size.toLong())
-        write(bytes)
-    }
-
-    private fun ByteArrayOutputStream.writeUInt32(value: Long) {
-        for (index in 0 until 4) {
-            write(((value shr (index * 8)) and 0xFF).toInt())
+    /** `GGUFReader.load` validates the GGUF magic before ever reaching the bridge. */
+    private fun ggufFile(): File =
+        temporaryFolder.newFile("model-${counter++}.gguf").apply {
+            writeBytes("GGUF".toByteArray(Charsets.US_ASCII) + byteArrayOf(3, 0, 0, 0))
         }
-    }
-
-    private fun ByteArrayOutputStream.writeUInt64(value: Long) {
-        for (index in 0 until 8) {
-            write(((value shr (index * 8)) and 0xFF).toInt())
-        }
-    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/model/GgufTensorPrefixNativeTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/model/GgufTensorPrefixNativeTest.kt
@@ -1,0 +1,71 @@
+package io.aatricks.llmedge.model
+
+import io.aatricks.llmedge.runtime.GGUFReader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.BeforeClass
+import org.junit.Test
+import java.io.File
+
+/**
+ * Exercises the real `llmedge_gguf_get_tensor_name_prefixes` against ggml's own GGUF parser,
+ * which validates tensor offsets and data size — the DEPTH CONTRACT the Kotlin prefix keys depend
+ * on cannot be verified by a stubbed bridge, because a stub returns whatever the test imagined.
+ *
+ * Opt-in: needs a desktop JNI build (`scripts/build_native_linux.sh smollm`) and fixtures from
+ * `scripts/testdata/make_gguf.py`. Run with:
+ *
+ * ```
+ * LLMEDGE_TEST_NATIVE_LIB=<path>/libsmollm.so LLMEDGE_TEST_GGUF_DIR=<dir> \
+ *   ./gradlew :llmedge:testDebugUnitTest --tests "*GgufTensorPrefixNativeTest"
+ * ```
+ */
+class GgufTensorPrefixNativeTest {
+    companion object {
+        private val nativeLib: String? = System.getenv("LLMEDGE_TEST_NATIVE_LIB")
+        private val ggufDir: String? = System.getenv("LLMEDGE_TEST_GGUF_DIR")
+
+        @JvmStatic
+        @BeforeClass
+        fun loadNativeLibrary() {
+            val lib = nativeLib ?: return
+            System.setProperty("llmedge.disableNativeLoad", "false")
+            System.load(File(lib).absolutePath)
+        }
+    }
+
+    @Test
+    fun `an all-in-one bundle yields depth-1 prefixes and classifies as all-in-one`() {
+        val summary = summarize("bundle.gguf")
+
+        // Depth contract: first segment only. "model.diffusion_model.joint_blocks.0.weight"
+        // must arrive as "model", never "model.diffusion_model".
+        assertEquals(setOf("model", "text_encoders", "first_stage_model"), summary.tensorPrefixes)
+        assertEquals("sd3", summary.architecture)
+        assertTrue(summary.isAllInOne)
+        assertEquals(
+            setOf(GgufComponent.DIFFUSION, GgufComponent.TEXT_ENCODER, GgufComponent.VAE),
+            summary.components,
+        )
+    }
+
+    @Test
+    fun `a DiT-only checkpoint is not an all-in-one`() {
+        val summary = summarize("dit.gguf")
+
+        // "pos_embed" has no separator, so it survives whole — the other half of the contract.
+        assertEquals(setOf("joint_blocks", "pos_embed", "x_embedder"), summary.tensorPrefixes)
+        assertEquals(setOf(GgufComponent.DIFFUSION), summary.components)
+        assertFalse(summary.isAllInOne)
+    }
+
+    private fun summarize(fixture: String): GgufFileSummary {
+        assumeTrue("Set LLMEDGE_TEST_NATIVE_LIB and LLMEDGE_TEST_GGUF_DIR", nativeLib != null && ggufDir != null)
+        val file = File(ggufDir, fixture)
+        assumeTrue("Missing fixture ${file.absolutePath}", file.isFile)
+        GGUFReader.resetNativeBridgeForTests()
+        return requireNotNull(GgufFileSummary.read(file)) { "Native reader returned no summary for $fixture" }
+    }
+}

--- a/scripts/testdata/make_gguf.py
+++ b/scripts/testdata/make_gguf.py
@@ -1,0 +1,74 @@
+"""Writes a minimal but spec-valid GGUF v3 file with real tensor data.
+
+Used to verify llmedge_gguf_get_tensor_name_prefixes against the actual ggml parser,
+which validates tensor offsets and data size — a hand-written header alone is rejected.
+"""
+import struct
+import sys
+
+ALIGNMENT = 32
+GGML_TYPE_F32 = 0
+
+
+def u32(v):
+    return struct.pack("<I", v)
+
+
+def u64(v):
+    return struct.pack("<Q", v)
+
+
+def gstr(s):
+    b = s.encode("utf-8")
+    return u64(len(b)) + b
+
+
+def kv_str(key, value):
+    return gstr(key) + u32(8) + gstr(value)
+
+
+def kv_u32(key, value):
+    return gstr(key) + u32(4) + u32(value)
+
+
+def build(path, architecture, tensor_names):
+    kvs = kv_str("general.architecture", architecture) + kv_u32("general.alignment", ALIGNMENT)
+    kv_count = 2
+
+    elements = 4
+    tensor_bytes = elements * 4  # F32
+    padded = (tensor_bytes + ALIGNMENT - 1) // ALIGNMENT * ALIGNMENT
+
+    infos = b""
+    for index, name in enumerate(tensor_names):
+        infos += gstr(name)
+        infos += u32(1)                 # n_dims
+        infos += u64(elements)          # dims[0]
+        infos += u32(GGML_TYPE_F32)     # type
+        infos += u64(index * padded)    # offset into the tensor-data section
+
+    header = b"GGUF" + u32(3) + u64(len(tensor_names)) + u64(kv_count) + kvs + infos
+    pad = (-len(header)) % ALIGNMENT
+    data = b"".join(struct.pack("<f", float(i)) * elements + b"\x00" * (padded - tensor_bytes)
+                    for i in range(len(tensor_names)))
+
+    with open(path, "wb") as f:
+        f.write(header + b"\x00" * pad + data)
+    print(f"wrote {path}: {len(tensor_names)} tensors, arch={architecture}")
+
+
+if __name__ == "__main__":
+    out = sys.argv[1]
+    kind = sys.argv[2]
+    if kind == "bundle":
+        build(out, "sd3", [
+            "model.diffusion_model.joint_blocks.0.weight",
+            "text_encoders.clip_l.transformer.weight",
+            "first_stage_model.decoder.conv_in.weight",
+        ])
+    else:
+        build(out, "sd3", [
+            "joint_blocks.0.x_block.attn.qkv.weight",
+            "pos_embed",
+            "x_embedder.proj.weight",
+        ])


### PR DESCRIPTION
Prompted by llmedge-examples#37: a diffusion worker died 3m26s into `phase=GENERATING` on a reporter with no PC, and the post-mortem we produced was `[phase=GENERATING; crash]` — no cause, and no way to get one.

## What the log could and could not tell us

`exitReason=4` is `ApplicationExitInfo.REASON_CRASH`, not `REASON_CRASH_NATIVE` (5) — a Java throwable killed the worker, so `buildCrashSummary` skipped the tombstone path. The uncaught-exception breadcrumb was also absent, so the summary fell through to `exitInfo.description`, the bare word `crash`.

Everything else needed to localise the failure — which pass acquired which backend, which runtime was invalidated before which phase — is logged through `AndroidLogAdapter`, which reaches logcat only. A reporter without adb cannot retrieve it, and the shared app log never contained it.

Ruled out while investigating, so no fix here: the classifier looks up the right file (`pid = worker.pid` is a live binder call, not a cached value); the progress-callback binder crossing is already wrapped in `runCatching`; and generation throwables are already caught as `Throwable` and reported over binder. The throwable that killed the worker escaped from another thread, and localising it needs the trail below.

## Worker diagnostics

- `AndroidLogAdapter` gains an optional sink. A failing sink can never break the call it observes.
- `WorkerDiagnosticsLog` mirrors the `:llmedge_sd` process's own log lines to a file in the shared data dir, flushed per line — a buffered line is a line lost to the crash it was meant to explain. Bounded to 400 lines / 256 KB, with a stale-file sweep on worker start.
- `WorkerFailureClassifier` appends that trail to the crash summary, always last and always attempted, then consumes it. It is read from the host after `binderDied`, which runs synchronously in the death notification, so a replacement worker cannot reuse the pid before the evidence is read.

Since the summary is already carried in `WorkerCrashedException`, which the example app logs to its shareable file, the trail reaches a bug report with no new user step.

Known limit: the sink installs at `Service.onCreate`, so anything logged during worker process startup before the service exists is not captured.

## Telling a denoiser from an all-in-one bundle

`GGUFReader` gains `getTensorNamePrefixes()`, backed by a new `llmedge_gguf_get_tensor_name_prefixes` that walks `gguf_get_tensor_name` and returns the deduplicated **first** segment of each name, capped at 64. That depth is a contract — callers match against depth-1 keys like `text_encoders` and `joint_blocks`, and returning deeper prefixes would silently stop detecting them — so it is stated in the native source, in the Kotlin accessor, and in the test that pins it.

`GgufFileSummary` classifies those prefixes into `DIFFUSION` / `TEXT_ENCODER` / `VAE`, and `ModelFileValidator.requireDiffusionOnlyGguf` rejects a bundle for a caller that loads encoders separately. A file that cannot be classified always passes: this exists to explain a known mistake, not to gate models.

This deliberately extends the existing native reader rather than adding a second GGUF parser. `GgufModelMetadataSupport` is not reused because it caches by absolute path, and the import path inspects a `.partial` file that is then renamed.

## Also

`Sd3Medium` KDoc claimed a "T5XXL FP8 … ~4.89 GB" encoder and a ~8.0 GB total while the code ships `t5-v1_1-xxl-encoder-Q3_K_S.gguf` (~2.1 GB, ~5.2 GB total). That stale doc is what prompted the reporter's "wrong t5xxl model" theory — same architecture and weights, lower precision.

## Verification

`:llmedge:testDebugUnitTest` — 655 tests, 4 failures, all pre-existing `libsdcpp.so` load failures on a host without the desktop native build (a clean-tree baseline fails 17; these 4 are a strict subset).

`GgufFileSummaryTest` 8/8 against the reader's test bridge, using real checkpoint layouts (city96 DiT-only, second-state bundle, a T5-encoder-only file) plus the degrade-to-null paths. `WorkerFailureClassifierTest` 4/4, including a case shaped exactly like the report — REASON_CRASH with no tombstone and no breadcrumb — asserting the trail is surfaced and consumed.

Native: `libggufreader.so` rebuilt for arm64-v8a and x86_64, with `getTensorNamePrefixesBytes` confirmed present in both and in the packaged APK.

Native prefix walk verified end-to-end by `GgufTensorPrefixNativeTest` against ggml's own GGUF parser, using spec-valid fixtures from `scripts/testdata/make_gguf.py` — the depth contract cannot be proven by a stubbed bridge, which returns whatever the test imagined. Opt-in via `LLMEDGE_TEST_NATIVE_LIB` / `LLMEDGE_TEST_GGUF_DIR`, skipped otherwise. Both toolchains that compile `GGUFReader.cpp` were built and export the new symbol: the Android NDK (`libggufreader.so`, arm64-v8a + x86_64) and the desktop JNI build (`libsmollm.so`).