### PR TITLE
Fix MiniT2I L/16 load failure and the HF cache path collision

### DIFF
--- a/llmedge/src/main/cpp/sdcpp_jni_load.cpp
+++ b/llmedge/src/main/cpp/sdcpp_jni_load.cpp
@@ -1,6 +1,7 @@
 #include <jni.h>
 
 #include <cstdlib>
+#include <deque>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -385,9 +386,25 @@ static SdHandle* try_create_llm_only_handle(JNIEnv* env, const char* llmPath, bo
 #endif
 }
 
+// sd.cpp explains a failed load only through its log callback, which lands in logcat -- unreadable
+// for a field reporter with nothing but the app's own log file. Keep the last few error lines so
+// the load failure surfaced to Kotlin can carry the reason with it.
+constexpr size_t kErrorTailLines = 8;
+std::mutex g_error_tail_mutex;
+std::deque<std::string> g_error_tail;
+
+void record_error_tail(const char* text) {
+    std::lock_guard<std::mutex> lock(g_error_tail_mutex);
+    g_error_tail.emplace_back(text);
+    while (g_error_tail.size() > kErrorTailLines) {
+        g_error_tail.pop_front();
+    }
+}
+
 void sd_android_log_cb(enum sd_log_level_t level, const char* text, void* data) {
     (void)data;
     if (!text) return;
+    if (level == SD_LOG_ERROR) record_error_tail(text);
     switch (level) {
         case SD_LOG_DEBUG: __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, "%s", text); break;
         case SD_LOG_INFO:  __android_log_print(ANDROID_LOG_INFO,  LOG_TAG, "%s", text); break;
@@ -636,6 +653,10 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
     if (jPhotoMakerPath && photoMakerPathRaw) env->ReleaseStringUTFChars(jPhotoMakerPath, photoMakerPathRaw);
 
     sd_set_log_callback(sd_android_log_cb, nullptr);
+    {
+        std::lock_guard<std::mutex> lock(g_error_tail_mutex);
+        g_error_tail.clear();
+    }
 
     ALOGI("Initializing Stable Diffusion with:");
     ALOGI("  modelPath=%s", modelPath ? modelPath : "NULL");
@@ -863,6 +884,20 @@ Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeCreate(
         jni_thread_cache_init(handle->jvm);
     }
     return reinterpret_cast<jlong>(handle);
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_io_aatricks_llmedge_image_diffusion_StableDiffusion_nativeLastErrorLog(JNIEnv* env, jobject) {
+    std::string joined;
+    {
+        std::lock_guard<std::mutex> lock(g_error_tail_mutex);
+        for (const auto& line : g_error_tail) {
+            if (!joined.empty()) joined += '\n';
+            joined += line;
+        }
+    }
+    if (joined.empty()) return nullptr;
+    return env->NewStringUTF(joined.c_str());
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFDownloadSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFDownloadSupport.kt
@@ -57,6 +57,8 @@ internal object HFDownloadSupport {
         val expectedSize: Long?,
         val expectedSha: String?,
         val downloadUrl: String,
+        /** Where builds before the nested-layout fix cached this file, when that differs. */
+        val legacyFlatFile: File? = null,
     ) {
         fun toResult(
             requestedModelId: String,
@@ -108,6 +110,9 @@ internal object HFDownloadSupport {
         val files = HFModels.tree().getModelFileTree(resolved.modelId, resolved.revision, token, recursive)
         val modelFile = fileSelector(files) ?: throw IllegalArgumentException(noMatchMessage)
         val target = buildDownloadTarget(destinationRoot, resolved, modelFile)
+        deleteFlatLayoutLeftover(target).takeIf { it > 0L }?.let {
+            Log.i(LOG_TAG, "Removed flat-layout cache leftover for ${modelFile.path}, reclaimed $it bytes")
+        }
 
         if (!forceDownload && isFileValidCached(target.targetFile, target.expectedSize, target.expectedSha)) {
             Log.d(
@@ -139,6 +144,20 @@ internal object HFDownloadSupport {
 
         verifyDownloadedFile(target)
         target.toResult(modelId, revision, resolved, fromCache = false)
+    }
+
+    /**
+     * Reclaims the copy an older build left at the flat, basename-only cache path. It cannot be
+     * reused — nothing records which repo subdirectory it came from — and for a diffusion
+     * transformer it is multiple GB of dead weight on the device. Returns the bytes reclaimed.
+     */
+    internal fun deleteFlatLayoutLeftover(target: DownloadTarget): Long {
+        val legacy = target.legacyFlatFile ?: return 0L
+        if (!legacy.isFile) return 0L
+        val freed = legacy.length()
+        if (!legacy.delete()) return 0L
+        File(legacy.parent, "${legacy.name}.validated").delete()
+        return freed
     }
 
     fun isFileValidCached(targetFile: File, expectedSize: Long?, expectedSha: String?): Boolean {
@@ -214,9 +233,11 @@ internal object HFDownloadSupport {
         // Mirror the repo's directory layout: repos like MiniT2I/MiniT2I ship the same basename
         // under several variant folders, and flattening to the basename makes them collide.
         val targetName = HFFileSelectionSupport.relativeCachePath(modelFile.path)
+        val flatName = modelFile.path.substringAfterLast('/')
         return DownloadTarget(
             modelFile = modelFile,
             targetFile = File(revisionDir, targetName),
+            legacyFlatFile = File(revisionDir, flatName).takeIf { targetName != flatName },
             expectedSize = modelFile.lfs?.size ?: modelFile.size,
             expectedSha = modelFile.lfs?.oid ?: modelFile.oid,
             downloadUrl = HFEndpoints.fileDownloadEndpoint(

--- a/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFDownloadSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFDownloadSupport.kt
@@ -211,7 +211,9 @@ internal object HFDownloadSupport {
         modelFile: HFModelTree.HFModelFile,
     ): DownloadTarget {
         val revisionDir = File(destinationRoot, "${HFFileSelectionSupport.sanitize(resolved.modelId)}/${resolved.revision}")
-        val targetName = modelFile.path.substringAfterLast('/')
+        // Mirror the repo's directory layout: repos like MiniT2I/MiniT2I ship the same basename
+        // under several variant folders, and flattening to the basename makes them collide.
+        val targetName = HFFileSelectionSupport.relativeCachePath(modelFile.path)
         return DownloadTarget(
             modelFile = modelFile,
             targetFile = File(revisionDir, targetName),

--- a/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFFileSelectionSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/huggingface/HFFileSelectionSupport.kt
@@ -23,6 +23,17 @@ internal object HFFileSelectionSupport {
 
     fun sanitize(modelId: String): String = modelId.replace("/", "_")
 
+    /**
+     * Repo-relative cache path for a downloaded file, preserving subdirectories so that variants
+     * sharing a basename (e.g. `minit2i-b-16/…` and `minit2i-l-16/…`) land on distinct files.
+     * Traversal segments are dropped: the path comes from the Hub API, not from us.
+     */
+    fun relativeCachePath(repoPath: String): String =
+        repoPath.split('/')
+            .filter { it.isNotEmpty() && it != "." && it != ".." }
+            .joinToString("/")
+            .ifEmpty { sanitize(repoPath) }
+
     fun selectModelFile(
         files: List<HFModelTree.HFModelFile>,
         filename: String?,

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlanner.kt
@@ -23,18 +23,11 @@ internal sealed interface DiffusionExecutionPlan {
 }
 
 internal object ImageRuntimeRequestPlanner {
-    private fun isMiniT2ILarge(model: ModelSpec?): Boolean {
-        return model is ModelSpec.HuggingFace &&
-            model.repoId == "MiniT2I/MiniT2I" &&
-            model.filename == "minit2i-l-16/transformer/diffusion_pytorch_model.safetensors"
-    }
-
     fun imageRequest(
         params: ImageGenerationRequest,
         config: LLMEdgeConfig,
     ): PlannedDiffusionRuntimeRequest {
         val modelSpec = params.model ?: config.models.image
-        val isLarge = isMiniT2ILarge(modelSpec)
         return PlannedDiffusionRuntimeRequest(
             spec =
                 DiffusionRuntimeSpec(
@@ -76,8 +69,6 @@ internal object ImageRuntimeRequestPlanner {
                     preferPerformanceMode = config.image.preferPerformanceMode,
                     loraModelDir = params.loraModelDir,
                     loraApplyMode = params.loraApplyMode,
-                    weightType = if (isLarge) "q8_0" else null,
-                    tensorTypeRules = if (isLarge) ".*mask_token.*=f16" else null,
                 ),
         )
     }
@@ -194,13 +185,7 @@ internal object ImageRuntimeRequestPlanner {
         )
         // The conditioning runtime is gone before diffusion begins, so keep diffusion weights
         // on a supported GPU instead of mirroring its multi-GB parameters in system RAM.
-        val isMiniT2ILarge = isMiniT2ILarge(ditModel)
-        val isMaskedT5Profile = profile == ImageConditioningProfile.MASKED_T5
-        val diffusionOptions = baseOptions.copy(
-            offloadToCpu = false,
-            weightType = if (isMiniT2ILarge && isMaskedT5Profile) "q8_0" else null,
-            tensorTypeRules = if (isMiniT2ILarge && isMaskedT5Profile) ".*mask_token.*=f16" else null,
-        )
+        val diffusionOptions = baseOptions.copy(offloadToCpu = false)
         return DiffusionExecutionPlan.Sequential(
             conditioningRequest =
                 PlannedDiffusionRuntimeRequest(

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/MiniT2I.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/MiniT2I.kt
@@ -92,6 +92,9 @@ object MiniT2I {
             cfgScale = cfgScale,
             seed = seed,
             flashAttention = flashAttention,
+            // L/16 is a 3.6 GB fp32 DiT sharing the process with a ~3 GB FLAN-T5. Stage the two
+            // phases so peak memory is the larger one rather than their sum.
+            sequential = true,
         )
 
     private fun buildRequest(
@@ -104,6 +107,7 @@ object MiniT2I {
         cfgScale: Float,
         seed: Long,
         flashAttention: Boolean,
+        sequential: Boolean? = null,
     ): ImageGenerationRequest =
         ImageGenerationRequest(
             prompt = prompt,
@@ -117,5 +121,6 @@ object MiniT2I {
             model = model,
             textEncoder = textEncoder,
             diffusionModelOnly = true,
+            sequential = sequential,
         )
 }

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusion.kt
@@ -336,6 +336,13 @@ class StableDiffusion internal constructor(
                 tensorTypeRules: String?,
         ): Long
 
+        /** Tail of sd.cpp's own error output from the most recent [supportNativeCreate]. */
+        internal fun supportNativeLastErrorLog(): String? =
+            runCatching { nativeLastErrorLog() }.getOrNull()?.takeIf { it.isNotBlank() }
+
+        @JvmStatic
+        private external fun nativeLastErrorLog(): String?
+
         @JvmStatic
         private external fun nativeGetVulkanDeviceCount(): Int
 

--- a/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadSupport.kt
+++ b/llmedge/src/main/java/io/aatricks/llmedge/image/diffusion/StableDiffusionLoadSupport.kt
@@ -502,7 +502,13 @@ internal object StableDiffusionLoadSupport {
             append("Failed to initialize Stable Diffusion context for $resolvedModelPath.")
             if (taesdPath != null) append(" Custom TAE/TAEHV: $taesdPath.")
             if (resolvedVaePath != null) append(" Custom VAE: $resolvedVaePath.")
-            append(" This often happens due to incompatible VAE/TAE weights or insufficient memory. Check logcat for [SmolSD] errors.")
+            append(" This often happens due to incompatible VAE/TAE weights or insufficient memory.")
+            val nativeErrors = StableDiffusion.supportNativeLastErrorLog()
+            if (nativeErrors != null) {
+                append(" Native errors:\n$nativeErrors")
+            } else {
+                append(" Check logcat for [SmolSD] errors.")
+            }
         }
 }
 

--- a/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HFDownloadVerificationTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HFDownloadVerificationTest.kt
@@ -22,6 +22,31 @@ class HFDownloadVerificationTest {
         )
 
     @Test
+    fun `flat-layout leftover is reclaimed once the nested path is used`() {
+        val revisionDir = File.createTempFile("hf-revision", "").also { it.delete() }
+        val legacy = File(revisionDir, "diffusion_pytorch_model.safetensors")
+        val nested = File(revisionDir, "minit2i-l-16/transformer/diffusion_pytorch_model.safetensors")
+        nested.parentFile!!.mkdirs()
+        legacy.writeBytes(ByteArray(16))
+        File(legacy.parent, "${legacy.name}.validated").writeText("stale")
+
+        HFDownloadSupport.deleteFlatLayoutLeftover(
+            HFDownloadSupport.DownloadTarget(
+                modelFile = HFModelTree.HFModelFile(path = "minit2i-l-16/transformer/diffusion_pytorch_model.safetensors"),
+                targetFile = nested,
+                expectedSize = null,
+                expectedSha = null,
+                downloadUrl = "https://example.invalid/model.safetensors",
+                legacyFlatFile = legacy,
+            ),
+        )
+
+        assertFalse("Unusable flat-layout copy should be deleted", legacy.exists())
+        assertFalse(File(legacy.parent, "${legacy.name}.validated").exists())
+        revisionDir.deleteRecursively()
+    }
+
+    @Test
     fun `sha mismatch throws and deletes the file`() {
         val file = File.createTempFile("hf-verify", ".gguf")
         file.writeBytes(byteArrayOf(1, 2, 3, 4))

--- a/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HuggingFaceHubSanitizeTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/huggingface/HuggingFaceHubSanitizeTest.kt
@@ -10,4 +10,18 @@ class HuggingFaceHubSanitizeTest {
         val sanitized = HuggingFaceHub.sanitize(input)
         assertEquals("unsloth_Qwen3-0.6B-GGUF", sanitized)
     }
+
+    @Test
+    fun `relativeCachePath keeps variant directories distinct`() {
+        val b16 = HFFileSelectionSupport.relativeCachePath("minit2i-b-16/transformer/diffusion_pytorch_model.safetensors")
+        val l16 = HFFileSelectionSupport.relativeCachePath("minit2i-l-16/transformer/diffusion_pytorch_model.safetensors")
+        assertEquals("minit2i-b-16/transformer/diffusion_pytorch_model.safetensors", b16)
+        assertEquals("minit2i-l-16/transformer/diffusion_pytorch_model.safetensors", l16)
+    }
+
+    @Test
+    fun `relativeCachePath drops traversal segments`() {
+        assertEquals("etc/passwd", HFFileSelectionSupport.relativeCachePath("../../etc/passwd"))
+        assertEquals("model.safetensors", HFFileSelectionSupport.relativeCachePath("model.safetensors"))
+    }
 }

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageClientTest.kt
@@ -2685,7 +2685,7 @@ class ImageClientTest {
     }
 
     @Test
-    fun `createDiffusionRuntimePool cache key differentiates quantized and default runtimes`() = runTest {
+    fun `MiniT2I is never loaded quantized and Large stages its phases`() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val dummyFile = java.io.File(context.filesDir, "dummy_model.safetensors").apply { writeBytes(byteArrayOf(0x01)) }
         val fakeRepo = object : io.aatricks.llmedge.model.ModelRepository {
@@ -2713,21 +2713,18 @@ class ImageClientTest {
             val resultLarge = runtimePool.coordinator.acquireDetailed(largeRequestDirect.spec, largeRequestDirect.options)
             val resultStandard = runtimePool.coordinator.acquireDetailed(standardRequestDirect.spec, standardRequestDirect.options)
 
-            assertTrue(resultLarge.keyPrefix.contains("weightType=q8_0"))
-            assertTrue(resultLarge.keyPrefix.contains("tensorTypeRules=.*mask_token.*=f16"))
-
+            // MiniT2I's custom ops and non-block-aligned dims cannot survive on-load
+            // quantization: a partially converted DiT is what broke L/16 loading entirely.
+            assertTrue(resultLarge.keyPrefix.contains("weightType=null"))
+            assertTrue(resultLarge.keyPrefix.contains("tensorTypeRules=null"))
             assertTrue(resultStandard.keyPrefix.contains("weightType=null"))
             assertTrue(resultStandard.keyPrefix.contains("tensorTypeRules=null"))
+            assertTrue(capturedRequests.isNotEmpty())
+            assertTrue(capturedRequests.all { it.weightType == null && it.tensorTypeRules == null })
 
-            org.junit.Assert.assertNotEquals(resultLarge.keyPrefix, resultStandard.keyPrefix)
-
-            val largeReq = capturedRequests.find { it.weightType == "q8_0" }
-            val standardReq = capturedRequests.find { it.weightType == null }
-
-            org.junit.Assert.assertNotNull(largeReq)
-            org.junit.Assert.assertNotNull(standardReq)
-            assertEquals(".*mask_token.*=f16", largeReq?.tensorTypeRules)
-            org.junit.Assert.assertNull(standardReq?.tensorTypeRules)
+            // L/16 must stage its phases; B/16 leaves the choice to the memory heuristic.
+            assertEquals(true, MiniT2I.largeImageRequest("x").sequential)
+            org.junit.Assert.assertNull(MiniT2I.imageRequest("x").sequential)
         } finally {
             runtimePool.close()
             scope.close()

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/ImageRuntimeRequestPlannerTest.kt
@@ -209,22 +209,24 @@ class ImageRuntimeRequestPlannerTest {
         assertFalse(plan.diffusionRequest.options.offloadToCpu)
     }
 
+    // MiniT2I cannot survive on-load quantization: its custom ops and non-block-aligned dims
+    // leave a partially converted DiT, which is what stopped L/16 loading at all.
     @Test
-    fun `MiniT2I large request selects correct quant options in direct planning`() {
+    fun `MiniT2I large request stays full precision in direct planning`() {
         val config = LLMEdgeConfig()
         val request = MiniT2I.largeImageRequest("test prompt")
         val plan = ImageRuntimeRequestPlanner.imageRequest(request, config)
-        org.junit.Assert.assertEquals("q8_0", plan.options.weightType)
-        org.junit.Assert.assertEquals(".*mask_token.*=f16", plan.options.tensorTypeRules)
+        org.junit.Assert.assertNull(plan.options.weightType)
+        org.junit.Assert.assertNull(plan.options.tensorTypeRules)
     }
 
     @Test
-    fun `MiniT2I large request selects correct quant options in sequential diffusion planning`() {
+    fun `MiniT2I large request stays full precision in sequential diffusion planning`() {
         val config = LLMEdgeConfig()
         val request = MiniT2I.largeImageRequest("test prompt")
         val plan = ImageRuntimeRequestPlanner.imageSequentialPlan(request, config)
-        org.junit.Assert.assertEquals("q8_0", plan.diffusionRequest.options.weightType)
-        org.junit.Assert.assertEquals(".*mask_token.*=f16", plan.diffusionRequest.options.tensorTypeRules)
+        org.junit.Assert.assertNull(plan.diffusionRequest.options.weightType)
+        org.junit.Assert.assertNull(plan.diffusionRequest.options.tensorTypeRules)
     }
 
     @Test
@@ -237,7 +239,7 @@ class ImageRuntimeRequestPlannerTest {
     }
 
     @Test
-    fun `MiniT2I equivalent HF spec selects correct quant options`() {
+    fun `MiniT2I equivalent HF spec stays full precision`() {
         val config = LLMEdgeConfig()
         val spec = ModelSpec.huggingFace(
             repoId = "MiniT2I/MiniT2I",
@@ -245,8 +247,8 @@ class ImageRuntimeRequestPlannerTest {
         )
         val request = MiniT2I.largeImageRequest("test prompt").copy(model = spec)
         val plan = ImageRuntimeRequestPlanner.imageRequest(request, config)
-        org.junit.Assert.assertEquals("q8_0", plan.options.weightType)
-        org.junit.Assert.assertEquals(".*mask_token.*=f16", plan.options.tensorTypeRules)
+        org.junit.Assert.assertNull(plan.options.weightType)
+        org.junit.Assert.assertNull(plan.options.tensorTypeRules)
     }
 
     @Test

--- a/llmedge/src/test/java/io/aatricks/llmedge/image/MiniT2ITest.kt
+++ b/llmedge/src/test/java/io/aatricks/llmedge/image/MiniT2ITest.kt
@@ -33,7 +33,7 @@ class MiniT2ITest {
     }
 
     @Test
-    fun `large image request uses the L transformer and automatic planning`() {
+    fun `large image request uses the L transformer and staged planning`() {
         val request = MiniT2I.largeImageRequest(prompt = "a cat", seed = 42L)
 
         val model = request.model as ModelSpec.HuggingFace
@@ -43,6 +43,7 @@ class MiniT2ITest {
         assertSame(MiniT2I.diffusionModelLarge, request.model)
         assertSame(MiniT2I.textEncoder, request.textEncoder)
         assertTrue(request.diffusionModelOnly)
-        assertNull(request.sequential)
+        // 3.6 GB fp32 DiT alongside a ~3 GB FLAN-T5 must not be resident at once.
+        assertEquals(true, request.sequential)
     }
 }


### PR DESCRIPTION
Reported in Aatricks/llmedge-examples#44: MiniT2I L/16 fails to load on a
OUKITEL WP55, ~7 minutes in, with `new_sd_ctx` returning null before any
sampling step.

## Why L/16 fails and B/16 does not

L/16 was the only preset carrying an on-load quantization override
(`weightType = "q8_0"`, `tensorTypeRules = ".*mask_token.*=f16"`). MiniT2I
cannot be quantized: its custom ops and dimensions that are not block-aligned
to 32 mean `ModelLoader::set_wtype_override` converts some tensors and skips
the rest, leaving a partially converted transformer. That was already
established by device testing in July; the override contradicted it.

The two obvious alternatives do not hold up. `RuntimeCoordinator` already
walks Vulkan then CPU and retries each without flash attention, so a driver
allocation cap cannot explain a failure that survived the CPU attempt, and
11.6 GB free makes a memory ceiling a poor fit for the CPU-with-offload
attempt failing too. This is elimination plus mechanism, not a confirmed
repro - the reporter still has to re-run it.

Removing the override puts L/16 back on B/16's load path, which leaves a
3.6 GB fp32 transformer sharing the worker with a ~3 GB FLAN-T5, so the
preset now stages the two phases: peak memory is the larger phase rather
than the sum.

## Cache path collision

Downloads were cached under the file's basename alone, so
`minit2i-b-16/transformer/diffusion_pytorch_model.safetensors` and
`minit2i-l-16/...` landed on the same file. Every switch between the two
variants cost a full SHA-256 of the wrong cached file plus a complete
re-download. Cache paths now mirror the repo layout, with traversal segments
dropped since the path comes from the Hub API.

Migration: existing installs re-download once. The old flat copy cannot be
identified as B or L, so it is deleted to reclaim the space - multiple GB per
diffusion transformer otherwise sits there unreadable.

## Diagnostics

"Check logcat for [SmolSD] errors" is unactionable for someone running the
app on a phone. The JNI layer now keeps the last few sd.cpp error lines
(which include ggml's, forwarded at `stable-diffusion.cpp:688`) and the
context-init failure message carries them, so the next report of this class
states the reason in the app's own log.

## Verification

- 211/211 image + huggingface unit tests pass; full suite 663 tests with the
  same 3 pre-existing failure classes as `main` (missing desktop `libsdcpp.so`,
  video tests).
- `nativeLastErrorLog` confirmed exported from the built arm64-v8a
  `libsdcpp.so`.
- Debug APK built and checked: new failure message present, `mask_token`
  absent.
- Not yet device-verified. Needs an L/16 run on the reporter's hardware
  before Aatricks/llmedge-examples#44 is closed.
