### PR TITLE
Pin classification against the published SD3 checkpoints

### DIFF
--- a/llmedge/src/androidTest/java/io/aatricks/llmedge/model/GgufClassificationDeviceTest.kt
+++ b/llmedge/src/androidTest/java/io/aatricks/llmedge/model/GgufClassificationDeviceTest.kt
@@ -1,0 +1,72 @@
+package io.aatricks.llmedge.model
+
+import androidx.test.platform.app.InstrumentationRegistry
+import io.aatricks.llmedge.core.InvalidModelFileException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Runs the all-in-one classification on device, through the packaged `libggufreader.so` — the
+ * build that actually ships, rather than the desktop JNI library the host-side test uses.
+ *
+ * Fixtures are header-only range reads of the published SD3 Medium checkpoints; the classifier
+ * never touches weights, so 8 MB is enough. Push them before running:
+ *
+ * ```
+ * curl -L -r 0-8388607 -o bundle.gguf \
+ *   https://huggingface.co/second-state/stable-diffusion-3-medium-GGUF/resolve/main/sd3-medium-Q4_0.gguf
+ * curl -L -r 0-8388607 -o dit.gguf \
+ *   https://huggingface.co/city96/stable-diffusion-3-medium-gguf/resolve/main/sd3_medium-Q4_0.gguf
+ * adb push bundle.gguf dit.gguf /sdcard/Android/data/io.aatricks.llmedge.test/files/
+ * ```
+ */
+class GgufClassificationDeviceTest {
+    private val fixtures: File?
+        get() =
+            InstrumentationRegistry.getInstrumentation()
+                .targetContext
+                .getExternalFilesDir(null)
+
+    @Test
+    fun publishedAllInOneCheckpointIsRejectedForADiffusionOnlySlot() {
+        val file = fixture("bundle.gguf")
+
+        val summary = requireNotNull(GgufFileSummary.read(file)) { "native reader returned no summary" }
+        android.util.Log.i(TAG, "bundle prefixes=${summary.tensorPrefixes.sorted()} components=${summary.components}")
+        assertTrue(summary.isAllInOne)
+
+        try {
+            ModelFileValidator.requireDiffusionOnlyGguf(file, "sd3-medium-Q4_0.gguf")
+            fail("Expected the bundle to be rejected")
+        } catch (expected: InvalidModelFileException) {
+            android.util.Log.i(TAG, "rejection message: ${expected.message}")
+            assertTrue(expected.message.orEmpty().contains("all-in-one"))
+        }
+    }
+
+    @Test
+    fun publishedDiffusionOnlyCheckpointIsAccepted() {
+        val file = fixture("dit.gguf")
+
+        val summary = requireNotNull(GgufFileSummary.read(file)) { "native reader returned no summary" }
+        android.util.Log.i(TAG, "dit prefixes=${summary.tensorPrefixes.sorted()} components=${summary.components}")
+        assertFalse(summary.isAllInOne)
+        assertTrue(GgufComponent.DIFFUSION in summary.components)
+        assertEquals(file, ModelFileValidator.requireDiffusionOnlyGguf(file))
+    }
+
+    private fun fixture(name: String): File {
+        val file = File(fixtures, name)
+        assumeTrue("Missing fixture ${file.absolutePath}; see the KDoc for how to push it", file.isFile)
+        return file
+    }
+
+    private companion object {
+        const val TAG = "GgufClassificationDeviceTest"
+    }
+}

--- a/llmedge/src/test/java/io/aatricks/llmedge/model/GgufTensorPrefixNativeTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/model/GgufTensorPrefixNativeTest.kt
@@ -61,6 +61,35 @@ class GgufTensorPrefixNativeTest {
         assertFalse(summary.isAllInOne)
     }
 
+    /**
+     * The published SD3 Medium checkpoints, which is what an importer actually picks up. Only the
+     * header is needed, so the fixtures are HTTP range reads rather than multi-GB downloads —
+     * `gguf_init_from_file` with `no_alloc` accepts a file truncated after the tensor infos:
+     *
+     * ```
+     * curl -L -r 0-8388607 -o real-sd3-dit.gguf \
+     *   https://huggingface.co/city96/stable-diffusion-3-medium-gguf/resolve/main/sd3_medium-Q4_0.gguf
+     * curl -L -r 0-8388607 -o real-sd3-bundle.gguf \
+     *   https://huggingface.co/second-state/stable-diffusion-3-medium-GGUF/resolve/main/sd3-medium-Q4_0.gguf
+     * ```
+     */
+    @Test
+    fun `the published city96 SD3 DiT is classified as diffusion-only`() {
+        val summary = summarize("real-sd3-dit.gguf")
+
+        println("city96 sd3_medium-Q4_0 prefixes: ${summary.tensorPrefixes.sorted()}")
+        assertTrue(summary.components.toString(), GgufComponent.DIFFUSION in summary.components)
+        assertFalse("must not be rejected for a diffusion-only preset", summary.isAllInOne)
+    }
+
+    @Test
+    fun `the published second-state SD3 bundle is classified as all-in-one`() {
+        val summary = summarize("real-sd3-bundle.gguf")
+
+        println("second-state sd3-medium-Q4_0 prefixes: ${summary.tensorPrefixes.sorted()}")
+        assertTrue("must be rejected for a diffusion-only preset", summary.isAllInOne)
+    }
+
     private fun summarize(fixture: String): GgufFileSummary {
         assumeTrue("Set LLMEDGE_TEST_NATIVE_LIB and LLMEDGE_TEST_GGUF_DIR", nativeLib != null && ggufDir != null)
         val file = File(ggufDir, fixture)


### PR DESCRIPTION
Extends `GgufTensorPrefixNativeTest` to the two SD3 Medium checkpoints an importer actually picks up, closing the last assumption behind llmedge-examples#37's import check: that the depth-1 prefix keys match real-world SD3 tensor naming. Until now that was only exercised against synthetic fixtures, which return whatever the fixture author imagined.

Observed prefixes, from the real reader:

| Checkpoint | First segments | `isAllInOne` |
| --- | --- | --- |
| `city96/stable-diffusion-3-medium-gguf` (DiT-only) | `context_embedder, final_layer, joint_blocks, pos_embed, t_embedder, x_embedder, y_embedder` | false — accepted |
| `second-state/stable-diffusion-3-medium-GGUF` (all-in-one) | `first_stage_model, model, text_encoders` | true — rejected |

The bundle matches the `sd3-` filename in the issue's log and is the obvious file to grab for that preset, so it is the leading candidate for what was imported. It is now refused at import with a message naming the problem, instead of surfacing as a worker crash minutes into `phase=GENERATING`.

Fixtures are 8 MB HTTP range reads rather than multi-GB downloads: `gguf_init_from_file` with `no_alloc` accepts a file truncated after the tensor infos, verified before relying on it. The curl commands are in the test's KDoc, and the tests skip when the fixtures are absent, like the rest of the class.

Assertions deliberately target the classification rather than exact prefix sets, so a benign upstream re-quantisation does not turn this red.