### PR TITLE
Skip the examples SDK revision pin when validating a local checkout

### DIFF
--- a/scripts/validate_examples.sh
+++ b/scripts/validate_examples.sh
@@ -15,6 +15,11 @@ fi
 read -r -a example_tasks <<< "$EXAMPLE_TASKS"
 
 echo "Building llmedge-examples against the local :llmedge composite build (${example_tasks[*]})..."
+# This script exists to compile the examples against the SDK commit under review, so the
+# examples' release pin (an exact, clean SDK revision) cannot apply here — and cannot be
+# satisfied at all once a submodule bump moves HEAD past the pinned commit. Release builds
+# performed any other way still enforce it.
+export LLMEDGE_SKIP_SDK_REVISION_CHECK=true
 (cd "$EXAMPLES_DIR" && ./gradlew --no-daemon "${example_tasks[@]}") || {
 	echo "ERROR: llmedge-examples failed to compile against the local :llmedge checkout." >&2
 	echo "This likely means a public API change in :llmedge broke the examples." >&2


### PR DESCRIPTION
Greens main, which has been red since #63 merged (run 30314737688). Pairs with llmedge-examples#39, which must merge first.

## Why CI broke

`:app:verifySdkRevision` in the examples requires this repo's checked-out `HEAD` to equal the SHA pinned in `llmedge-examples/llmedge-sdk-revision.txt`. `validate_examples.sh` runs `:app:assembleRelease`, which reaches that check through `preReleaseBuild`.

The requirement is unsatisfiable here, and not merely stale:

```
main HEAD:             eea0a549b1d1a226aca818f906633c265e408fe1
submodule ptr at main: 618a7924ac7daf228577896ce96736bedee40659
pin CI actually read:  41469740fdfb8bb8d7dd63ec2ae961256ebe7e27
```

The pin can only be changed by an examples commit, which this repo must then point at — and that pointer bump moves `HEAD` again, producing a fresh mismatch. Updating the pin does not converge.

The check had never run in this repo's CI before: main's submodule pointer predated the pin file, and the bump in #63 activated it. Nothing about the SDK sources caused this.

## What changed

`scripts/validate_examples.sh` exports `LLMEDGE_SKIP_SDK_REVISION_CHECK=true`. The script exists to compile the examples against the SDK commit under review, so the examples' release pin — an exact, clean SDK revision — cannot apply, and the clean-tree half is equally wrong for a mid-PR working tree.

The alternative was dropping `:app:assembleRelease` from `LLMEDGE_EXAMPLES_GRADLE_TASKS`, which would lose the R8/minification coverage that #62 added the consumer keep rules for. Skipping a check that cannot pass is preferable to dropping one that can.

The examples-side skip logs loudly and is honoured only via this variable, so a release built any other way still enforces both checks.

## Verification

`bash scripts/validate_examples.sh` with CI's exact environment against a dirty, unpinned tree exits 0, with the skip line present. Running `:app:verifySdkRevision` without the variable still fails with the original message and a non-zero exit, so the release gate is intact.

Submodule pointer moves to llmedge-examples `9badb29`, which also carries `618a792` — merged into neither examples main nor this repo's pointer history by #38, and required for the examples to compile against current main after `GgufFileSummary.tensorCount` was removed.