### PR TITLE
Stop the hard wall from killing a progressing generation

### DIFF
--- a/llmedge/src/main/java/io/aatricks/llmedge/core/LLMEdgeException.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/core/LLMEdgeException.kt
@@ -87,8 +87,21 @@ class GenerationHangException(
     val backend: String?,
     val phase: String,
     val stallMs: Long,
+    /** True when the total-runtime wall expired rather than the worker going idle. */
+    val hardWall: Boolean = false,
 ) : WorkerProcessException(
-    "Generation hung in phase $phase for ${stallMs}ms with an idle worker" +
+    (
+        if (hardWall) {
+            "Generation exceeded the total time limit (${stallMs}ms elapsed, phase $phase)"
+        } else {
+            "Generation hung in phase $phase for ${stallMs}ms with an idle worker"
+        }
+    ) +
         (backend?.let { " (backend=$it)" } ?: "") +
-        "; the worker process was killed. This usually indicates a broken GPU driver.",
+        "; the worker process was killed." +
+        if (hardWall) {
+            " The device is likely too slow for this model/resolution; try fewer steps or a smaller size."
+        } else {
+            " This usually indicates a broken GPU driver."
+        },
 )

--- a/llmedge/src/main/java/io/aatricks/llmedge/core/LLMEdgeException.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/core/LLMEdgeException.kt
@@ -87,12 +87,12 @@ class GenerationHangException(
     val backend: String?,
     val phase: String,
     val stallMs: Long,
-    /** True when the total-runtime wall expired rather than the worker going idle. */
+    /** True when the total-runtime hard wall expired rather than the worker going idle. */
     val hardWall: Boolean = false,
 ) : WorkerProcessException(
     (
         if (hardWall) {
-            "Generation exceeded the total time limit (${stallMs}ms elapsed, phase $phase)"
+            "Generation hit the hard wall in phase $phase after ${stallMs}ms with no progress"
         } else {
             "Generation hung in phase $phase for ${stallMs}ms with an idle worker"
         }
@@ -100,7 +100,7 @@ class GenerationHangException(
         (backend?.let { " (backend=$it)" } ?: "") +
         "; the worker process was killed." +
         if (hardWall) {
-            " The device is likely too slow for this model/resolution; try fewer steps or a smaller size."
+            " The worker was not idle: a stalled download or a compute loop that never advances is the likely cause."
         } else {
             " This usually indicates a broken GPU driver."
         },

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/GenerationWatchdog.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/GenerationWatchdog.kt
@@ -17,7 +17,7 @@ internal class GenerationWatchdog(
     private val config: WorkerWatchdogConfig,
     private val clock: () -> Long,
     private val cpuTimeMsReader: () -> Long?,
-    private val onHangVerdict: (phase: String, backend: String?, stallMs: Long) -> Unit,
+    private val onHangVerdict: (phase: String, backend: String?, stallMs: Long, hardWall: Boolean) -> Unit,
 ) {
     private val fired = AtomicBoolean(false)
     private val stopped = AtomicBoolean(false)
@@ -51,11 +51,14 @@ internal class GenerationWatchdog(
     fun sample() {
         if (fired.get() || stopped.get()) return
         val now = clock()
-        if (now - startMs >= config.hardWallTimeoutMs) {
-            fire(now)
+        val stallMs = now - windowStartMs
+        // The hard wall backstops the phases the stall rule can't judge (download, unreadable CPU);
+        // it is not a cap on total runtime. A worker still emitting heartbeats is making progress —
+        // killing it just fails slow devices that would have finished.
+        if (now - startMs >= config.hardWallTimeoutMs && stallMs >= stallTimeoutFor(phase)) {
+            fire(now, hardWall = true)
             return
         }
-        val stallMs = now - windowStartMs
         if (stallMs < stallTimeoutFor(phase)) return
         if (phase == DiffusionPhases.RESOLVING_MODEL) return // downloads are CPU-flat; hard wall only
 
@@ -86,9 +89,13 @@ internal class GenerationWatchdog(
 
     fun lastBackend(): String? = backend
 
-    private fun fire(now: Long) {
+    private fun fire(
+        now: Long,
+        hardWall: Boolean = false,
+    ) {
         if (fired.compareAndSet(false, true)) {
-            onHangVerdict(phase, backend, now - windowStartMs)
+            val reportedMs = if (hardWall) now - startMs else now - windowStartMs
+            onHangVerdict(phase, backend, reportedMs, hardWall)
         }
     }
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/GenerationWatchdog.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/GenerationWatchdog.kt
@@ -12,6 +12,10 @@ import java.util.concurrent.atomic.AtomicBoolean
  * minutes and must never be killed; a driver dispatch deadlock sits at 0% with all threads
  * sleeping. RESOLVING_MODEL (network download) is legitimately CPU-flat and only the hard wall
  * applies there. If CPU time is unreadable the stall rule is skipped entirely (hard wall only).
+ *
+ * The hard wall backstops exactly those two blind spots — it is not a cap on total runtime, so it
+ * also requires the heartbeat window to have lapsed. A slow-but-progressing generation is never
+ * killed; there is deliberately no absolute upper bound on a run that keeps reporting progress.
  */
 internal class GenerationWatchdog(
     private val config: WorkerWatchdogConfig,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngine.kt
@@ -225,6 +225,9 @@ internal class IsolatedDiffusionEngine(
         return try {
             issue(false)
         } catch (hang: GenerationHangException) {
+            // A total-runtime timeout says "too slow", not "broken driver": don't blacklist a
+            // backend over it, and don't retry on CPU (slower still — it would just time out again).
+            if (hang.hardWall) throw hang
             recordHangVerdict(subsystem, hang.backend)
             when (config.image.hangRecoveryPolicy) {
                 HangRecoveryPolicy.FAIL_FAST -> throw hang
@@ -385,6 +388,7 @@ internal class IsolatedDiffusionEngine(
     ): T {
         val connection = connectionManager.connect(buildInitConfig(forceCpu))
         val killedByWatchdog = AtomicBoolean(false)
+        val killedByHardWall = AtomicBoolean(false)
         val verdictStallMs = AtomicLong(0L)
 
         var watchdog: GenerationWatchdog? = null
@@ -394,8 +398,9 @@ internal class IsolatedDiffusionEngine(
                     config = config.image.watchdog,
                     clock = clock,
                     cpuTimeMsReader = cpuReaderFor(connection.pid),
-                ) { _, _, stallMs ->
+                ) { _, _, stallMs, hardWall ->
                     killedByWatchdog.set(true)
+                    killedByHardWall.set(hardWall)
                     verdictStallMs.set(stallMs)
                     connectionManager.killWorker(connection)
                 }
@@ -411,6 +416,7 @@ internal class IsolatedDiffusionEngine(
                     lastBackend = watchdogRef?.lastBackend(),
                     killedByWatchdog = killedByWatchdog.get(),
                     stallMs = verdictStallMs.get(),
+                    hardWall = killedByHardWall.get(),
                 ),
             )
         }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerFailureClassifier.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ipc/WorkerFailureClassifier.kt
@@ -27,9 +27,15 @@ internal object WorkerFailureClassifier {
         lastBackend: String?,
         killedByWatchdog: Boolean,
         stallMs: Long,
+        hardWall: Boolean = false,
     ): WorkerProcessException {
         if (killedByWatchdog) {
-            return GenerationHangException(backend = lastBackend, phase = lastPhase, stallMs = stallMs)
+            return GenerationHangException(
+                backend = lastBackend,
+                phase = lastPhase,
+                stallMs = stallMs,
+                hardWall = hardWall,
+            )
         }
         val exitInfo = exitInfoFor(context, pid)
         return when (exitInfo?.reason) {

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/GenerationWatchdogTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/GenerationWatchdogTest.kt
@@ -7,18 +7,25 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GenerationWatchdogTest {
+    private data class Verdict(
+        val phase: String,
+        val backend: String?,
+        val stallMs: Long,
+        val hardWall: Boolean,
+    )
+
     private class Harness(
         config: WorkerWatchdogConfig = WorkerWatchdogConfig(),
     ) {
         var nowMs = 0L
         var cpuMs: Long? = 0L
-        var verdicts = mutableListOf<Triple<String, String?, Long>>()
+        var verdicts = mutableListOf<Verdict>()
         val watchdog =
             GenerationWatchdog(
                 config = config,
                 clock = { nowMs },
                 cpuTimeMsReader = { cpuMs },
-            ) { phase, backend, stallMs -> verdicts.add(Triple(phase, backend, stallMs)) }
+            ) { phase, backend, stallMs, hardWall -> verdicts.add(Verdict(phase, backend, stallMs, hardWall)) }
 
         /** Advance time in sample-interval ticks, optionally accruing CPU. */
         fun run(
@@ -42,9 +49,9 @@ class GenerationWatchdogTest {
         h.watchdog.onPhase(DiffusionPhases.LOADING, "VULKAN")
         h.run(durationMs = 95_000, cpuBusyFraction = 0.0)
         assertEquals(1, h.verdicts.size)
-        val (phase, backend, _) = h.verdicts.single()
-        assertEquals(DiffusionPhases.LOADING, phase)
-        assertEquals("VULKAN", backend)
+        assertEquals(DiffusionPhases.LOADING, h.verdicts.single().phase)
+        assertEquals("VULKAN", h.verdicts.single().backend)
+        assertFalse(h.verdicts.single().hardWall)
     }
 
     @Test
@@ -68,7 +75,20 @@ class GenerationWatchdogTest {
         // Steps stop AND cpu is flat -> verdict after the step stall window.
         h.run(durationMs = 310_000, cpuBusyFraction = 0.0)
         assertEquals(1, h.verdicts.size)
-        assertEquals(DiffusionPhases.STEP, h.verdicts.single().first)
+        assertEquals(DiffusionPhases.STEP, h.verdicts.single().phase)
+    }
+
+    /** Regression: OUKITEL WP55 issue — a slow CPU run heartbeating every ~38s was killed at the wall. */
+    @Test
+    fun `hard wall spares a worker that is still heartbeating steps`() {
+        val h = Harness()
+        h.watchdog.onPhase(DiffusionPhases.GENERATING, "CPU")
+        repeat(60) {
+            h.run(durationMs = 40_000, cpuBusyFraction = 1.0)
+            h.watchdog.onStep(it, 60)
+        }
+        assertTrue(h.nowMs > 30 * 60_000)
+        assertTrue(h.verdicts.isEmpty())
     }
 
     @Test
@@ -86,6 +106,10 @@ class GenerationWatchdogTest {
         h.watchdog.onPhase(DiffusionPhases.RESOLVING_MODEL, null)
         h.run(durationMs = 31 * 60_000, cpuBusyFraction = 1.0)
         assertEquals(1, h.verdicts.size)
+        // Hard-wall verdicts report total elapsed time, not the stall window, and are flagged so
+        // callers don't read a timeout as a driver hang.
+        assertTrue(h.verdicts.single().hardWall)
+        assertTrue(h.verdicts.single().stallMs >= 30 * 60_000)
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/GenerationWatchdogTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/GenerationWatchdogTest.kt
@@ -101,7 +101,7 @@ class GenerationWatchdogTest {
     }
 
     @Test
-    fun `hard wall fires regardless of cpu activity`() {
+    fun `hard wall fires on a busy but heartbeat-less phase`() {
         val h = Harness()
         h.watchdog.onPhase(DiffusionPhases.RESOLVING_MODEL, null)
         h.run(durationMs = 31 * 60_000, cpuBusyFraction = 1.0)

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngineTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/IsolatedDiffusionEngineTest.kt
@@ -89,7 +89,7 @@ class IsolatedDiffusionEngineTest {
 
         // Mock WorkerFailureClassifier to return WorkerKilledByMemoryException
         every {
-            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any(), any())
         } returns WorkerKilledByMemoryException()
 
         // Capture request params without mockk capture slots (which can be flaky)
@@ -174,7 +174,7 @@ class IsolatedDiffusionEngineTest {
         )
 
         every {
-            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any(), any())
         } returns WorkerKilledByMemoryException()
 
         val requestSlots = mutableListOf<IpcImageRequest>()
@@ -216,7 +216,7 @@ class IsolatedDiffusionEngineTest {
         val params = ImageGenerationRequest(prompt = "hello")
 
         every {
-            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any(), any())
         } returns io.aatricks.llmedge.core.WorkerCrashedException(
             backend = "CPU",
             exitReason = 5,
@@ -264,7 +264,7 @@ class IsolatedDiffusionEngineTest {
         val params = ImageGenerationRequest(prompt = "hello")
 
         every {
-            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any(), any())
         } returns io.aatricks.llmedge.core.WorkerCrashedException(
             backend = "CPU",
             exitReason = 5,
@@ -323,7 +323,7 @@ class IsolatedDiffusionEngineTest {
                 sequential = false,
             )
         every {
-            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any(), any())
         } returns WorkerKilledByMemoryException()
         val requestSlots = mutableListOf<IpcImageRequest>()
 
@@ -624,7 +624,7 @@ class IsolatedDiffusionEngineTest {
 
         // Mock WorkerFailureClassifier to return WorkerCrashedException (implicating Vulkan)
         every {
-            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any(), any())
         } returns io.aatricks.llmedge.core.WorkerCrashedException(
             backend = "VULKAN",
             exitReason = 5,

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerBackendProberTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ipc/WorkerBackendProberTest.kt
@@ -93,7 +93,7 @@ class WorkerBackendProberTest {
         coEvery { anyConstructed<WorkerConnectionManager>().connect(null) } returns connection
 
         every {
-            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any(), any())
         } returns io.aatricks.llmedge.core.WorkerCrashedException(
             backend = "VULKAN",
             exitReason = 5,
@@ -137,7 +137,7 @@ class WorkerBackendProberTest {
         every { connection.pid } returns 1234
 
         every {
-            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any())
+            WorkerFailureClassifier.classify(any(), any(), any(), any(), any(), any(), any())
         } returns io.aatricks.llmedge.core.GenerationHangException(backend = "VULKAN", phase = "PROBE", stallMs = 10000L)
 
         every { worker.probeBackends(any()) } answers {


### PR DESCRIPTION
Reported on an OUKITEL WP55: a 384x384 / 15-step CPU generation failed after an hour with

    Generation hung in phase STEP for 38579ms with an idle worker (backend=CPU);
    the worker process was killed. This usually indicates a broken GPU driver.

38579ms is below every stall timeout (stepStallTimeoutMs is 300000), so the idle-worker branch cannot
have produced it. Only the 30-minute hard wall can. The worker had emitted a step heartbeat 38s before
it died: it was making progress and got killed for elapsed time alone, then reported through a message
that blames a GPU driver on a CPU-only run.

Two bugs:

* The hard wall was an unconditional cap on total runtime, so a slow device that would have finished
  gets killed instead.
* Both fire paths reported through the same message and the same stallMs, so the diagnosis was wrong.

Changes:

* The hard wall now also requires the phase heartbeat window to have lapsed. That keeps it covering the
  cases it exists for (a CPU-flat model download, a worker whose CPU time is unreadable, a busy loop
  that never advances) and stops it killing a run that is still reporting progress.
* Hard-wall verdicts carry a flag, report total elapsed time instead of the stall window, and get their
  own message.
* A hard-wall kill no longer records a backend hang verdict. With no backend heartbeat yet the verdict
  defaults to VULKAN, so a slow download was enough to blacklist Vulkan and persist it.
* A hard-wall kill no longer retries on CPU. CPU is slower than the backend that just ran out of time.

Consequence, deliberate: a generation that keeps heartbeating inside its phase window now has no
absolute runtime cap. Cancellation is the user's control there, and killing progressing work was the
reported bug.

Test: 60 steps at 40s apart past the 30-minute wall, no verdict. Hard-wall coverage of a stuck
RESOLVING_MODEL download is unchanged, that phase emits one phase update per resolve and nothing resets
the window while a download is stalled. 58/58 ipc unit tests pass.
